### PR TITLE
When private key byte array has leading zero, retain in to be exact 3…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -129,7 +129,7 @@ dependencies {
 
     //Kotlin toolkit
     implementation 'com.radixdlt:kotlin-engine-toolkit:1.9.1-snapshot'
-    implementation 'com.radixdlt:slip10:60ebe566'
+    implementation 'com.radixdlt:slip10-android:1.1-snapshot'
 
     //Retrofit & OkHttp
     implementation platform('com.squareup.okhttp3:okhttp-bom:4.10.0')

--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/EngineExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/EngineExtensions.kt
@@ -13,10 +13,12 @@ import com.radixdlt.toolkit.models.crypto.PublicKey as EnginePublicKey
 fun ECKeyPair.toEnginePublicKeyModel(): EnginePublicKey {
     return when (this.publicKey.curveType) {
         EllipticCurveType.Secp256k1 -> {
+            // Required size 33 bytes
             EnginePublicKey.EcdsaSecp256k1.fromByteArray(getCompressedPublicKey())
         }
         EllipticCurveType.Ed25519 -> {
-            EnginePublicKey.EddsaEd25519.fromByteArray(getCompressedPublicKey())
+            // Required size 32 bytes
+            EnginePublicKey.EddsaEd25519.fromByteArray(getCompressedPublicKey().removeLeadingZero())
         }
         EllipticCurveType.P256 -> throw Exception("Curve EllipticCurveType.P256 not supported")
     }
@@ -24,12 +26,8 @@ fun ECKeyPair.toEnginePublicKeyModel(): EnginePublicKey {
 
 fun PrivateKey.toEngineModel(): EnginePrivateKey {
     return when (this.curveType) {
-        EllipticCurveType.Secp256k1 -> {
-            EnginePrivateKey.EcdsaSecp256k1.newFromPrivateKeyBytes(this.key.toByteArray())
-        }
-        EllipticCurveType.Ed25519 -> EnginePrivateKey.EddsaEd25519.newFromPrivateKeyBytes(
-            this.key.toByteArray().removeLeadingZero()
-        )
+        EllipticCurveType.Secp256k1 -> EnginePrivateKey.EcdsaSecp256k1.newFromPrivateKeyBytes(this.keyByteArray())
+        EllipticCurveType.Ed25519 -> EnginePrivateKey.EddsaEd25519.newFromPrivateKeyBytes(this.keyByteArray())
         EllipticCurveType.P256 -> throw Exception("Curve EllipticCurveType.P256 not supported")
     }
 }

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     // Datastore
     implementation 'androidx.datastore:datastore-preferences:1.0.0'
 
-    implementation 'com.radixdlt:slip10:60ebe566'
+    implementation 'com.radixdlt:slip10-android:1.1-snapshot'
     implementation 'com.radixdlt:kotlin-engine-toolkit:1.9.0-snapshot'
 
     testImplementation "junit:junit:4.13.2"


### PR DESCRIPTION
…2 bytes.

## Description
[ticket_title](ticket_url)

### Screenshots (optional)
<img src="image_url" width="300">

### Notes (optional)

This was the edge case where converting byte array with leading zero to BigInteger was causing stripping those zeros which is why PrivateKey was not retaining 32 bytes.