### PR TITLE
[ABW-1158] Rename P2PClient to P2PLink

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/MainViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/MainViewModel.kt
@@ -77,11 +77,11 @@ class MainViewModel @Inject constructor(
     private var processingRequestJob: Job? = null
 
     init {
-        profileDataSource.p2pClient
-            .map { p2pClient ->
-                if (p2pClient != null) {
+        profileDataSource.p2pLink
+            .map { p2pLink ->
+                if (p2pLink != null) {
                     Timber.d("found connection password")
-                    currentConnectionPassword = p2pClient.connectionPassword
+                    currentConnectionPassword = p2pLink.connectionPassword
                     openDataChannelWithDapp(
                         connectionPassword = currentConnectionPassword,
                         isRestart = false

--- a/app/src/main/java/com/babylon/wallet/android/domain/SampleDataProvider.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/SampleDataProvider.kt
@@ -96,7 +96,7 @@ class SampleDataProvider {
             appPreferences = AppPreferences(
                 display = Display.default,
                 gateways = Gateways(Gateway.hammunet.url, listOf(Gateway.hammunet)),
-                p2pClients = emptyList()
+                p2pLinks = emptyList()
             ),
             factorSources = listOf(
                 FactorSource.babylon(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsViewModel.kt
@@ -32,8 +32,8 @@ class SettingsViewModel @Inject constructor(
         SettingsItem.TopLevelSettings.DeleteAll
     )
 
-    val state = profileDataSource.p2pClient.map { p2pClient ->
-        val updatedSettings = if (p2pClient == null) {
+    val state = profileDataSource.p2pLink.map { p2pLink ->
+        val updatedSettings = if (p2pLink == null) {
             defaultSettings.toMutableList().apply {
                 if (!contains(SettingsItem.TopLevelSettings.Connection)) {
                     add(0, SettingsItem.TopLevelSettings.Connection)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/connector/SettingsConnectorViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/connector/SettingsConnectorViewModel.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.peerdroid.helpers.Result
 import rdx.works.profile.data.repository.ProfileDataSource
-import rdx.works.profile.domain.AddP2PClientUseCase
-import rdx.works.profile.domain.DeleteP2PClientUseCase
+import rdx.works.profile.domain.AddP2PLinkUseCase
+import rdx.works.profile.domain.DeleteP2PLinkUseCase
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -21,8 +21,8 @@ import javax.inject.Inject
 class SettingsConnectorViewModel @Inject constructor(
     private val peerdroidClient: PeerdroidClient,
     profileDataSource: ProfileDataSource,
-    private val addP2PClientUseCase: AddP2PClientUseCase,
-    private val deleteP2PClientUseCase: DeleteP2PClientUseCase,
+    private val addP2PLinkUseCase: AddP2PLinkUseCase,
+    private val deleteP2PLinkUseCase: DeleteP2PLinkUseCase,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -44,14 +44,14 @@ class SettingsConnectorViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            profileDataSource.p2pClient.collect { p2pClient ->
-                if (p2pClient != null) { // if we already have an active connector
+            profileDataSource.p2pLink.collect { p2pLink ->
+                if (p2pLink != null) { // if we already have an active connector
                     // we need a reference of the connectionPassword
                     // so we can pass it in the onDeleteConnectorClick
-                    currentConnectionPassword = p2pClient.connectionPassword
+                    currentConnectionPassword = p2pLink.connectionPassword
                 }
                 _state.update {
-                    it.copy(isLoading = false, connectorName = p2pClient?.displayName)
+                    it.copy(isLoading = false, connectorName = p2pLink?.displayName)
                 }
             }
         }
@@ -97,7 +97,7 @@ class SettingsConnectorViewModel @Inject constructor(
 
     fun onDeleteConnectorClick() {
         viewModelScope.launch {
-            deleteP2PClientUseCase(currentConnectionPassword)
+            deleteP2PLinkUseCase(currentConnectionPassword)
             peerdroidClient.close(
                 shouldCloseConnectionToSignalingServer = true,
                 isDeleteConnectionEvent = true
@@ -122,7 +122,7 @@ class SettingsConnectorViewModel @Inject constructor(
     private fun saveConnectionPassword(connectorDisplayName: String) {
         viewModelScope.launch {
             peerdroidClient.close(shouldCloseConnectionToSignalingServer = true)
-            addP2PClientUseCase(
+            addP2PLinkUseCase(
                 displayName = connectorDisplayName,
                 connectionPassword = currentConnectionPassword
             )

--- a/profile/src/main/java/rdx/works/profile/data/extensions/ProfileExtensions.kt
+++ b/profile/src/main/java/rdx/works/profile/data/extensions/ProfileExtensions.kt
@@ -8,7 +8,7 @@ import rdx.works.core.mapWhen
 import rdx.works.profile.data.model.Profile
 import rdx.works.profile.data.model.apppreferences.AppPreferences
 import rdx.works.profile.data.model.apppreferences.Gateway
-import rdx.works.profile.data.model.apppreferences.P2PClient
+import rdx.works.profile.data.model.apppreferences.P2PLink
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.factorsources.WasNotDeviceFactorSource
 import rdx.works.profile.data.model.pernetwork.OnNetwork
@@ -148,18 +148,18 @@ fun Profile.deleteGateway(
     return copy(appPreferences = appPreferences.copy(gateways = updatedGateways))
 }
 
-fun Profile.addP2PClient(
-    p2pClient: P2PClient
+fun Profile.addP2PLink(
+    p2pLink: P2PLink
 ): Profile {
-    val updatedP2PClients = appPreferences.p2pClients.toMutableList()
-    updatedP2PClients.add(
-        p2pClient
+    val updatedP2PLinks = appPreferences.p2pLinks.toMutableList()
+    updatedP2PLinks.add(
+        p2pLink
     )
 
     val newAppPreferences = AppPreferences(
         display = appPreferences.display,
         gateways = appPreferences.gateways,
-        p2pClients = updatedP2PClients.toList()
+        p2pLinks = updatedP2PLinks.toList()
     )
 
     return this.copy(
@@ -168,16 +168,16 @@ fun Profile.addP2PClient(
     )
 }
 
-fun Profile.deleteP2PClient(connectionPassword: String): Profile {
-    val updatedP2PClients = appPreferences.p2pClients.toMutableList()
-    updatedP2PClients.removeIf { p2pClient ->
-        p2pClient.connectionPassword == connectionPassword
+fun Profile.deleteP2PLink(connectionPassword: String): Profile {
+    val updatedP2PLinks = appPreferences.p2pLinks.toMutableList()
+    updatedP2PLinks.removeIf { p2pLink ->
+        p2pLink.connectionPassword == connectionPassword
     }
 
     val newAppPreferences = AppPreferences(
         display = appPreferences.display,
         gateways = appPreferences.gateways,
-        p2pClients = updatedP2PClients.toList()
+        p2pLinks = updatedP2PLinks.toList()
     )
 
     return this.copy(

--- a/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
@@ -155,7 +155,7 @@ data class Profile(
         }
 
     companion object {
-        const val LATEST_PROFILE_VERSION = 21
+        const val LATEST_PROFILE_VERSION = 22
         private const val GENERIC_ANDROID_DEVICE_PLACEHOLDER = "Android Phone"
 
         fun init(
@@ -187,7 +187,7 @@ data class Profile(
             val appPreferences = AppPreferences(
                 display = Display.default,
                 gateways = Gateways.fromCurrent(current = gateway),
-                p2pClients = listOf()
+                p2pLinks = listOf()
             )
 
             return Profile(

--- a/profile/src/main/java/rdx/works/profile/data/model/apppreferences/AppPreferences.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/apppreferences/AppPreferences.kt
@@ -11,8 +11,8 @@ data class AppPreferences(
     @SerialName("gateways")
     val gateways: Gateways,
 
-    @SerialName("p2pClients")
-    val p2pClients: List<P2PClient>
+    @SerialName("p2pLinks")
+    val p2pLinks: List<P2PLink>
 )
 
 @Serializable
@@ -88,7 +88,7 @@ data class Gateway(
 }
 
 @Serializable
-data class P2PClient(
+data class P2PLink(
     /**
      * The most important property of this struct, this password,
      * is used to be able to reestablish the P2P connection and also acts as the seed
@@ -111,7 +111,7 @@ data class P2PClient(
         fun init(
             connectionPassword: String,
             displayName: String
-        ): P2PClient = P2PClient(
+        ): P2PLink = P2PLink(
             connectionPassword = connectionPassword,
             displayName = displayName
         )

--- a/profile/src/main/java/rdx/works/profile/data/repository/ProfileDataSourceImpl.kt
+++ b/profile/src/main/java/rdx/works/profile/data/repository/ProfileDataSourceImpl.kt
@@ -18,7 +18,7 @@ import rdx.works.profile.data.model.ProfileSnapshot
 import rdx.works.profile.data.model.apppreferences.Gateway
 import rdx.works.profile.data.model.apppreferences.Gateways
 import rdx.works.profile.data.model.apppreferences.Network
-import rdx.works.profile.data.model.apppreferences.P2PClient
+import rdx.works.profile.data.model.apppreferences.P2PLink
 import rdx.works.profile.datastore.EncryptedPreferencesManager
 import rdx.works.profile.derivation.model.NetworkId
 import rdx.works.profile.di.coroutines.IoDispatcher
@@ -30,7 +30,7 @@ interface ProfileDataSource {
 
     val profile: Flow<Profile?>
 
-    val p2pClient: Flow<P2PClient?>
+    val p2pLink: Flow<P2PLink?>
 
     val gateways: Flow<Gateways>
 
@@ -82,8 +82,8 @@ class ProfileDataSourceImpl @Inject constructor(
             it.getOrNull()
         }
 
-    override val p2pClient: Flow<P2PClient?> = profile.map { profile ->
-        profile?.appPreferences?.p2pClients?.firstOrNull()
+    override val p2pLink: Flow<P2PLink?> = profile.map { profile ->
+        profile?.appPreferences?.p2pLinks?.firstOrNull()
     }.distinctUntilChanged()
 
     override val gateways = profile

--- a/profile/src/main/java/rdx/works/profile/domain/AddP2PLinkUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/AddP2PLinkUseCase.kt
@@ -1,11 +1,11 @@
 package rdx.works.profile.domain
 
-import rdx.works.profile.data.extensions.addP2PClient
-import rdx.works.profile.data.model.apppreferences.P2PClient
+import rdx.works.profile.data.extensions.addP2PLink
+import rdx.works.profile.data.model.apppreferences.P2PLink
 import rdx.works.profile.data.repository.ProfileDataSource
 import javax.inject.Inject
 
-class AddP2PClientUseCase @Inject constructor(
+class AddP2PLinkUseCase @Inject constructor(
     private val profileDataSource: ProfileDataSource,
 ) {
 
@@ -18,14 +18,14 @@ class AddP2PClientUseCase @Inject constructor(
             "Profile does not exist"
         }
 
-        val p2pClient = P2PClient.init(
+        val p2pLink = P2PLink.init(
             connectionPassword = connectionPassword,
             displayName = displayName
         )
 
         // Add p2p client to the profile
-        val updatedProfile = profile.addP2PClient(
-            p2pClient = p2pClient
+        val updatedProfile = profile.addP2PLink(
+            p2pLink = p2pLink
         )
 
         // Save updated profile

--- a/profile/src/main/java/rdx/works/profile/domain/DeleteP2PLinkUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/DeleteP2PLinkUseCase.kt
@@ -1,10 +1,10 @@
 package rdx.works.profile.domain
 
-import rdx.works.profile.data.extensions.deleteP2PClient
+import rdx.works.profile.data.extensions.deleteP2PLink
 import rdx.works.profile.data.repository.ProfileDataSource
 import javax.inject.Inject
 
-class DeleteP2PClientUseCase @Inject constructor(
+class DeleteP2PLinkUseCase @Inject constructor(
     private val profileDataSource: ProfileDataSource
 ) {
 
@@ -14,7 +14,7 @@ class DeleteP2PClientUseCase @Inject constructor(
             "Profile does not exist"
         }
 
-        val updatedProfile = profile.deleteP2PClient(
+        val updatedProfile = profile.deleteP2PLink(
             connectionPassword = connectionPassword
         )
         // Save updated profile

--- a/profile/src/test/java/rdx/works/profile/AddP2PLinkUseCaseTest.kt
+++ b/profile/src/test/java/rdx/works/profile/AddP2PLinkUseCaseTest.kt
@@ -10,19 +10,19 @@ import rdx.works.profile.data.model.apppreferences.AppPreferences
 import rdx.works.profile.data.model.apppreferences.Display
 import rdx.works.profile.data.model.apppreferences.Gateway
 import rdx.works.profile.data.model.apppreferences.Gateways
-import rdx.works.profile.data.model.apppreferences.P2PClient
+import rdx.works.profile.data.model.apppreferences.P2PLink
 import rdx.works.profile.data.repository.ProfileDataSource
-import rdx.works.profile.domain.AddP2PClientUseCase
+import rdx.works.profile.domain.AddP2PLinkUseCase
 import kotlin.test.Ignore
 
-class AddP2PClientUseCaseTest {
+class AddP2PLinkUseCaseTest {
 
-    @Ignore("P2PClient data class or this unit test needs refactor")
+    @Ignore("P2PLink data class or this unit test needs refactor")
     @Test
     fun `given profile exists, when adding p2p client, verify it is added properly`() = runBlocking {
         val profileDataSource = mock(ProfileDataSource::class.java)
-        val addP2PClientUseCase = AddP2PClientUseCase(profileDataSource)
-        val expectedP2pClient = P2PClient.init(
+        val addP2PLinkUseCase = AddP2PLinkUseCase(profileDataSource)
+        val expectedP2PLink = P2PLink.init(
             connectionPassword = "pass1234",
             displayName = "Mac browser"
         )
@@ -33,7 +33,7 @@ class AddP2PClientUseCaseTest {
             appPreferences = AppPreferences(
                 display = Display.default,
                 gateways = Gateways(Gateway.hammunet.url, listOf(Gateway.hammunet)),
-                p2pClients = emptyList()
+                p2pLinks = emptyList()
             ),
             factorSources = listOf(),
             onNetwork = emptyList(),
@@ -41,7 +41,7 @@ class AddP2PClientUseCaseTest {
         )
         whenever(profileDataSource.readProfile()).thenReturn(initialProfile)
 
-        addP2PClientUseCase(
+        addP2PLinkUseCase(
             displayName = "Mac browser",
             connectionPassword = "pass1234"
         )
@@ -50,7 +50,7 @@ class AddP2PClientUseCaseTest {
             appPreferences = AppPreferences(
                 display = initialProfile.appPreferences.display,
                 gateways = initialProfile.appPreferences.gateways,
-                p2pClients = listOf(expectedP2pClient)
+                p2pLinks = listOf(expectedP2PLink)
             ),
             factorSources = initialProfile.factorSources,
             onNetwork = initialProfile.onNetwork,
@@ -60,13 +60,13 @@ class AddP2PClientUseCaseTest {
     }
 
     @Test(expected = IllegalStateException::class)
-    fun `when profile does not exist, verify exception thrown when adding p2pclient`(): Unit = runBlocking {
+    fun `when profile does not exist, verify exception thrown when adding p2pLink`(): Unit = runBlocking {
         val profileDataSource = mock(ProfileDataSource::class.java)
-        val addP2PClientUseCase = AddP2PClientUseCase(profileDataSource)
+        val addP2PLinkUseCase = AddP2PLinkUseCase(profileDataSource)
 
         whenever(profileDataSource.readProfile()).thenReturn(null)
 
-        addP2PClientUseCase(
+        addP2PLinkUseCase(
             displayName = "Mac browser",
             connectionPassword = "pass1234"
         )

--- a/profile/src/test/java/rdx/works/profile/CreateAccountUseCaseTest.kt
+++ b/profile/src/test/java/rdx/works/profile/CreateAccountUseCaseTest.kt
@@ -17,7 +17,7 @@ import rdx.works.profile.data.model.apppreferences.AppPreferences
 import rdx.works.profile.data.model.apppreferences.Display
 import rdx.works.profile.data.model.apppreferences.Gateway
 import rdx.works.profile.data.model.apppreferences.Gateways
-import rdx.works.profile.data.model.apppreferences.P2PClient
+import rdx.works.profile.data.model.apppreferences.P2PLink
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.pernetwork.DerivationPath
 import rdx.works.profile.data.model.pernetwork.FactorInstance
@@ -50,8 +50,8 @@ class CreateAccountUseCaseTest {
                 appPreferences = AppPreferences(
                     display = Display.default,
                     Gateways(network.url, listOf(network)),
-                    p2pClients = listOf(
-                        P2PClient.init(
+                    p2pLinks = listOf(
+                        P2PLink.init(
                             connectionPassword = "My password",
                             displayName = "Browser name test"
                         )

--- a/profile/src/test/java/rdx/works/profile/CreatePersonaUseCaseTest.kt
+++ b/profile/src/test/java/rdx/works/profile/CreatePersonaUseCaseTest.kt
@@ -17,7 +17,7 @@ import rdx.works.profile.data.model.apppreferences.AppPreferences
 import rdx.works.profile.data.model.apppreferences.Display
 import rdx.works.profile.data.model.apppreferences.Gateway
 import rdx.works.profile.data.model.apppreferences.Gateways
-import rdx.works.profile.data.model.apppreferences.P2PClient
+import rdx.works.profile.data.model.apppreferences.P2PLink
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.pernetwork.DerivationPath
 import rdx.works.profile.data.model.pernetwork.FactorInstance
@@ -61,8 +61,8 @@ class CreatePersonaUseCaseTest {
                 appPreferences = AppPreferences(
                     display = Display.default,
                     gateways = Gateways(network.url, listOf(network)),
-                    p2pClients = listOf(
-                        P2PClient.init(
+                    p2pLinks = listOf(
+                        P2PLink.init(
                             connectionPassword = "My password",
                             displayName = "Browser name test"
                         )

--- a/profile/src/test/java/rdx/works/profile/GenerateProfileUseCaseTest.kt
+++ b/profile/src/test/java/rdx/works/profile/GenerateProfileUseCaseTest.kt
@@ -17,7 +17,7 @@ import rdx.works.profile.data.model.apppreferences.AppPreferences
 import rdx.works.profile.data.model.apppreferences.Display
 import rdx.works.profile.data.model.apppreferences.Gateway
 import rdx.works.profile.data.model.apppreferences.Gateways
-import rdx.works.profile.data.model.apppreferences.P2PClient
+import rdx.works.profile.data.model.apppreferences.P2PLink
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.pernetwork.DerivationPath
 import rdx.works.profile.data.model.pernetwork.FactorInstance
@@ -54,8 +54,8 @@ class GenerateProfileUseCaseTest {
                 appPreferences = AppPreferences(
                     display = Display.default,
                     Gateways(Gateway.hammunet.url, listOf(Gateway.hammunet)),
-                    p2pClients = listOf(
-                        P2PClient.init(
+                    p2pLinks = listOf(
+                        P2PLink.init(
                             connectionPassword = "My password",
                             displayName = "Browser name test"
                         )

--- a/profile/src/test/java/rdx/works/profile/ProfileTest.kt
+++ b/profile/src/test/java/rdx/works/profile/ProfileTest.kt
@@ -11,14 +11,14 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import rdx.works.core.UUIDGenerator
 import rdx.works.profile.data.extensions.addAccount
-import rdx.works.profile.data.extensions.addP2PClient
+import rdx.works.profile.data.extensions.addP2PLink
 import rdx.works.profile.data.extensions.addPersona
 import rdx.works.profile.data.model.MnemonicWithPassphrase
 import rdx.works.profile.data.model.Profile
 import rdx.works.profile.data.model.ProfileSnapshot
 import rdx.works.profile.data.model.apppreferences.Gateway
 import rdx.works.profile.data.model.apppreferences.Network
-import rdx.works.profile.data.model.apppreferences.P2PClient
+import rdx.works.profile.data.model.apppreferences.P2PLink
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.pernetwork.OnNetwork
 import rdx.works.profile.data.model.pernetwork.OnNetwork.Account.Companion.init
@@ -109,15 +109,15 @@ class ProfileTest {
             1
         )
 
-        val p2pClient = P2PClient.init(
+        val p2pLink = P2PLink.init(
             connectionPassword = "deadbeeffadedeafdeadbeeffadedeafdeadbeeffadedeafdeadbeeffadedeaf",
             displayName = "Brave browser on Mac Studio"
         )
-        updatedProfile = updatedProfile.addP2PClient(
-            p2pClient = p2pClient
+        updatedProfile = updatedProfile.addP2PLink(
+            p2pLink = p2pLink
         )
 
-        assertEquals(updatedProfile.appPreferences.p2pClients.count(), 1)
+        assertEquals(updatedProfile.appPreferences.p2pLinks.count(), 1)
 
         Assert.assertTrue(profile.id.isNotBlank())
     }
@@ -221,13 +221,13 @@ class ProfileTest {
             onNetwork = networkId
         )
 
-        val p2pClient = P2PClient.init(
+        val p2pLink = P2PLink.init(
             connectionPassword = "deadbeeffadedeafdeadbeeffadedeafdeadbeeffadedeafdeadbeeffadedeaf",
             displayName = "Brave browser on Mac Studio"
         )
 
-        expected = expected.addP2PClient(
-            p2pClient = p2pClient
+        expected = expected.addP2PLink(
+            p2pLink = p2pLink
         )
 
         val authorizedDapp = OnNetwork.AuthorizedDapp(
@@ -295,18 +295,18 @@ class ProfileTest {
         // P2P clients
         assertEquals(
             "P2P clients count is the same",
-            expected.appPreferences.p2pClients.count(),
-            actual.appPreferences.p2pClients.count()
+            expected.appPreferences.p2pLinks.count(),
+            actual.appPreferences.p2pLinks.count()
         )
         assertEquals(
             "Connection password is the same for the first p2p client",
-            expected.appPreferences.p2pClients.first().connectionPassword,
-            actual.appPreferences.p2pClients.first().connectionPassword
+            expected.appPreferences.p2pLinks.first().connectionPassword,
+            actual.appPreferences.p2pLinks.first().connectionPassword
         )
         assertEquals(
             "The display name is the same for the first p2p client",
-            expected.appPreferences.p2pClients.first().displayName,
-            actual.appPreferences.p2pClients.first().displayName
+            expected.appPreferences.p2pLinks.first().displayName,
+            actual.appPreferences.p2pLinks.first().displayName
         )
 
         // Factor Sources

--- a/profile/src/test/resources/raw/profile_snapshot.json
+++ b/profile/src/test/resources/raw/profile_snapshot.json
@@ -15,7 +15,7 @@
         }
       ]
     },
-    "p2pClients": [
+    "p2pLinks": [
       {
         "connectionPassword": "deadbeeffadedeafdeadbeeffadedeafdeadbeeffadedeafdeadbeeffadedeaf",
         "displayName": "Brave browser on Mac Studio"
@@ -236,5 +236,5 @@
   ],
   "id": "9958f568-8c9b-476a-beeb-017d1f843266",
   "creatingDevice": "Galaxy A53 5G (Samsung SM-A536B)",
-  "version": 21
+  "version": 22
 }


### PR DESCRIPTION
## Description
[ticket_title](https://radixdlt.atlassian.net/browse/ABW-1158)

### Notes
* Renamed all classes and variables from p2p client to p2p link.
* Better be merged after this [PR](https://github.com/radixdlt/babylon-wallet-android/pull/172), since it is based on that.  
* You may see more changes, than you should. That's because, when we merge the aforementioned PR, you will be able to see the only changes related to renaming.