### PR TITLE
[ABW-1172] Fix close button not clickable in nft, and fungible bottom sheets

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/RadixCenteredTopAppBar.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/RadixCenteredTopAppBar.kt
@@ -43,7 +43,7 @@ fun RadixCenteredTopAppBar(
                         contentDescription = "navigate back"
                     )
                 }
-                BackIconType.Close -> {
+                BackIconType.Close -> IconButton(onClick = onBackClick) {
                     Icon(
                         painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_close),
                         tint = contentColor,


### PR DESCRIPTION
## Description
[Android  | Latest build | Account View | Token Info pop-up (X) button not working](https://radixdlt.atlassian.net/browse/ABW-1172)

### Screenshots (optional)
<img src="https://user-images.githubusercontent.com/125959264/226593012-111c3c69-0559-41be-a88f-db2a2ec09517.jpg" width="300">

### Notes (optional)
* It was not an `IconButton`
