### PR TITLE
ABW-1798 - Focus cleared on tap outside of the textfield.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -304,8 +304,6 @@ fun TransferContent(
 
                 items(state.targetAccounts.size) { index ->
                     val targetAccount = state.targetAccounts[index]
-
-                    val focusManager = LocalFocusManager.current
                     TargetAccountCard(
                         onChooseAccountClick = {
                             focusManager.clearFocus()


### PR DESCRIPTION
## Description
https://radixdlt.atlassian.net/browse/ABW-1798

### Screenshots (optional)
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/1b89d7a7-2103-465a-a17f-4581b8db3b19" width="300">

### Notes (optional)
Focus cleared and keyboard hidden on tapping outside of Message textfield.
