### PR TITLE
ABW-1235 Add displayId property as a key to NFT list

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/model/NftCollectionUiModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/model/NftCollectionUiModel.kt
@@ -10,6 +10,7 @@ data class NftCollectionUiModel(
 
     data class NftItemUiModel(
         val id: String,
+        val displayId: Int,
         val nftImage: String? = null,
         val nftsMetadata: List<Pair<String, String>> = emptyList()
     )
@@ -20,7 +21,7 @@ fun List<OwnedNonFungibleToken>.toNftUiModel() = map { ownedNonFungibleToken ->
         name = ownedNonFungibleToken.token?.getTokenName().orEmpty(),
         iconUrl = ownedNonFungibleToken.token?.getImageUrl().orEmpty(),
         nft = ownedNonFungibleToken.token?.nonFungibleIdContainer?.ids?.map {
-            NftCollectionUiModel.NftItemUiModel(id = it)
+            NftCollectionUiModel.NftItemUiModel(id = it, displayId = (ownedNonFungibleToken.tokenResourceAddress + it).hashCode())
         }.orEmpty()
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/NftListContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/NftListContent.kt
@@ -45,7 +45,7 @@ fun NftListContent(
             }
             items(
                 dataItem.nft,
-                key = { nft -> nft.id }
+                key = { nft -> nft.displayId }
             ) { item ->
                 AnimatedVisibility(
                     visible = !collapsed,


### PR DESCRIPTION
- crash happens when you created multiple owner badges via Dashboard for same account