### PR TITLE
UTF-8 encode url before attaching it to image service URL

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FungibleTokenBottomSheetDetails.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FungibleTokenBottomSheetDetails.kt
@@ -76,7 +76,7 @@ fun FungibleTokenBottomSheetDetails(
                 rememberDrawablePainter(drawable = ColorDrawable(RadixTheme.colors.gray3.toArgb()))
             }
             AsyncImage(
-                model = rememberImageUrl(fromUrl = fungible.iconUrl.toString(), size = ImageSize.LARGE),
+                model = rememberImageUrl(fromUrl = fungible.iconUrl, size = ImageSize.LARGE),
                 placeholder = placeholder,
                 fallback = placeholder,
                 error = placeholder,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/NonFungibleTokenBottomSheetDetails.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/NonFungibleTokenBottomSheetDetails.kt
@@ -67,7 +67,7 @@ fun NonFungibleTokenBottomSheetDetails(
         ) {
             val painter = rememberAsyncImagePainter(
                 model = rememberImageUrl(
-                    fromUrl = item.imageUrl.toString(),
+                    fromUrl = item.imageUrl,
                     size = ImageSize.LARGE
                 ),
                 placeholder = painterResource(id = R.drawable.img_placeholder),
@@ -133,7 +133,7 @@ fun NonFungibleTokenBottomSheetDetails(
                         rememberDrawablePainter(drawable = ColorDrawable(RadixTheme.colors.gray3.toArgb()))
                     AsyncImage(
                         model = rememberImageUrl(
-                            fromUrl = nonFungibleItem.iconUrl.toString(),
+                            fromUrl = nonFungibleItem.iconUrl,
                             size = ImageSize.LARGE
                         ),
                         placeholder = placeholder,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/permission/LoginPermissionScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/permission/LoginPermissionScreen.kt
@@ -125,7 +125,7 @@ private fun LoginPermissionContent(
         ) {
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
             AsyncImage(
-                model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl?.toString(), size = ImageSize.MEDIUM),
+                model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl, size = ImageSize.MEDIUM),
                 placeholder = painterResource(id = R.drawable.img_placeholder),
                 fallback = painterResource(id = R.drawable.img_placeholder),
                 error = painterResource(id = R.drawable.img_placeholder),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
@@ -179,7 +179,7 @@ private fun PersonaDataOnetimeContent(
             item {
                 Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                 AsyncImage(
-                    model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl?.toString(), size = ImageSize.MEDIUM),
+                    model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl, size = ImageSize.MEDIUM),
                     placeholder = painterResource(id = R.drawable.img_placeholder),
                     fallback = painterResource(id = R.drawable.img_placeholder),
                     error = painterResource(id = R.drawable.img_placeholder),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
@@ -169,7 +169,7 @@ private fun PersonaDataOngoingPermissionContent(
         ) {
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
             AsyncImage(
-                model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl?.toString(), size = ImageSize.MEDIUM),
+                model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl, size = ImageSize.MEDIUM),
                 placeholder = painterResource(id = R.drawable.img_placeholder),
                 fallback = painterResource(id = R.drawable.img_placeholder),
                 error = painterResource(id = R.drawable.img_placeholder),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
@@ -185,7 +185,7 @@ private fun SelectPersonaContent(
                         item {
                             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                             AsyncImage(
-                                model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl?.toString(), size = ImageSize.MEDIUM),
+                                model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl, size = ImageSize.MEDIUM),
                                 placeholder = painterResource(id = R.drawable.img_placeholder),
                                 fallback = painterResource(id = R.drawable.img_placeholder),
                                 error = painterResource(id = R.drawable.img_placeholder),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/personaonetime/PersonaDataOnetimeScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/personaonetime/PersonaDataOnetimeScreen.kt
@@ -174,7 +174,7 @@ private fun PersonaDataOnetimeContent(
             item {
                 Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                 AsyncImage(
-                    model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl?.toString(), size = ImageSize.MEDIUM),
+                    model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl, size = ImageSize.MEDIUM),
                     placeholder = painterResource(id = R.drawable.img_placeholder),
                     fallback = painterResource(id = R.drawable.img_placeholder),
                     error = painterResource(id = R.drawable.img_placeholder),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ConnectedDAppsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ConnectedDAppsContent.kt
@@ -131,7 +131,7 @@ fun ConnectedDAppsContent(
                     val placeholder = painterResource(id = R.drawable.ic_unknown_component)
                     AsyncImage(
                         model = rememberImageUrl(
-                            fromUrl = connectedDApp.dAppWithMetadata.iconUrl.toString(),
+                            fromUrl = connectedDApp.dAppWithMetadata.iconUrl,
                             size = ImageSize.SMALL
                         ),
                         placeholder = placeholder,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PresentingProofsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PresentingProofsContent.kt
@@ -79,7 +79,7 @@ fun PresentingProofsContent(
                         val placeholder =
                             rememberDrawablePainter(drawable = ColorDrawable(RadixTheme.colors.gray3.toArgb()))
                         AsyncImage(
-                            model = rememberImageUrl(fromUrl = badge.icon.toString(), size = ImageSize.SMALL),
+                            model = rememberImageUrl(fromUrl = badge.icon, size = ImageSize.SMALL),
                             placeholder = placeholder,
                             fallback = placeholder,
                             error = placeholder,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountCard.kt
@@ -1,6 +1,7 @@
 package com.babylon.wallet.android.presentation.transaction.composables
 
 import android.graphics.drawable.ColorDrawable
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -108,7 +109,7 @@ fun TransactionAccountCard(
 
             TokenItemContent(
                 isXrdToken = transferableAmount.resource.isXrd,
-                tokenUrl = transferableAmount.resource.iconUrl.toString(),
+                tokenUrl = transferableAmount.resource.iconUrl,
                 tokenSymbol = transferableAmount.resource.displayTitle.ifEmpty {
                     stringResource(id = com.babylon.wallet.android.R.string.transactionReview_unknown)
                 },
@@ -127,7 +128,7 @@ fun TransactionAccountCard(
                 val lastItem = itemIndex == collection.resource.items.lastIndex && collectionIndex == nftTransferables.lastIndex
                 TokenItemContent(
                     isXrdToken = false,
-                    tokenUrl = collection.resource.iconUrl.toString(),
+                    tokenUrl = collection.resource.iconUrl,
                     tokenSymbol = item.localId.displayable,
                     isTokenAmountVisible = false,
                     shape = if (lastItem) RadixTheme.shapes.roundedRectBottomMedium else RectangleShape
@@ -140,7 +141,7 @@ fun TransactionAccountCard(
 @Composable
 private fun TokenItemContent(
     isXrdToken: Boolean,
-    tokenUrl: String,
+    tokenUrl: Uri?,
     tokenSymbol: String?,
     tokenAmount: String? = null,
     isTokenAmountVisible: Boolean,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountWithGuaranteesCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountWithGuaranteesCard.kt
@@ -130,7 +130,7 @@ fun TransactionAccountWithGuaranteesCard(
                         .background(RadixTheme.colors.gray3, shape = RadixTheme.shapes.circle)
                 ) {
                     AsyncImage(
-                        model = rememberImageUrl(fromUrl = transferrable.resource.iconUrl.toString(), size = ImageSize.LARGE),
+                        model = rememberImageUrl(fromUrl = transferrable.resource.iconUrl, size = ImageSize.LARGE),
                         placeholder = placeholder,
                         fallback = placeholder,
                         error = placeholder,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/SpendingAssetItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/SpendingAssetItem.kt
@@ -138,7 +138,7 @@ private fun ColumnScope.FungibleSpendingAsset(
             model = if (resource.isXrd) {
                 R.drawable.ic_xrd_token
             } else {
-                rememberImageUrl(fromUrl = resource.iconUrl.toString(), size = ImageSize.MEDIUM)
+                rememberImageUrl(fromUrl = resource.iconUrl, size = ImageSize.MEDIUM)
             },
             placeholder = placeholder,
             fallback = placeholder,
@@ -275,7 +275,7 @@ private fun NonFungibleSpendingAsset(
         if (nft.imageUrl != null) {
             AsyncImage(
                 model = rememberImageUrl(
-                    fromUrl = nft.imageUrl.toString(),
+                    fromUrl = nft.imageUrl,
                     size = ImageSize.SMALL,
                     placeholder = com.babylon.wallet.android.R.drawable.img_placeholder,
                     error = com.babylon.wallet.android.R.drawable.img_placeholder

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ChooseAccountContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ChooseAccountContent.kt
@@ -80,7 +80,7 @@ fun ChooseAccountContent(
                 item {
                     Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                     AsyncImage(
-                        model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl?.toString(), size = ImageSize.MEDIUM),
+                        model = rememberImageUrl(fromUrl = dappWithMetadata?.iconUrl, size = ImageSize.MEDIUM),
                         placeholder = painterResource(id = R.drawable.img_placeholder),
                         fallback = painterResource(id = R.drawable.img_placeholder),
                         error = painterResource(id = R.drawable.img_placeholder),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Extensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Extensions.kt
@@ -1,6 +1,7 @@
 package com.babylon.wallet.android.presentation.ui.composables
 
 import android.content.Context
+import android.net.Uri
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.runtime.Composable
@@ -16,6 +17,7 @@ import coil.request.ImageRequest
 import com.babylon.wallet.android.BuildConfig
 import com.babylon.wallet.android.domain.model.Resource
 import com.babylon.wallet.android.domain.model.behaviours.ResourceBehaviour
+import rdx.works.core.toEncodedString
 
 private const val IMAGE_RATIO = 16 / 9f
 
@@ -42,7 +44,7 @@ fun Modifier.applyImageAspectRatio(
 
 // For some reason Coil library requires this header to be added when using with cloudflare service. Otherwise it fails
 private fun Context.buildImageRequest(
-    imageUrl: String?,
+    imageUrl: Uri?,
     @DrawableRes placeholder: Int?,
     @DrawableRes error: Int?
 ): ImageRequest {
@@ -65,15 +67,20 @@ private fun Context.buildImageRequest(
 
 @Composable
 fun rememberImageUrl(
-    fromUrl: String?,
+    fromUrl: Uri?,
     size: ImageSize = ImageSize.SMALL,
     @DrawableRes placeholder: Int? = null,
     @DrawableRes error: Int? = null
 ): ImageRequest {
     val context = LocalContext.current
-    val url = "${BuildConfig.IMAGE_HOST_BASE_URL}/?imageOrigin=$fromUrl&imageSize=${size.toSizeString()}"
-    return remember(url, placeholder, error) {
-        context.buildImageRequest(url, placeholder, error)
+    return remember(fromUrl, size, placeholder, error) {
+        val requestUrl = fromUrl?.let {
+            Uri.parse(
+                "${BuildConfig.IMAGE_HOST_BASE_URL}/?imageOrigin=${it.toEncodedString()}&imageSize=${size.toSizeString()}"
+            )
+        }
+
+        context.buildImageRequest(requestUrl, placeholder, error)
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/FungibleResourceItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/FungibleResourceItem.kt
@@ -49,7 +49,7 @@ fun FungibleResourceItem(
             model = if (resource.isXrd) {
                 R.drawable.ic_xrd_token
             } else {
-                rememberImageUrl(fromUrl = resource.iconUrl.toString(), size = ImageSize.MEDIUM)
+                rememberImageUrl(fromUrl = resource.iconUrl, size = ImageSize.MEDIUM)
             },
             placeholder = placeholder,
             fallback = placeholder,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/NonFungibleResourceCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/NonFungibleResourceCard.kt
@@ -106,7 +106,7 @@ fun NonFungibleResourceCollectionHeader(
             ) {
                 Image(
                     painter = rememberAsyncImagePainter(
-                        model = rememberImageUrl(fromUrl = collection.iconUrl?.toString().orEmpty(), size = ImageSize.SMALL),
+                        model = rememberImageUrl(fromUrl = collection.iconUrl, size = ImageSize.SMALL),
                         placeholder = painterResource(id = R.drawable.img_placeholder),
                         error = painterResource(id = R.drawable.img_placeholder)
                     ),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/NonFungibleResourceItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/NonFungibleResourceItem.kt
@@ -41,7 +41,7 @@ fun NonFungibleResourceItem(
         if (imageUrl != null) {
             val painter = rememberAsyncImagePainter(
                 model = rememberImageUrl(
-                    fromUrl = imageUrl.toString(),
+                    fromUrl = imageUrl,
                     size = ImageSize.LARGE
                 ),
                 placeholder = placeholder,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountAssetsRow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountAssetsRow.kt
@@ -142,7 +142,7 @@ private fun AssetsContent(
             } else {
                 AsyncImage(
                     modifier = iconModifier,
-                    model = rememberImageUrl(fromUrl = fungible.iconUrl.toString(), size = ImageSize.SMALL),
+                    model = rememberImageUrl(fromUrl = fungible.iconUrl, size = ImageSize.SMALL),
                     placeholder = painterResource(id = R.drawable.ic_token),
                     error = painterResource(id = R.drawable.ic_token),
                     contentDescription = null,

--- a/core/src/main/java/rdx/works/core/UriExtensions.kt
+++ b/core/src/main/java/rdx/works/core/UriExtensions.kt
@@ -1,0 +1,6 @@
+package rdx.works.core
+
+import android.net.Uri
+import java.net.URLEncoder
+
+fun Uri.toEncodedString(): String = URLEncoder.encode(toString(), "UTF-8")


### PR DESCRIPTION
### Notes
Create an NFT and attach this url as the resource's icon:
```
https://static.miraheze.org/greatcharacterswiki/c/c5/BenderBendingRodr%C3%ADguez.png
```

In order for the correct url to be sent to the image service the `%` chars need to be escaped before attaching them to the image service. This means that the url needs to be utf encoded and then attached to the image service url
