### PR TITLE
[ABW-1544] Make values-en the default strings directory for Crowdin compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-
-
 # Gradle files
 .gradle/
 build/
@@ -37,3 +35,6 @@ google-services.json
 .DS_Store
 
 vendor/
+
+# Default translation file (See in app/build.gradle)
+app/src/main/res/values/strings.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -230,3 +230,19 @@ dependencies {
     debugImplementation libs.composeUiTooling
     debugImplementation libs.composeUiTestManifest
 }
+
+/**
+ * Copies the english translation file to the default location.
+ * This is needed since Crowdin cannot create pull requests
+ * in a path that does not declare the language code.
+ *
+ * So assuming that the english language defined in the values-es is the default,
+ * this will be the file that gets copied.
+ */
+task buildDefaultLanguage {
+    copy {
+        from ('src/main/res/values-en/strings.xml')
+        into ('src/main/res/values/')
+    }
+}
+preBuild.dependsOn buildDefaultLanguage

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/permission/LoginPermissionScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/permission/LoginPermissionScreen.kt
@@ -193,9 +193,8 @@ private fun RequestedPermissionsList(
             if (numberOfAccounts == 0) {
                 stringResource(id = R.string.any_number_of_accounts)
             } else {
-                pluralStringResource(
-                    id = R.plurals.view_at_least_x_accounts,
-                    numberOfAccounts,
+                stringResource(
+                    id = R.string.view_at_least_x_accounts,
                     numberOfAccounts
                 )
             }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -139,9 +139,7 @@
         <item quantity="one">\u2022 %d account</item>
         <item quantity="other">\u2022 %d accounts</item>
     </plurals>
-    <plurals name="view_at_least_x_accounts">
-        <item quantity="other">\u2022 %d or more accounts</item>
-    </plurals>
+    <string name="view_at_least_x_accounts">\u2022 %d or more accounts</string>
     <string name="any_number_of_accounts">\u2022 Any number of accounts</string>
     <string name="agree">Agree</string>
     <string name="new_login_request">New Login Request</string>


### PR DESCRIPTION
## Description
[(Android) Modify build to use values-en/ as default translations since Crowdin cannot target values/](https://radixdlt.atlassian.net/browse/ABW-1544)

### Notes
* Unfortunately Crowdin does not support targeting a directory without the two letter code
![Screenshot 2023-05-18 at 14 33 27](https://github.com/radixdlt/babylon-wallet-android/assets/125959264/2b154b00-da15-4681-805d-7f594e21450e)
![Screenshot 2023-05-18 at 14 33 36](https://github.com/radixdlt/babylon-wallet-android/assets/125959264/741efc49-7139-45df-bbc5-c34dd4886f85)
* This means that we can no longer keep our default strings file inside the `/values/strings.xml`. On the other hand this is the default location our build system needs to build the `R` class.
* An easy solution to that was to:
    1. Move the strings.xml file inside the `values-en/` directory.
    2. Add the default strings path to `.gitignore`
    3. Create a gradle task like this:
        ```
            task buildDefaultLanguage {
                copy {
                    from ('src/main/res/values-en/strings.xml')
                    into ('src/main/res/values/')
                }
            }
            preBuild.dependsOn buildDefaultLanguage
       ```
        Which copies the `values-en/strings.xml` file to the default directory.
    4. So from now on we will be treating the strings file as a "build" file
