### PR TITLE
ABW-950 - NavigateUp used instead of PopBackStack.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsNavGraph.kt
@@ -83,7 +83,7 @@ private fun NavGraphBuilder.settingsAll(navController: NavController) {
         SettingsScreen(
             viewModel = hiltViewModel(),
             onBackClick = {
-                navController.popBackStack()
+                navController.navigateUp()
             },
             onSettingClick = { item ->
                 when (item) {


### PR DESCRIPTION
## Description
https://radixdlt.atlassian.net/browse/ABW-950

### Screenshots (optional)
<img src="image_url" width="300">

### Notes (optional)
It fixes the problem however I don't fully understand why, because it don't know what exactly was causing it.
Documentation basically recommends to use `navigateUp()` for Up button click and `popBackStack()` for Back button clicks, even though behaviour is exactly the same except the scenario when deep linking into the app which is not the case.
Any ideas thoughts on what could be causing this are welcome.

I have also checked this (https://radixdlt.atlassian.net/browse/ABW-1373) because I thought it might be the same thing however can't use the same solution as here.