### PR TITLE
ABW-1963 - Copy text changed. Guarantees can go above 100%. Formattin…

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/Transferable.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/Transferable.kt
@@ -44,7 +44,7 @@ sealed interface Transferable {
     ) : Transferable
 
     fun updateGuarantee(
-        @FloatRange(from = 0.0, to = 1.0)
+        @FloatRange(from = 0.0)
         guaranteeOffset: Float
     ): Transferable {
         return when (this) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountWithGuaranteesCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountWithGuaranteesCard.kt
@@ -210,7 +210,9 @@ fun TransactionAccountWithGuaranteesCard(
             ) {
                 Text(
                     modifier = Modifier.weight(2f),
-                    text = stringResource(id = com.babylon.wallet.android.R.string.transactionReview_guarantees_setGuaranteedMinimum),
+                    text = stringResource(
+                        id = com.babylon.wallet.android.R.string.transactionReview_guarantees_setGuaranteedMinimum
+                    ).replace("%%", "%"),
                     style = RadixTheme.typography.body2Header,
                     color = RadixTheme.colors.gray1
                 )


### PR DESCRIPTION
…g fixed.

## Description
https://radixdlt.atlassian.net/browse/ABW-1963

### Screenshots (optional)
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/ff00fd5d-fe06-42ff-9d9f-f05ba7e72c81" width="300">

### Notes (optional)
- Guarantees can go above 100% 
- Formatting guarantees number scaled to 1 place after decimal point i.e. 99.8 and not 99.8000054243
- Duplicated %% fixed. Didn't want to create separate string in Crowdin and prefer to remove duplicated %% on our side as that's how iOS seems to escape % which we don't need actually.
