### PR TITLE
Fix firebase distribution problem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-firebase_app_distribution (0.3.8)
+    fastlane-plugin-json (1.1.0)
     fastlane-plugin-versioning_android (0.1.0)
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.31.0)
@@ -218,6 +219,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   fastlane-plugin-firebase_app_distribution
+  fastlane-plugin-json
   fastlane-plugin-versioning_android
 
 BUNDLED WITH

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,10 @@ def debugPropertiesFile = rootProject.file("keystore-development.properties")
 def debugKeystoreProperties = new Properties()
 debugKeystoreProperties.load(new FileInputStream(debugPropertiesFile))
 
+static def getCommitHash() {
+    'git rev-parse --verify --short HEAD'.execute().text.trim()
+}
+
 android {
     signingConfigs {
         debug {
@@ -63,7 +67,7 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled true
-            versionNameSuffix "-" + rootProject.ext.internalVersionName
+            versionNameSuffix "-" + rootProject.ext.internalVersionName + "-" + getCommitHash()
             resValue "string", "app_name", "Radix Wallet Dev"
         }
         debugAlpha {
@@ -78,7 +82,7 @@ android {
         debugPreview {
             initWith release
             applicationIdSuffix ".preview"
-            versionNameSuffix "-" + rootProject.ext.internalVersionName
+            versionNameSuffix "-" + rootProject.ext.internalVersionName + "-" + getCommitHash()
             minifyEnabled true
             signingConfig signingConfigs.debugPreview
             resValue "string", "app_name", "Radix Wallet Preview"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,31 +16,26 @@
 desc "Deploy merges to main and any other manual trigger"
 lane :alpha do
 
-  branch_name = git_branch
-  version_name = android_get_version_name
-  commit = last_git_commit
-  ENV["RELEASE_NOTES"] = "Branch: " + branch_name + "\n" + "Commit: " + commit[:message]
-  short_hash = commit[:abbreviated_commit_hash]
-  version = version_name + "-" + short_hash
-  android_set_version_name(
-    version_name: version
-  )
-  gradle(
-      task: "assemble",
-      flavor: "Debug",
-      build_type: "Alpha",
-      properties: {
+    branch_name = git_branch
+    commit = last_git_commit
+    ENV["RELEASE_NOTES"] = "Branch: " + branch_name + "\n" + "Commit: " + commit[:message]
+
+    gradle(
+        task: "assemble",
+        flavor: "Debug",
+        build_type: "Alpha",
+        properties: {
           "android.injected.signing.store.file" => ENV["RADIX_DEBUG_PREVIEW_KEYSTORE_FILE"],
           "android.injected.signing.store.password" => ENV["RADIX_ANDROID_KEYSTORE_PASSWORD"],
           "android.injected.signing.key.alias" => ENV["RADIX_ANDROID_KEYSTORE_ALIAS"],
           "android.injected.signing.key.password" => ENV["RADIX_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD"]
         }
-      )
-  firebase_app_distribution(
-      app: ENV["FIREBASE_APP_ID"],
-      release_notes: ENV["RELEASE_NOTES"],
-      groups: ENV["GROUPS"]
-  )
+    )
+    firebase_app_distribution(
+        app: ENV["FIREBASE_APP_ID"],
+        release_notes: ENV["RELEASE_NOTES"],
+        groups: ENV["GROUPS"]
+    )
 
 end
 
@@ -57,15 +52,15 @@ lane :preview do
             "android.injected.signing.store.password" => ENV["RADIX_ANDROID_KEYSTORE_PASSWORD"],
             "android.injected.signing.key.alias" => ENV["RADIX_ANDROID_KEYSTORE_ALIAS"],
             "android.injected.signing.key.password" => ENV["RADIX_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD"]
-          }
-        )
+        }
+    )
     firebase_app_distribution(
         app: ENV["FIREBASE_APP_ID"],
         release_notes: ENV["RELEASE_NOTES"],
         groups: ENV["GROUPS"]
     )
     build_number_to_commit = File.read("../versioning/#{BUILD_NUMBER_FILE}")
-    version_name = android_get_version_name
+    version_name = get_version_name output_file: Actions.lane_context[SharedValues::GRADLE_OUTPUT_JSON_OUTPUT_PATH]
     git_commit(
         path: "./versioning/#{BUILD_NUMBER_FILE}",
         message: "Version #{version_name} (#{build_number_to_commit}) distributed to Firebase"
@@ -83,15 +78,17 @@ lane :release_to_google_play do
     BUILD_NUMBER_FILE = "PLAYSTORE_BUILD_NUMBER"
     bump_build_number versioning_file: "../versioning/#{BUILD_NUMBER_FILE}"
     gradle(
-        task: "bundle",
-        build_type: "releasePreview",
+        tasks: [
+            "bundleReleasePreview",  # Builds the bundle for PlayStore
+            "assembleReleasePreview" # Builds the APK that extracts the output.json for the version
+        ],
         properties: {
             "android.injected.signing.store.file" => ENV["RADIX_DEBUG_PREVIEW_KEYSTORE_FILE"],
             "android.injected.signing.store.password" => ENV["RADIX_ANDROID_KEYSTORE_PASSWORD"],
             "android.injected.signing.key.alias" => ENV["RADIX_ANDROID_KEYSTORE_ALIAS"],
             "android.injected.signing.key.password" => ENV["RADIX_ANDROID_KEYSTORE_PRIVATE_KEY_PASSWORD"]
-          }
-        )
+        }
+    )
 
     upload_to_play_store(
         package_name: "com.babylon.wallet.android.preview",
@@ -102,10 +99,10 @@ lane :release_to_google_play do
         skip_upload_screenshots: true,
         release_status: "draft",
         json_key: ENV["GOOGLE_PLAY_PREVIEW_DEPLOYER_JSON_FILE"]
-        )
+    )
 
     build_number_to_commit = File.read("../versioning/#{BUILD_NUMBER_FILE}")
-    version_name = android_get_version_name
+    version_name = get_version_name output_file: Actions.lane_context[SharedValues::GRADLE_OUTPUT_JSON_OUTPUT_PATH]
     git_commit(
         path: "./versioning/#{BUILD_NUMBER_FILE}",
         message: "Version #{version_name} (#{build_number_to_commit}) distributed to Playstore"
@@ -146,4 +143,9 @@ lane :bump_build_number do |options|
         gradle_file: "app/build.gradle"
     )
 
+end
+
+lane :get_version_name do |options|
+    output = read_json(json_path: options[:output_file])
+    output[:elements][0][:versionName]
 end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,3 +4,4 @@
 
 gem 'fastlane-plugin-firebase_app_distribution'
 gem 'fastlane-plugin-versioning_android'
+gem 'fastlane-plugin-json'

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -45,6 +45,14 @@ Deploy to Google Play Console
 
 
 
+### get_version_name
+
+```sh
+[bundle exec] fastlane get_version_name
+```
+
+
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
The plugin being used to get the version name has a [bug](https://github.com/beplus/fastlane-plugin-versioning_android/issues/7). When the version name is a variable it reads it as a string. 

### Fixes
1. Added the commit hash as part of the version name suffix in debug builds (Used for firebase, and local builds)
2. No need for the `alpha` lane to suffix the commit hash since it is already part of the version name
3. The `release_to_google_play` lane needs to build both the bundle (for PlayStore) and the APK (for the `output.json`)
4. The **compiled** version name can be retrieved from the `output.json`