### PR TITLE
ABW-2001 - Network security config added with debuggable builds accep…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:allowBackup="true"
         android:backupAgent=".WalletBackupAgent"
         android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.BabylonWallet">

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+            <certificates src="system" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
…ting self signed certs.

## Description
https://radixdlt.atlassian.net/browse/ABW-2001

### Screenshots (optional)
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/8e88eff0-8eaf-4b2e-a8a5-4da5656f9888" width="300">
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/8a799965-f121-4f57-8c91-cf87ea91b4fd" width="300">

### Notes (optional)
What we want to achieve is allowing debug and only debug build to be intercept able by third party apps such as Proxyman Charles or any man in the middle.
So I have added config purely to allow self signed system & user certs only for debug builds.

*** The important things to test here *** 
- Verify that debug build perform HTTP requests fine when no proxy set up.
- Verify that debug build perform HTTP requests fine when proxy is set up and all details can be looked up (see screenshots)

- Verify that **non** debug builds (releasePreview for example) **perform** HTTP requests fine when no proxy is set up.
- Verify that **non** debug builds (releasePreview for example) **fail** HTTP requests with handshake when proxy is set up and **no** details can be looked up (see screenshots)
