### PR TITLE
ci: remove lint job

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -177,6 +177,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs:
+      - unit_tests
       - static_analysis
       - snyk_scan_deps_licences
       - snyk_scan_code


### PR DESCRIPTION
On request from: https://rdxworks.slack.com/archives/C03Q8QK1GLW/p1690530794449439

- remove lint job
- move static analysis to the beginning of the pipeline

