### PR TITLE
[ABW-1851] Fix ignored tests

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/Resource.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/Resource.kt
@@ -8,6 +8,7 @@ import com.babylon.wallet.android.domain.model.metadata.SymbolMetadataItem
 import com.radixdlt.toolkit.RadixEngineToolkit
 import com.radixdlt.toolkit.models.method.KnownEntityAddressesInput
 import rdx.works.profile.data.model.apppreferences.Radix
+import rdx.works.profile.derivation.model.NetworkId
 import java.math.BigDecimal
 import java.util.UUID
 
@@ -43,9 +44,7 @@ sealed class Resource {
                 ""
             }
 
-        val isXrd: Boolean = RadixEngineToolkit.knownEntityAddresses(
-            KnownEntityAddressesInput(networkId = Radix.Gateway.default.network.id.toUByte())
-        ).getOrNull()?.xrdResourceAddress == resourceAddress
+        val isXrd: Boolean = officialXrdResourceAddress() == resourceAddress
 
         @Suppress("CyclomaticComplexMethod")
         override fun compareTo(other: FungibleResource): Int {
@@ -75,6 +74,14 @@ sealed class Resource {
             } else {
                 resourceAddress.compareTo(other.resourceAddress)
             }
+        }
+
+        companion object {
+            fun officialXrdResourceAddress(
+                onNetworkId: NetworkId = Radix.Gateway.default.network.networkId()
+            ) = RadixEngineToolkit.knownEntityAddresses(
+                KnownEntityAddressesInput(networkId = onNetworkId.value.toUByte())
+            ).getOrNull()?.xrdResourceAddress
         }
     }
 

--- a/app/src/test/java/com/babylon/wallet/android/data/transaction/TransactionClientTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/data/transaction/TransactionClientTest.kt
@@ -1,11 +1,14 @@
 package com.babylon.wallet.android.data.transaction
 
+import com.babylon.wallet.android.data.gateway.model.ExplicitMetadataKey
 import com.babylon.wallet.android.data.manifest.addLockFeeInstructionToManifest
+import com.babylon.wallet.android.data.repository.entity.EntityRepository
 import com.babylon.wallet.android.data.repository.transaction.TransactionRepository
 import com.babylon.wallet.android.domain.common.Result
 import com.babylon.wallet.android.domain.model.AccountWithResources
 import com.babylon.wallet.android.domain.model.Resource
 import com.babylon.wallet.android.domain.model.Resources
+import com.babylon.wallet.android.domain.model.metadata.OwnerKeyHashesMetadataItem
 import com.babylon.wallet.android.domain.model.metadata.SymbolMetadataItem
 import com.babylon.wallet.android.domain.usecases.GetAccountsWithResourcesUseCase
 import com.babylon.wallet.android.domain.usecases.transaction.CollectSignersSignaturesUseCase
@@ -17,18 +20,21 @@ import com.radixdlt.toolkit.builders.ManifestBuilder
 import com.radixdlt.toolkit.models.Instruction
 import com.radixdlt.toolkit.models.ManifestAstValue
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import rdx.works.profile.data.model.Profile
+import rdx.works.profile.data.model.ProfileState
 import rdx.works.profile.data.model.apppreferences.Radix
+import rdx.works.profile.data.model.pernetwork.Network
+import rdx.works.profile.data.repository.ProfileRepository
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.gateway.GetCurrentGatewayUseCase
 import java.math.BigDecimal
@@ -40,31 +46,15 @@ internal class TransactionClientTest {
 
     private val transactionRepository = mockk<TransactionRepository>()
     private val getCurrentGatewayUseCase = mockk<GetCurrentGatewayUseCase>()
-    private val getProfileUseCase = mockk<GetProfileUseCase>()
-    private val getAccountsWithResourcesUseCase = mockk<GetAccountsWithResourcesUseCase>()
+    private val getProfileUseCase = GetProfileUseCase(ProfileRepositoryFake)
+    private val getAccountsWithResourcesUseCase = GetAccountsWithResourcesUseCase(
+        EntityRepositoryFake,
+        getProfileUseCase
+    )
     private val collectSignersSignaturesUseCase = mockk<CollectSignersSignaturesUseCase>()
     private val submitTransactionUseCase = mockk<SubmitTransactionUseCase>()
-    private val networkId = 242
 
     private lateinit var transactionClient: TransactionClient
-
-    private val addressWithFunds = "account_sim1cyvgx33089ukm2pl97pv4max0x40ruvfy4lt60yvya744cve475w0q"
-    private val accountWithFunds = AccountWithResources(
-        account = account(address = addressWithFunds),
-        resources = Resources(
-            fungibleResources = listOf(Resource.FungibleResource(
-                resourceAddress = "resource_rdx_abc",
-                amount = BigDecimal.TEN,
-                symbolMetadataItem = SymbolMetadataItem("XRD")
-            )),
-            nonFungibleResources = emptyList()
-        )
-    )
-    private val addressWithNoFunds = "account_sim1cyzfj6p254jy6lhr237s7pcp8qqz6c8ahq9mn6nkdjxxxat5syrgz9"
-    private val accountWithNoFunds = AccountWithResources(
-        account = account(address = addressWithNoFunds),
-        resources = Resources.EMPTY
-    )
 
     @Before
     fun setUp() {
@@ -77,96 +67,58 @@ internal class TransactionClientTest {
             getAccountsWithResourcesUseCase,
             submitTransactionUseCase
         )
-        coEvery { getCurrentGatewayUseCase() } returns Radix.Gateway.hammunet
-        coEvery { getAccountsWithResourcesUseCase(accounts = listOf(), isRefreshing = true) } returns Result.Success(emptyList())
+        coEvery { getCurrentGatewayUseCase() } returns Radix.Gateway.default
     }
 
-    @Ignore("until we have the validated addresses from iOS")
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when address exists, finds address involved & signing for set metadata manifest`() =
         runTest {
             var manifest = ManifestBuilder().addInstruction(
                 Instruction.SetMetadata(
-                    entityAddress = ManifestAstValue.Address(addressWithFunds),
+                    entityAddress = ManifestAstValue.Address(EntityRepositoryFake.addressWithFunds),
                     ManifestAstValue.String("name"),
                     ManifestAstValue.Enum("RadixDashboard")
                 )
             ).build()
 
-            every { getProfileUseCase() } returns flowOf(
-                profile(
-                    accounts = listOf(
-                        accountWithFunds.account,
-                        accountWithNoFunds.account
-                    )
-                )
-            )
-            coEvery {
-                getAccountsWithResourcesUseCase(accounts = listOf(accountWithFunds.account), isRefreshing = true)
-            } returns Result.Success(
-                data = listOf(accountWithFunds)
-            )
-
             val addressToLockFee = transactionClient.findFeePayerInManifest(manifest).getOrThrow().feePayerAddressFromManifest
             manifest = manifest.addLockFeeInstructionToManifest(addressToLockFee!!)
-            val signingEntities = transactionClient.getSigningEntities(networkId, manifest)
+            val signingEntities = transactionClient.getSigningEntities(Radix.Gateway.default.network.id, manifest)
 
             Assert.assertEquals(1, signingEntities.size)
             Assert.assertEquals(
-                addressWithFunds,
+                EntityRepositoryFake.addressWithFunds,
                 signingEntities.first().address
             )
         }
 
-    @Ignore("until we have the validated addresses from iOS")
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when given address has no funds but there is another address with funds, use the other address for the transaction`() =
         runTest {
             val manifest = ManifestBuilder().addInstruction(
                 Instruction.SetMetadata(
-                    entityAddress = ManifestAstValue.Address(addressWithNoFunds),
+                    entityAddress = ManifestAstValue.Address(EntityRepositoryFake.addressWithNoFunds),
                     ManifestAstValue.String("name"),
                     ManifestAstValue.Enum("RadixDashboard")
                 )
             ).build()
-
-            every { getProfileUseCase() } returns flowOf(profile(accounts = listOf(accountWithNoFunds.account, accountWithFunds.account)))
-            coEvery {
-                getAccountsWithResourcesUseCase(accounts = listOf(accountWithNoFunds.account), isRefreshing = true)
-            } returns Result.Success(
-                data = listOf(accountWithNoFunds)
-            )
-
-            coEvery {
-                getAccountsWithResourcesUseCase(accounts = listOf(accountWithFunds.account), isRefreshing = true)
-            } returns Result.Success(
-                data = listOf(accountWithFunds)
-            )
 
             val addressToLockFee = transactionClient.findFeePayerInManifest(manifest).getOrThrow()
             assert(addressToLockFee.feePayerAddressFromManifest == null)
             assert(addressToLockFee.candidates.size == 1)
         }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `when address has no funds, return the respective error`() = runTest {
         val manifest = ManifestBuilder().addInstruction(
             Instruction.SetMetadata(
-                entityAddress = ManifestAstValue.Address(addressWithNoFunds),
+                entityAddress = ManifestAstValue.Address(EntityRepositoryFake.addressWithNoFunds),
                 ManifestAstValue.String("name"),
                 ManifestAstValue.Enum("RadixDashboard")
             )
         ).build()
-
-        every { getProfileUseCase() } returns flowOf(profile(accounts = listOf(accountWithNoFunds.account)))
-        coEvery {
-            getAccountsWithResourcesUseCase(accounts = listOf(accountWithNoFunds.account), isRefreshing = true)
-        } returns Result.Success(
-            data = listOf(accountWithNoFunds)
-        )
 
         try {
             transactionClient.findFeePayerInManifest(manifest)
@@ -177,6 +129,89 @@ internal class TransactionClientTest {
                 ),
                 exception
             )
+        }
+
+    }
+
+    private object EntityRepositoryFake : EntityRepository {
+
+        const val addressWithFunds = "account_tdx_21_12ya9jylskaa6gdrfr8nvve3pfc6wyhyw7eg83fwlc7fv2w0eanumcd"
+        const val addressWithNoFunds = "account_tdx_21_12xg7tf7aup8lrxkvug0vzatntzww0c6jnntyj6yd4eg5920kpxpzvt"
+
+        val account1 = account(address = addressWithFunds)
+        val accountResourcesWithFunds = AccountWithResources(
+            account = account1,
+            resources = Resources(
+                fungibleResources = listOf(
+                    Resource.FungibleResource(
+                        resourceAddress = Resource.FungibleResource.officialXrdResourceAddress()!!,
+                        amount = BigDecimal.TEN,
+                        symbolMetadataItem = SymbolMetadataItem("XRD")
+                    )
+                ),
+                nonFungibleResources = emptyList()
+            )
+        )
+
+        val account2 = account(address = addressWithNoFunds)
+        val accountResourcesWithNoFunds = AccountWithResources(
+            account = account2,
+            resources = Resources.EMPTY
+        )
+
+
+        override suspend fun getAccountsWithResources(
+            accounts: List<Network.Account>,
+            explicitMetadataForAssets: Set<ExplicitMetadataKey>,
+            isRefreshing: Boolean
+        ): Result<List<AccountWithResources>> = Result.Success(accounts.map {
+            when (it.address) {
+                addressWithFunds -> accountResourcesWithFunds
+                addressWithNoFunds -> accountResourcesWithNoFunds
+                else -> error("Not faked account with address ${it.address}")
+            }
+        })
+
+        override suspend fun getEntityOwnerKeyHashes(entityAddress: String, isRefreshing: Boolean): Result<OwnerKeyHashesMetadataItem?> {
+            error("Not needed")
+        }
+
+    }
+
+    private object ProfileRepositoryFake: ProfileRepository {
+        private val profile = profile(accounts = listOf(EntityRepositoryFake.account1, EntityRepositoryFake.account2))
+
+        override val profileState: Flow<ProfileState> = flowOf(ProfileState.Restored(profile = profile))
+
+        override val inMemoryProfileOrNull: Profile?
+            get() = profile
+
+        override suspend fun saveProfile(profile: Profile) {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun clear() {
+            TODO("Not yet implemented")
+        }
+
+        override suspend fun saveRestoringSnapshot(snapshotSerialised: String): Boolean {
+            error("Not needed")
+        }
+
+        override suspend fun getSnapshotForBackup(): String? {
+            error("Not needed")
+        }
+
+        override suspend fun isRestoredProfileFromBackupExists(): Boolean {
+            error("Not needed")
+        }
+
+        override suspend fun getRestoredProfileFromBackup(): Profile? {
+            error("Not needed")
+        }
+
+        override suspend fun discardBackedUpProfile() {
+            error("Not needed")
         }
 
     }

--- a/app/src/test/java/com/babylon/wallet/android/mockdata/Accounts.kt
+++ b/app/src/test/java/com/babylon/wallet/android/mockdata/Accounts.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.mockdata
 
+import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.pernetwork.DerivationPath
 import rdx.works.profile.data.model.pernetwork.FactorInstance
@@ -10,12 +11,13 @@ import rdx.works.profile.derivation.model.NetworkId
 
 fun account(
     name: String = "account-name",
-    address: String = "address-$name"
+    address: String = "address-$name",
+    networkId: NetworkId = Radix.Gateway.default.network.networkId()
 ) = Network.Account(
     address = address,
     appearanceID = 1,
     displayName = name,
-    networkID = 10,
+    networkID = networkId.value,
     securityState = SecurityState.Unsecured(
         unsecuredEntityControl = SecurityState.UnsecuredEntityControl(
             transactionSigning = FactorInstance(

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transfer/TransferViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transfer/TransferViewModelTest.kt
@@ -101,14 +101,13 @@ class TransferViewModelTest : StateViewModelTest<TransferViewModel>() {
         }
     }
 
-    @Ignore("until we have the validated addresses from iOS")
     @Test
     fun `choosing an third party address from the accounts chooser`() = runTest {
         val viewModel = vm.value
         viewModel.state.test {
             assertFromAccountSet()
             assertOpenSheetForSkeleton(viewModel, viewModel.state.value.targetAccounts[0] as TargetAccount.Skeleton)
-            assertOtherAccountSubmitted(viewModel, "account_tdx_c_1pyq480rav9n99eq9hmrjdz8u9km05zx7u2kluh79dnpsr962km")
+            assertOtherAccountSubmitted(viewModel, "account_tdx_21_12ya9jylskaa6gdrfr8nvve3pfc6wyhyw7eg83fwlc7fv2w0eanumcd")
         }
     }
 


### PR DESCRIPTION
### Notes
We used to ignore some tests due to lack of compatibility until birch was integrated. In general we need to create a method which will prefix the account's network (for example on enkinet, default for now, the accounts start with `account_tdx_21_`) and then suffix a random hex string.

* Besides that, I've changed the network of the `account()` test vector to be the default one since we have some tests that rely on the actual chosen network.
* The known XRD resource address on the network has now become a static function in `FungibleResource`. This is needed if we want to make some tests think that an account owns a resource which is actually XRD in order to pay for fees.
* Used the Fake approach and not mockk in order to test the TransactionClient. To be honest I prefer fakes from mocks and since we are on the road to use the clean architecture correctly, it was very easy to integrate. I would like to mention this in next week's chapter meeting, but in general If I went with mocks in this particular test, I would have to mock every single possible use case invocation (one with one account, one with two accounts, one with another account etc...)