### PR TITLE
Fail on gateway error when loadng the accounts

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
@@ -176,7 +176,7 @@ class TransactionClient @Inject constructor(
     }
 
     private suspend fun getAccountAddressToLockFee(): String? {
-        return when (val accounts = getAccountResourcesUseCase()) {
+        return when (val accounts = getAccountResourcesUseCase(failOnAnyError = false)) {
             is Result.Error -> null
             is Result.Success -> {
                 val accountWithXrd = accounts.data.firstOrNull { accountResources ->
@@ -236,7 +236,7 @@ class TransactionClient @Inject constructor(
         }
     }
 
-    suspend fun convertManifestInstructionsToJSON(
+    private suspend fun convertManifestInstructionsToJSON(
         manifest: TransactionManifest
     ): Result<ConvertManifestResponse> {
         val networkId = profileDataSource.getCurrentNetworkId()
@@ -261,7 +261,7 @@ class TransactionClient @Inject constructor(
         }
     }
 
-    suspend fun convertManifestInstructionsToString(
+    private suspend fun convertManifestInstructionsToString(
         manifest: TransactionManifest,
     ): Result<ConvertManifestResponse> {
         val networkId = profileDataSource.getCurrentNetworkId()

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetAccountResourcesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetAccountResourcesUseCase.kt
@@ -24,7 +24,7 @@ class GetAccountResourcesUseCase @Inject constructor(
     private val accountRepository: AccountRepository
 ) {
 
-    suspend operator fun invoke(): Result<List<AccountResources>> = coroutineScope {
+    suspend operator fun invoke(failOnAnyError: Boolean = true): Result<List<AccountResources>> = coroutineScope {
         val accountResourceList = mutableListOf<AccountResources>()
         val results = accountRepository.getAccounts().map { account ->
             async {
@@ -37,6 +37,7 @@ class GetAccountResourcesUseCase @Inject constructor(
         }.awaitAll()
 
         results.forEach { result ->
+            if (failOnAnyError && result is Result.Error) return@coroutineScope Result.Error(result.exception)
             result.onValue {
                 accountResourceList.add(it)
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
@@ -76,7 +76,7 @@ class AccountViewModel @Inject constructor(
                 val result = getAccountResourcesUseCase(accountId)
                 result.onError { e ->
                     _accountUiState.update { accountUiState ->
-                        accountUiState.copy(uiMessage = UiMessage.ErrorMessage(error = e))
+                        accountUiState.copy(uiMessage = UiMessage.ErrorMessage(error = e), isLoading = false)
                     }
                 }
                 result.onValue { accountResource ->

--- a/app/src/test/java/com/babylon/wallet/android/presentation/AccountViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/AccountViewModelTest.kt
@@ -52,7 +52,7 @@ class AccountViewModelTest {
     fun setUp() = runTest {
         whenever(savedStateHandle.get<String>(Screen.ARG_ACCOUNT_ID)).thenReturn(accountId)
         whenever(savedStateHandle.get<String>(Screen.ARG_ACCOUNT_NAME)).thenReturn(accountName)
-        whenever(requestAccountsUseCase(any())).thenReturn(Result.Success(sampleData))
+        whenever(requestAccountsUseCase(any<String>())).thenReturn(Result.Success(sampleData))
         whenever(appEventBus.events).thenReturn(MutableSharedFlow<AppEvent>().asSharedFlow())
         mockkStatic("com.babylon.wallet.android.utils.StringExtensionsKt")
         every { any<String>().decodeUtf8() } returns accountName


### PR DESCRIPTION
When Gateway fails to return details for an account we proceeed with GetAccountResourcesUseCase logic returning only accounts that had sucesfull gateway request. With this change we fail if at least one request fails