### PR TITLE
ABW-1862 - Explicitly remove radix prefix from scanned content.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/connector/qrcode/CameraPreview.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/connector/qrcode/CameraPreview.kt
@@ -58,7 +58,7 @@ private fun BarcodePreviewView(
                 val barcodeAnalyser = QrcodeAnalyser { qrCodes ->
                     qrCodes.forEach { barcode ->
                         barcode.rawValue?.let { barcodeValue ->
-                            onQrCodeDetected(barcodeValue)
+                            onQrCodeDetected(barcodeValue.replace("radix:", ""))
                         }
                     }
                 }


### PR DESCRIPTION
## Description
https://radixdlt.atlassian.net/browse/ABW-1862

### Screenshots (optional)
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/19858c6d-ac90-4192-a544-27cd03675fbd" width="300">

### Notes (optional)
