### PR TITLE
Fix data channel closing when parsing error in incoming request

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/PeerdroidClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/PeerdroidClient.kt
@@ -109,6 +109,7 @@ class PeerdroidClientImpl @Inject constructor(
         peerdroidConnector.terminateConnectionToConnectorExtension()
     }
 
+    @Suppress("SwallowedException")
     private fun parseIncomingMessage(
         remoteClientId: String,
         messageInJsonString: String

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/MessageFromDataChannel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/MessageFromDataChannel.kt
@@ -26,7 +26,7 @@ sealed interface MessageFromDataChannel {
 
             fun hasOngoingRequestItemsOnly(): Boolean {
                 return isUsePersonaAuth() && hasNoOneTimeRequestItems() && hasNoResetRequestItem() &&
-                        (ongoingAccountsRequestItem != null || ongoingPersonaDataRequestItem != null)
+                    (ongoingAccountsRequestItem != null || ongoingPersonaDataRequestItem != null)
             }
 
             fun isInternalRequest(): Boolean {
@@ -47,14 +47,14 @@ sealed interface MessageFromDataChannel {
 
             fun hasOnlyAuthItem(): Boolean {
                 return ongoingAccountsRequestItem == null &&
-                        ongoingPersonaDataRequestItem == null &&
-                        oneTimeAccountsRequestItem == null &&
-                        oneTimePersonaDataRequestItem == null
+                    ongoingPersonaDataRequestItem == null &&
+                    oneTimeAccountsRequestItem == null &&
+                    oneTimePersonaDataRequestItem == null
             }
 
             fun isValidRequest(): Boolean {
                 return ongoingAccountsRequestItem?.isValidRequestItem() != false &&
-                        oneTimeAccountsRequestItem?.isValidRequestItem() != false
+                    oneTimeAccountsRequestItem?.isValidRequestItem() != false
             }
 
             sealed interface AuthRequest {


### PR DESCRIPTION
## Description
This is a quick fix when wallet fails to parse an incoming request that causes the termination of the data channel.
This is not necessary and we can keep the channel open (same happens in iOS)

### Testing
Test the main branch with the rcnet dashboard which is not compatible with the new CAP21 update. Try to login and then try to login with another compatible dapp. Wallet will never receive the request because channel has been closed.
