### PR TITLE
Fix peerdroid job in MainViewModel

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
@@ -154,6 +154,7 @@ class MainViewModel @Inject constructor(
 
     private fun terminatePeerdroid() {
         incomingDappRequestsJob?.cancel()
+        incomingDappRequestsJob = null
         processingDappRequestJob?.cancel()
         processingDappRequestJob = null
         peerdroidClient.terminate()


### PR DESCRIPTION
## Description
When the app goes into background and then back to foreground the mainviewmodel doesn't receive the requests from dapp because the job is still in memory. 
This can be fixed by null the job.