### PR TITLE
[ABW-1607] Keyboard is hiding textfield on create account screen 

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/createaccount/CreateAccountScreen.kt
@@ -115,6 +115,7 @@ fun CreateAccountContent(
     Column(
         modifier = modifier
             .navigationBarsPadding()
+            .imePadding()
             .background(RadixTheme.colors.defaultBackground)
             .fillMaxSize()
     ) {


### PR DESCRIPTION
## Description
[Android | 0.2.1-ash-fb0e6642 | Create new/first Account - Keyboard blocking input field ](https://radixdlt.atlassian.net/browse/ABW-1607)

### Notes 
* Added ime padding