### PR TITLE
[ABW-1234] Pass MainViewModel instance down to the graph

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
+++ b/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
@@ -39,6 +39,7 @@ class MainActivity : FragmentActivity() {
                 val state by viewModel.state.collectAsStateWithLifecycle()
                 DevelopmentPreviewWrapper {
                     WalletApp(
+                        mainViewModel = viewModel,
                         appNavigationState = state.initialAppState,
                         oneOffEvent = viewModel.oneOffEvent
                     )

--- a/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
+++ b/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.Flow
 @Composable
 @Suppress("ModifierMissing")
 fun WalletApp(
+    mainViewModel: MainViewModel,
     appNavigationState: AppNavigationState,
     oneOffEvent: Flow<MainEvent>,
 ) {
@@ -28,24 +29,28 @@ fun WalletApp(
     when (appNavigationState) {
         AppNavigationState.CreateAccount -> {
             NavigationHost(
+                mainViewModel = mainViewModel,
                 startDestination = ROUTE_CREATE_ACCOUNT,
                 navController = navController
             )
         }
         AppNavigationState.Wallet -> {
             NavigationHost(
+                mainViewModel = mainViewModel,
                 startDestination = Screen.WalletDestination.route,
                 navController = navController
             )
         }
         is AppNavigationState.IncompatibleProfile -> {
             NavigationHost(
+                mainViewModel = mainViewModel,
                 startDestination = ROUTE_INCOMPATIBLE_PROFILE,
                 navController = navController
             )
         }
         AppNavigationState.Onboarding -> {
             NavigationHost(
+                mainViewModel = mainViewModel,
                 startDestination = Screen.OnboardingDestination.route,
                 navController = navController
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/IncompatibleProfileDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/IncompatibleProfileDialog.kt
@@ -19,7 +19,7 @@ const val ROUTE_INCOMPATIBLE_PROFILE = "incompatible_profile_route"
 
 @Composable
 fun IncompatibleProfileContent(
-    viewModel: MainViewModel,
+    mainViewModel: MainViewModel,
     modifier: Modifier = Modifier
 ) {
     val activity = (LocalContext.current as MainActivity)
@@ -32,7 +32,7 @@ fun IncompatibleProfileContent(
         BasicPromptAlertDialog(
             finish = {
                 if (it) {
-                    viewModel.deleteProfile()
+                    mainViewModel.deleteProfile()
                 } else {
                     activity.finish()
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -9,6 +9,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
+import com.babylon.wallet.android.MainViewModel
 import com.babylon.wallet.android.presentation.IncompatibleProfileContent
 import com.babylon.wallet.android.presentation.ROUTE_INCOMPATIBLE_PROFILE
 import com.babylon.wallet.android.presentation.account.AccountScreen
@@ -44,6 +45,7 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun NavigationHost(
+    mainViewModel: MainViewModel,
     startDestination: String,
     navController: NavHostController,
 ) {
@@ -184,9 +186,12 @@ fun NavigationHost(
             }
         )
         settingsNavGraph(navController)
-        requestResultSuccess(onBackPress = {
-            navController.popBackStack()
-        })
+        requestResultSuccess(
+            mainViewModel = mainViewModel,
+            onBackPress = {
+                navController.popBackStack()
+            }
+        )
         createPersonaConfirmationScreen(
             finishPersonaCreation = {
                 navController.popPersonaCreation()
@@ -208,9 +213,7 @@ fun NavigationHost(
         composable(
             route = ROUTE_INCOMPATIBLE_PROFILE
         ) {
-            IncompatibleProfileContent(
-                viewModel = hiltViewModel()
-            )
+            IncompatibleProfileContent(mainViewModel = mainViewModel)
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/requestresult/success/RequestResultSuccessScreenNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/requestresult/success/RequestResultSuccessScreenNav.kt
@@ -2,12 +2,12 @@ package com.babylon.wallet.android.presentation.ui.composables.requestresult.suc
 
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.dialog
 import androidx.navigation.navArgument
+import com.babylon.wallet.android.MainViewModel
 import com.babylon.wallet.android.R
 
 @VisibleForTesting
@@ -26,7 +26,10 @@ fun NavController.requestResultSuccess(
     navigate("request_result_success/$requestId/$name")
 }
 
-fun NavGraphBuilder.requestResultSuccess(onBackPress: () -> Unit) {
+fun NavGraphBuilder.requestResultSuccess(
+    mainViewModel: MainViewModel,
+    onBackPress: () -> Unit
+) {
     dialog(
         route = "request_result_success/{$ARG_REQUEST_ID}/{$ARG_DAPP_NAME}",
         arguments = listOf(
@@ -39,7 +42,7 @@ fun NavGraphBuilder.requestResultSuccess(onBackPress: () -> Unit) {
         val dAppName = checkNotNull(it.arguments?.getString(ARG_DAPP_NAME))
 
         RequestResultSuccessScreen(
-            viewModel = hiltViewModel(),
+            viewModel = mainViewModel,
             requestId = requestId,
             dAppName = dAppName,
             onBackPress = onBackPress


### PR DESCRIPTION
### Notes (optional)
* To a luck of a better solution, passed the instance of the `MainActivity`'s `MainViewModel` down to all composables that needed it.
* In order to test it create an `init` block in `MainViewModel` and log its initialisation. Now it will log only once. Then try to connect with different dApps. The success screen, which caused the double-init, is now shown, but after that it does not cause any trouble when logging in.