### PR TITLE
EntityDetails api calls being run at parallel.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecase/wallet/GetAccountResourcesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecase/wallet/GetAccountResourcesUseCase.kt
@@ -1,15 +1,20 @@
 package com.babylon.wallet.android.domain.usecase.wallet
 
+import com.babylon.wallet.android.data.gateway.generated.model.EntityDetailsResponse
 import com.babylon.wallet.android.data.gateway.toFungibleToken
 import com.babylon.wallet.android.data.gateway.toNonFungibleToken
 import com.babylon.wallet.android.data.repository.entity.EntityRepository
 import com.babylon.wallet.android.data.repository.nonfungible.NonFungibleRepository
 import com.babylon.wallet.android.domain.common.Result
 import com.babylon.wallet.android.domain.common.onValue
-import com.babylon.wallet.android.domain.common.value
 import com.babylon.wallet.android.domain.model.AccountResources
+import com.babylon.wallet.android.domain.model.NonFungibleTokenIdContainer
 import com.babylon.wallet.android.domain.model.OwnedFungibleToken
 import com.babylon.wallet.android.domain.model.OwnedNonFungibleToken
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import rdx.works.profile.data.repository.ProfileRepository
 import javax.inject.Inject
 
@@ -18,7 +23,10 @@ class GetAccountResourcesUseCase @Inject constructor(
     private val nonFungibleRepository: NonFungibleRepository,
     private val profileRepository: ProfileRepository
 ) {
-    suspend operator fun invoke(address: String): Result<AccountResources> {
+
+    suspend operator fun invoke(
+        address: String
+    ): Result<AccountResources> = coroutineScope {
         var accountDisplayName = ""
         var appearanceId = -1
         profileRepository.readProfileSnapshot()?.let { profileSnapshot ->
@@ -26,52 +34,96 @@ class GetAccountResourcesUseCase @Inject constructor(
             accountDisplayName = account?.displayName.orEmpty()
             appearanceId = account?.appearanceID ?: -1
         }
-        return when (val accountResourcesResult = entityRepository.getAccountResources(address)) {
+
+        when (val accountResourcesResult = entityRepository.getAccountResources(address)) {
             is Result.Error -> Result.Error(accountResourcesResult.exception)
             is Result.Success -> {
-                return Result.Success(
-                    data = accountResourcesResult.data.let { accountResources ->
-                        // TODO make api calls to run simultaneously, not one by one to increase efficiency
-                        val fungibleTokens = mutableListOf<OwnedFungibleToken>()
-                        accountResources.simpleFungibleTokens.forEach { fungibleToken ->
-                            entityRepository.entityDetails(fungibleToken.address).onValue { response ->
-                                fungibleTokens.add(
-                                    OwnedFungibleToken(
-                                        fungibleToken.owner,
-                                        fungibleToken.amount,
-                                        fungibleToken.address,
-                                        response.toFungibleToken()
-                                    )
-                                )
-                            }
+
+                val fungibleTokens = mutableListOf<OwnedFungibleToken>()
+                val nonFungibleTokens = mutableListOf<OwnedNonFungibleToken>()
+
+                accountResourcesResult.data.let { accountResources ->
+                    val fungibleTokensDeferred = accountResources.simpleFungibleTokens.map { fungibleToken ->
+                        async {
+                            entityRepository.entityDetails(fungibleToken.address)
                         }
-                        val nonFungibleTokens = mutableListOf<OwnedNonFungibleToken>()
-                        accountResources.simpleNonFungibleTokens.forEach { nonFungibleToken ->
-                            val nonFungibleIds =
-                                nonFungibleRepository.nonFungibleIds(nonFungibleToken.tokenResourceAddress).value()
-                            entityRepository.entityDetails(nonFungibleToken.tokenResourceAddress).onValue { response ->
+                    }
+
+                    val nonFungibleTokensDeferred = mutableListOf<Deferred<Result<EntityDetailsResponse>>>()
+                    val nonFungibleIdsDeferred = mutableListOf<Deferred<Result<NonFungibleTokenIdContainer>>>()
+
+                    accountResources.simpleNonFungibleTokens
+                        .map { nonFungibleToken ->
+                            nonFungibleTokensDeferred.add(
+                                async {
+                                    entityRepository.entityDetails(nonFungibleToken.tokenResourceAddress)
+                                }
+                            )
+                            nonFungibleIdsDeferred.add(
+                                async {
+                                    nonFungibleRepository.nonFungibleIds(nonFungibleToken.tokenResourceAddress)
+                                }
+                            )
+                        }
+
+                    // Run all requests simultaneously
+                    val accountResourcesJobs = AccountResourcesJobs(
+                        fungibleTokensDeferred.awaitAll(),
+                        nonFungibleTokensDeferred.awaitAll(),
+                        nonFungibleIdsDeferred.awaitAll()
+                    )
+
+                    accountResourcesJobs.fungibleResults.forEachIndexed { index, result ->
+                        val fungibleToken = accountResourcesResult.data.simpleFungibleTokens[index]
+                        result.onValue { response ->
+                            fungibleTokens.add(
+                                OwnedFungibleToken(
+                                    fungibleToken.owner,
+                                    fungibleToken.amount,
+                                    fungibleToken.address,
+                                    response.toFungibleToken()
+                                )
+                            )
+                        }
+                    }
+
+                    accountResourcesJobs.nonFungibleResults.forEachIndexed { index, result ->
+                        val nonFungibleToken = accountResourcesResult.data.simpleNonFungibleTokens[index]
+                        val nonFungibleId = accountResourcesJobs.nonFungibleIdResults[index]
+
+                        result.onValue { response ->
+                            nonFungibleId.onValue { nonFungibleIdResponse ->
                                 nonFungibleTokens.add(
                                     OwnedNonFungibleToken(
                                         nonFungibleToken.owner,
                                         nonFungibleToken.amount,
                                         nonFungibleToken.tokenResourceAddress,
-                                        response.toNonFungibleToken(nonFungibleIds)
+                                        response.toNonFungibleToken(nonFungibleIdResponse)
                                     )
                                 )
                             }
                         }
-                        AccountResources(
-                            address = address,
-                            displayName = accountDisplayName,
-                            currencySymbol = "$", // TODO replace when endpoint ready
-                            value = "100",
-                            fungibleTokens = fungibleTokens.toList(),
-                            nonFungibleTokens = nonFungibleTokens.toList(),
-                            appearanceID = appearanceId
-                        )
                     }
+                }
+
+                Result.Success(
+                    data = AccountResources(
+                        address = address,
+                        displayName = accountDisplayName,
+                        currencySymbol = "$", // TODO replace when endpoint ready
+                        value = "100",
+                        fungibleTokens = fungibleTokens,
+                        nonFungibleTokens = nonFungibleTokens,
+                        appearanceID = appearanceId
+                    )
                 )
             }
         }
     }
 }
+
+data class AccountResourcesJobs(
+    val fungibleResults: List<Result<EntityDetailsResponse>>,
+    val nonFungibleResults: List<Result<EntityDetailsResponse>>,
+    val nonFungibleIdResults: List<Result<NonFungibleTokenIdContainer>>
+)


### PR DESCRIPTION
## Description
I refactored the code in a way that API calls to display all token resources are being run at parallel rather than one by one.
It doesn't look clear and perfect from the first sight but could not find easier way how to handle them as we have to run multiple different requests. Any feedback welcome.

### Screenshots (optional)
<img src="image_url" width="300">

### Notes (optional)
