### PR TITLE
ABW-1898 - Text centered on multiple screens. Add Ledger flow issue f…

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/createaccount/CreateAccountScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -155,18 +156,21 @@ fun CreateAccountContent(
                     stringResource(id = R.string.createAccount_titleNotFirst)
                 },
                 style = RadixTheme.typography.title,
-                color = RadixTheme.colors.gray1
+                color = RadixTheme.colors.gray1,
+                textAlign = TextAlign.Center
             )
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
             Text(
                 text = stringResource(id = R.string.createAccount_nameNewAccount_subtitle),
                 style = RadixTheme.typography.body1Regular,
-                color = RadixTheme.colors.gray1
+                color = RadixTheme.colors.gray1,
+                textAlign = TextAlign.Center
             )
             Text(
-                text = stringResource(id = R.string.createEntity_nameNewEntity_explanation),
+                text = stringResource(id = R.string.createAccount_nameNewAccount_explanation),
                 style = RadixTheme.typography.body1Regular,
-                color = RadixTheme.colors.gray2
+                color = RadixTheme.colors.gray2,
+                textAlign = TextAlign.Center
             )
             Spacer(modifier = Modifier.height(30.dp))
             RadixTextField(
@@ -199,6 +203,7 @@ fun CreateAccountContent(
                 },
                 modifier = Modifier
                     .fillMaxWidth()
+                    .padding(top = RadixTheme.dimensions.paddingLarge)
                     .imePadding(),
                 enabled = buttonEnabled,
                 throttleClicks = true

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/connector/SettingsConnectorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/connector/SettingsConnectorScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -180,7 +182,8 @@ private fun SettingsLinkConnectorContent(
                                     .padding(horizontal = RadixTheme.dimensions.paddingDefault),
                                 text = stringResource(id = R.string.linkedConnectors_linkNewConnector),
                                 style = RadixTheme.typography.title,
-                                color = RadixTheme.colors.gray1
+                                color = RadixTheme.colors.gray1,
+                                textAlign = TextAlign.Center
                             )
 
                             Text(
@@ -358,6 +361,7 @@ private fun ConnectorNameInput(
 ) {
     Column(
         modifier = modifier
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = RadixTheme.dimensions.paddingDefault)
     ) {
         Text(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/ledgerfactorsource/LedgerFactorSourcesViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/ledgerfactorsource/LedgerFactorSourcesViewModel.kt
@@ -59,6 +59,7 @@ class LedgerFactorSourcesViewModel @Inject constructor(
 
     fun onConfirmLedgerName(name: String) {
         createLedgerDelegate.onConfirmLedgerName(name)
+        _state.update { it.copy(mode = LedgerFactorSourcesMode.Details) }
     }
 
     fun onMessageShown() {


### PR DESCRIPTION
…ixed. Copy text provided as per Zeplin.

## Description
https://radixdlt.atlassian.net/browse/ABW-1898
https://radixdlt.atlassian.net/browse/ABW-1899
https://radixdlt.atlassian.net/browse/ABW-1901

### Screenshots (optional)
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/21fe5105-39c3-4e83-85ab-26207620835f" width="300">
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/856b0aaa-ddd7-49e7-9a95-e4866c0aa7ab" width="300">

### Notes (optional)
- Title and subtitles centred aligned on Link New Connector flow and Create New Accounts 
- Issue raised by @giannis-rdx fixed -> https://rdxworks.slack.com/archives/C04QL520D4L/p1689611306993699
- Correct copy strings provided from Crowdin
- Ignore comments about text being in multiple lines (this is expected when it doesn't fit as we do in various places)
