### PR TITLE
Fix one time persona crash/display only info we sent back to dApp

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/model/AccountsRequest.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/model/AccountsRequest.kt
@@ -47,7 +47,7 @@ fun OneTimeAccountsRequestItem.toDomainModel(): IncomingRequest.AccountsRequestI
     return IncomingRequest.AccountsRequestItem(
         isOngoing = false,
         requiresProofOfOwnership = requiresProofOfOwnership,
-        numberOfAccounts = numberOfAccounts.quantity,
+        numberOfAccounts = numberOfAccounts.quantity.coerceAtLeast(1),
         quantifier = numberOfAccounts.quantifier.toDomainModel()
     )
 }
@@ -56,7 +56,7 @@ fun OngoingAccountsRequestItem.toDomainModel(): IncomingRequest.AccountsRequestI
     return IncomingRequest.AccountsRequestItem(
         isOngoing = true,
         requiresProofOfOwnership = requiresProofOfOwnership,
-        numberOfAccounts = numberOfAccounts.quantity,
+        numberOfAccounts = numberOfAccounts.quantity.coerceAtLeast(1),
         quantifier = numberOfAccounts.quantifier.toDomainModel()
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -278,6 +278,19 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
         }
     }
 
+    fun onGrantedPersonaDataOnetime(persona: Network.Persona) {
+        viewModelScope.launch {
+            val requiredFields = checkNotNull(request.oneTimePersonaDataRequestItem?.fields?.map { it.toKind() })
+            val requiredDataFields = persona.fields.filter { requiredFields.contains(it.kind) }
+            _state.update {
+                it.copy(
+                    selectedOnetimeDataFields = requiredDataFields
+                )
+            }
+            sendRequestResponse()
+        }
+    }
+
     private suspend fun requestedAccountsPermissionAlreadyGranted(
         personaAddress: String,
         accountsRequestItem: AccountsRequestItem?

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
@@ -94,7 +94,9 @@ fun PersonaDataOnetimeScreen(
         }
     }
     PersonaDataOnetimeContent(
-        onContinueClick = {},
+        onContinueClick = {
+            sharedViewModel.onGrantedPersonaDataOnetime(state.selectedPersona())
+        },
         dappMetadata = sharedState.dappMetadata,
         onBackClick = {
             if (sharedState.initialAuthorizedLoginRoute is InitialAuthorizedLoginRoute.OneTimePersonaData) {
@@ -107,7 +109,8 @@ fun PersonaDataOnetimeScreen(
         personas = state.personaListToDisplay,
         onSelectPersona = viewModel::onSelectPersona,
         onCreatePersona = viewModel::onCreatePersona,
-        onEditClick = viewModel::onEditClick
+        onEditClick = viewModel::onEditClick,
+        continueButtonEnabled = state.continueButtonEnabled
     )
 }
 
@@ -122,6 +125,7 @@ private fun PersonaDataOnetimeContent(
     onSelectPersona: ((Network.Persona) -> Unit)?,
     onCreatePersona: () -> Unit,
     onEditClick: (String) -> Unit,
+    continueButtonEnabled: Boolean,
 ) {
     Column(
         modifier = modifier
@@ -210,6 +214,7 @@ private fun PersonaDataOnetimeContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(RadixTheme.dimensions.paddingDefault),
+            enabled = continueButtonEnabled,
             onClick = onContinueClick,
             text = stringResource(id = R.string.continue_button_title)
         )
@@ -249,7 +254,8 @@ fun LoginPermissionContentPreview() {
             personas = persistentListOf(PersonaUiModel(SampleDataProvider().samplePersona())),
             onSelectPersona = {},
             onCreatePersona = {},
-            onEditClick = {}
+            onEditClick = {},
+            continueButtonEnabled = false
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeViewModel.kt
@@ -77,4 +77,8 @@ sealed interface PersonaDataOnetimeEvent : OneOffEvent {
 data class PersonaDataOnetimeUiState(
     val personaListToDisplay: ImmutableList<PersonaUiModel> = persistentListOf(),
     val continueButtonEnabled: Boolean = false
-) : UiState
+) : UiState {
+    fun selectedPersona(): Network.Persona {
+        return personaListToDisplay.first { it.selected }.persona
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/PersonaUiModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/PersonaUiModel.kt
@@ -15,6 +15,20 @@ data class PersonaUiModel(
     fun missingFieldKinds(): ImmutableList<Network.Persona.Field.Kind> {
         return requiredFieldKinds.minus(persona.fields.map { it.kind }.toSet()).sortedBy { it.ordinal }.toPersistentList()
     }
+
+    fun personalInfoFormatted(): String {
+        return buildString {
+            val fields = persona.fields.filter { requiredFieldKinds.contains(it.kind) }
+            val givenName = fields.firstOrNull { it.kind == Network.Persona.Field.Kind.GivenName }?.value
+            val familyName = fields.firstOrNull { it.kind == Network.Persona.Field.Kind.FamilyName }?.value
+            val email = fields.firstOrNull { it.kind == Network.Persona.Field.Kind.EmailAddress }?.value
+            val phone = fields.firstOrNull { it.kind == Network.Persona.Field.Kind.PhoneNumber }?.value
+            append(
+                listOfNotNull(listOfNotNull(givenName, familyName).joinToString(separator = " "), email, phone).filter { it.isNotEmpty() }
+                    .joinToString("\n")
+            )
+        }
+    }
 }
 
 fun Network.Persona.toUiModel(): PersonaUiModel {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/model/PersonaExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/model/PersonaExtensions.kt
@@ -17,19 +17,6 @@ fun Network.Persona.Field.Kind.toDisplayResource(): Int {
     }
 }
 
-fun Network.Persona.personalInfoFormatted(): String {
-    return buildString {
-        val givenName = fields.firstOrNull { it.kind == Network.Persona.Field.Kind.GivenName }?.value
-        val familyName = fields.firstOrNull { it.kind == Network.Persona.Field.Kind.FamilyName }?.value
-        val email = fields.firstOrNull { it.kind == Network.Persona.Field.Kind.EmailAddress }?.value
-        val phone = fields.firstOrNull { it.kind == Network.Persona.Field.Kind.PhoneNumber }?.value
-        append(
-            listOfNotNull(listOfNotNull(givenName, familyName).joinToString(separator = " "), email, phone).filter { it.isNotEmpty() }
-                .joinToString("\n")
-        )
-    }
-}
-
 fun List<Network.Persona.Field.Kind>.encodeToString(): String {
     return joinToString(",") { it.name }.encodeUtf8()
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/persona/PersonaDetailCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/persona/PersonaDetailCard.kt
@@ -27,7 +27,6 @@ import com.babylon.wallet.android.designsystem.composable.RadixPrimaryButton
 import com.babylon.wallet.android.designsystem.composable.RadixSecondaryButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.PersonaUiModel
-import com.babylon.wallet.android.presentation.model.personalInfoFormatted
 import com.babylon.wallet.android.presentation.model.toDisplayResource
 import com.babylon.wallet.android.presentation.ui.composables.PersonaRoundedAvatar
 import com.babylon.wallet.android.utils.setSpanForPlaceholder
@@ -76,7 +75,7 @@ fun PersonaDetailCard(
             }
         }
         Divider(color = RadixTheme.colors.gray4)
-        val personalInfo = persona.persona.personalInfoFormatted()
+        val personalInfo = persona.personalInfoFormatted()
         if (personalInfo.isNotEmpty()) {
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
             Text(


### PR DESCRIPTION
- one time persona data was not handled in authorized request
- show only persona data that dApp requested 
- when dapp requests 0 account, request at least 1 or exactly 1 depending on quantifier