### PR TITLE
Create Network if does not exist before switching to it

### DIFF
--- a/profile/src/main/java/rdx/works/profile/data/model/pernetwork/Network.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/pernetwork/Network.kt
@@ -486,6 +486,24 @@ fun Profile.addAccount(
     return updatedProfile
 }
 
+fun Profile.addNetworkIfDoesNotExist(
+    onNetwork: NetworkId
+): Profile {
+    val networkExist = this.networks.any { onNetwork.value == it.networkID }
+    return if (!networkExist) {
+        copy(
+            networks = networks + Network(
+                accounts = listOf(),
+                authorizedDapps = listOf(),
+                networkID = onNetwork.value,
+                personas = listOf()
+            )
+        )
+    } else {
+        this
+    }
+}
+
 fun Profile.incrementFactorSourceNextAccountIndex(
     forNetwork: NetworkId,
     factorSourceId: FactorSource.ID

--- a/profile/src/main/java/rdx/works/profile/domain/account/SwitchNetworkUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/account/SwitchNetworkUseCase.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.apppreferences.changeGateway
+import rdx.works.profile.data.model.pernetwork.addNetworkIfDoesNotExist
 import rdx.works.profile.data.repository.ProfileRepository
 import rdx.works.profile.data.repository.profile
 import rdx.works.profile.derivation.model.NetworkId
@@ -28,7 +29,7 @@ class SwitchNetworkUseCase @Inject constructor(
                     network.name == networkName
                 }
             )
-            val updatedProfile = profile.changeGateway(gateway)
+            val updatedProfile = profile.addNetworkIfDoesNotExist(gateway.network.networkId()).changeGateway(gateway)
             profileRepository.saveProfile(updatedProfile)
             gateway.network.networkId()
         }


### PR DESCRIPTION
After decoupling network switching, for a moment it was possible to have profile without the network we just switched to, because new network was only created when new account was added. Right now empty network is created before we switch to it.