### PR TITLE
[ABW-1528] Add internal build names

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,6 @@ def debugKeystoreProperties = new Properties()
 debugKeystoreProperties.load(new FileInputStream(debugPropertiesFile))
 
 android {
-    compileSdk rootProject.ext.compileSdk
-
     signingConfigs {
         debug {
             keyAlias debugKeystoreProperties['keyAlias']
@@ -44,12 +42,14 @@ android {
         }
     }
 
+    compileSdk rootProject.ext.compileSdk
+
     defaultConfig {
         applicationId "com.babylon.wallet.android"
-        minSdk 27
+        minSdk rootProject.ext.minSdk
         targetSdk rootProject.ext.targetSdk
         versionCode 1
-        versionName "0.2.1"
+        versionName rootProject.ext.versionName
         buildConfigField "boolean", "DEBUG_MODE", "true"
         buildConfigField "String", "WELL_KNOWN_URL_SUFFIX", '".well-known/radix.json"'
         buildConfigField "String", "IMAGE_HOST_BASE_URL", '"https://image-service-dev.extratools.works"'
@@ -63,6 +63,7 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled true
+            versionNameSuffix "-" + rootProject.ext.internalVersionName
             resValue "string", "app_name", "Radix Wallet Dev"
         }
         debugAlpha {
@@ -77,6 +78,7 @@ android {
         debugPreview {
             initWith release
             applicationIdSuffix ".preview"
+            versionNameSuffix "-" + rootProject.ext.internalVersionName
             minifyEnabled true
             signingConfig signingConfigs.debugPreview
             resValue "string", "app_name", "Radix Wallet Preview"
@@ -89,6 +91,7 @@ android {
             buildConfigField "String", "IMAGE_HOST_BASE_URL", '"https://image-service.radixdlt.com"'
             signingConfig signingConfigs.releasePreview
             applicationIdSuffix ".preview"
+            versionNameSuffix "-" + rootProject.ext.internalVersionName
             minifyEnabled true
             resValue "string", "app_name", "Radix Wallet Preview"
             matchingFallbacks = ['release']

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,7 +103,7 @@
     <string name="link_to_connector">Link to Connector</string>
     <string name="link_new_connector">Link New Connector</string>
     <string name="linked_connector">Linked Connector</string>
-    <string name="version_and_build">Version: %s build %d</string>
+    <string name="version_and_build">Version: %s (build %d)</string>
     <string name="your_radix_wallet_is_linked">Your Radix Wallet is linked to the following desktop browser using the Connector browser extension.</string>
     <string name="space">" "</string>
     <string name="resource_address">Resource Address</string>

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ buildscript {
         minSdk = 27
         compileSdk = 33
         targetSdk = 33
+        versionName = "0.2.1"
+        internalVersionName = "ash"
         kotlinCompilerExtensionVersion = "1.4.0"
     }
     dependencies {


### PR DESCRIPTION
## Description
[(Android) Add internal release name to build name](https://radixdlt.atlassian.net/browse/ABW-1528)

### Notes
Check the naming strategy in [confluence](https://radixdlt.atlassian.net/wiki/spaces/AT/pages/edit-v2/2826076188). From my understanding the `debug`, `alpha` and `preview` builds need to have the internal release name suffixed (eg. `-ash`). The release version should not include it. 

Tell my what you think
