### PR TITLE
ABW-1812 - Data is displayed properly when account does not contain t…

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionApprovalViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionApprovalViewModel.kt
@@ -305,17 +305,11 @@ class TransactionApprovalViewModel @Inject constructor(
                         when (accountDeposit.resourceQuantifier) {
                             is ResourceQuantifier.Amount -> {
                                 amount = (accountDeposit.resourceQuantifier as ResourceQuantifier.Amount).amount
-                                val fungibleToken = accountWithResource?.resources?.fungibleResources?.find {
+                                // Search for fungible resource among all accounts
+                                val fungibleToken = accountsWithResources.mapNotNull { accountsWithResources ->
+                                    accountsWithResources.resources?.fungibleResources
+                                }.flatten().find {
                                     it.resourceAddress == resourceAddress
-                                } ?: run {
-                                    // When its null it means that depositing account is empty (no tokens) or simply
-                                    // does not contain token with this particular resourceAddress so we take it
-                                    // from the whole list
-                                    accountsWithResources.mapNotNull { accountsWithResources ->
-                                        accountsWithResources.resources?.fungibleResources
-                                    }.flatten().find {
-                                        it.resourceAddress == resourceAddress
-                                    }
                                 }
                                 fungibleResource = fungibleToken?.copy(
                                     amount = amount.toBigDecimal()
@@ -387,17 +381,11 @@ class TransactionApprovalViewModel @Inject constructor(
                         when (accountDeposit.resourceQuantifier) {
                             is ResourceQuantifier.Amount -> {
                                 amount = (accountDeposit.resourceQuantifier as ResourceQuantifier.Amount).amount
-                                val fungibleToken = accountWithResource?.resources?.fungibleResources?.find {
+                                // Search for fungible resource among all accounts
+                                val fungibleToken = accountsWithResources.mapNotNull { accountsWithResources ->
+                                    accountsWithResources.resources?.fungibleResources
+                                }.flatten().find {
                                     it.resourceAddress == resourceAddress
-                                } ?: run {
-                                    // When its null it means that depositing account is empty (no tokens) or simply
-                                    // does not contain token with this particular resourceAddress so we take it
-                                    // from the whole list
-                                    accountsWithResources.mapNotNull { accountsWithResources ->
-                                        accountsWithResources.resources?.fungibleResources
-                                    }.flatten().find {
-                                        it.resourceAddress == resourceAddress
-                                    }
                                 }
                                 fungibleResource = fungibleToken?.copy(
                                     amount = amount.toBigDecimal()


### PR DESCRIPTION
…oken being transferred.

## Description
https://radixdlt.atlassian.net/browse/ABW-1812

### Screenshots (optional)
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/a3dd0215-1aa9-48a5-96ba-dfea1e29b947" width="300">

### Notes (optional)
Token data in recipient account holder is displayed correctly if recipient account does not contain such a token.
