### PR TITLE
[ABW-1110] update lock fee selection procedure for RCNet

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
@@ -82,11 +82,16 @@ class TransactionClient @Inject constructor(
             is Result.Success -> manifestConversionResult.data
         }
         val addressesInvolved = getAddressesInvolvedInATransaction(jsonTransactionManifest)
-        val accountAddressToLockFee = selectAccountAddressToLockFee(addressesInvolved) ?: return Result.Error(
-            TransactionApprovalException(
-                DappRequestFailure.TransactionApprovalFailure.FailedToFindAccountWithEnoughFundsToLockFee
+        val accountAddressToLockFee = selectAccountAddressToLockFee(
+            addressesInvolved
+        ) ?: selectAccountAddressToLockFee(getAddressesOfThisWallet())
+        if (accountAddressToLockFee == null) {
+            return Result.Error(
+                TransactionApprovalException(
+                    DappRequestFailure.TransactionApprovalFailure.FailedToFindAccountWithEnoughFundsToLockFee
+                )
             )
-        )
+        }
         return Result.Success(
             addLockFeeInstructionToManifest(
                 manifest = jsonTransactionManifest,
@@ -115,12 +120,16 @@ class TransactionClient @Inject constructor(
         val manifestWithTransactionFee = if (hasLockFeeInstruction) {
             jsonTransactionManifest
         } else {
-            val accountAddressToLockFee =
-                selectAccountAddressToLockFee(addressesInvolved) ?: return Result.Error(
+            val accountAddressToLockFee = selectAccountAddressToLockFee(
+                addressesInvolved
+            ) ?: selectAccountAddressToLockFee(getAddressesOfThisWallet())
+            if (accountAddressToLockFee == null) {
+                return Result.Error(
                     TransactionApprovalException(
                         DappRequestFailure.TransactionApprovalFailure.PrepareNotarizedTransaction
                     )
                 )
+            }
             addLockFeeInstructionToManifest(jsonTransactionManifest, accountAddressToLockFee)
         }
         val addressesNeededToSign = getAddressesNeededToSign(manifestWithTransactionFee)
@@ -198,6 +207,10 @@ class TransactionClient @Inject constructor(
             }
         }
         return selectedAddress
+    }
+
+    private suspend fun getAddressesOfThisWallet(): List<String> {
+        return accountRepository.getAccounts().map { it.address }
     }
 
     private suspend fun buildTransactionHeader(


### PR DESCRIPTION
If we don't find address involved in a transaction, we try to pick first one with funds from wallet. If both fail - we fail approval. To test it - send raw manifest (WITHOUT lock_fee) via dashboard pre and before - https://github.com/radixdlt/radixdlt-scrypto/blob/release/betanet-v2/transaction/examples/resources/creation/non_fungible/no_initial_supply.rtm It should fail before the change and succeed after