### PR TITLE
[ABW-1419] Add one minute timeout before peerdroid termination

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
+++ b/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
@@ -11,8 +11,6 @@ import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.FragmentActivity
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.ui.composables.DevelopmentPreviewWrapper
 import com.google.accompanist.pager.ExperimentalPagerApi
@@ -43,7 +41,6 @@ class MainActivity : FragmentActivity() {
                 }
             }
         }
-        lifecycle.addObserver(PeerdroidHandler())
     }
 
     private fun setSplashExitAnimation(splashScreen: SplashScreen) {
@@ -63,17 +60,5 @@ class MainActivity : FragmentActivity() {
 
     companion object {
         private const val splashExitAnimDurationMs = 300L
-    }
-
-    inner class PeerdroidHandler : DefaultLifecycleObserver {
-        override fun onPause(owner: LifecycleOwner) {
-            viewModel.onPause()
-            super.onPause(owner)
-        }
-
-        override fun onResume(owner: LifecycleOwner) {
-            viewModel.onResume()
-            super.onResume(owner)
-        }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
+++ b/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
@@ -3,6 +3,7 @@ package com.babylon.wallet.android
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.presentation.dapp.authorized.login.dAppLoginAuthorized
 import com.babylon.wallet.android.presentation.dapp.unauthorized.login.dAppLoginUnauthorized
@@ -56,4 +57,5 @@ fun WalletApp(
             }
         }
     }
+    mainViewModel.observeP2PLinks.collectAsStateWithLifecycle(null)
 }

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -2,6 +2,7 @@ package rdx.works.profile.domain
 
 import com.radixdlt.toolkit.RadixEngineToolkit
 import com.radixdlt.toolkit.models.request.DecodeAddressRequest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -74,4 +75,4 @@ val GetProfileUseCase.security
  * P2P Links preferences
  */
 val GetProfileUseCase.p2pLinks
-    get() = invoke().map { it.appPreferences.p2pLinks }
+    get() = invoke().map { it.appPreferences.p2pLinks }.distinctUntilChanged()


### PR DESCRIPTION
## Description
[Keep WebRTC data channel during biometric or pin dialog](https://radixdlt.atlassian.net/browse/ABW-1419)

In order to avoid the termination of WebRTC data channel during a security prompt (either a biometric or pin screen) we add a 1 minute timeout termination.
