### PR TITLE
Link connector prompt in account creation flow after CE was unlinked

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/createaccount/withledger/CreateAccountWithLedgerScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/createaccount/withledger/CreateAccountWithLedgerScreen.kt
@@ -60,7 +60,7 @@ fun CreateAccountWithLedgerScreen(
         }
     }
 
-    when (state.showContent) {
+    when (val showContent = state.showContent) {
         CreateAccountWithLedgerUiState.ShowContent.ChooseLedger -> {
             ChooseLedgerDeviceContent(
                 modifier = modifier,
@@ -72,15 +72,17 @@ fun CreateAccountWithLedgerScreen(
             )
         }
 
-        CreateAccountWithLedgerUiState.ShowContent.LinkNewConnector -> {
+        is CreateAccountWithLedgerUiState.ShowContent.LinkNewConnector -> {
             LinkConnectorScreen(
                 modifier = Modifier.fillMaxSize(),
-                onLinkConnectorClick = viewModel::onLinkConnectorClick,
+                onLinkConnectorClick = {
+                    viewModel.onLinkConnectorClick(showContent.addDeviceAfterLinking)
+                },
                 onCloseClick = viewModel::onCloseClick
             )
         }
 
-        CreateAccountWithLedgerUiState.ShowContent.AddLinkConnector -> {
+        is CreateAccountWithLedgerUiState.ShowContent.AddLinkConnector -> {
             AddLinkConnectorScreen(
                 modifier = Modifier,
                 showContent = addLinkConnectorState.showContent,
@@ -92,7 +94,11 @@ fun CreateAccountWithLedgerScreen(
                 onNewConnectorContinueClick = {
                     coroutineScope.launch {
                         addLinkConnectorViewModel.onContinueClick()
-                        viewModel.onAddLedgerDeviceClick()
+                        if (showContent.addDeviceAfterLinking) {
+                            viewModel.onAddLedgerDeviceClick()
+                        } else {
+                            viewModel.onCloseClick()
+                        }
                     }
                 },
                 onNewConnectorCloseClick = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/createaccount/withledger/CreateAccountWithLedgerViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/createaccount/withledger/CreateAccountWithLedgerViewModel.kt
@@ -87,7 +87,7 @@ class CreateAccountWithLedgerViewModel @Inject constructor(
                 // check again if link connector exists
                 if (getProfileUseCase.p2pLinks.first().isEmpty()) {
                     _state.update {
-                        it.copy(showContent = CreateAccountWithLedgerUiState.ShowContent.LinkNewConnector)
+                        it.copy(showContent = CreateAccountWithLedgerUiState.ShowContent.LinkNewConnector(false))
                     }
                     return@launch
                 }
@@ -123,7 +123,7 @@ class CreateAccountWithLedgerViewModel @Inject constructor(
         viewModelScope.launch {
             _state.update {
                 if (getProfileUseCase.p2pLinks.first().isEmpty()) {
-                    it.copy(showContent = CreateAccountWithLedgerUiState.ShowContent.LinkNewConnector)
+                    it.copy(showContent = CreateAccountWithLedgerUiState.ShowContent.LinkNewConnector())
                 } else {
                     it.copy(showContent = CreateAccountWithLedgerUiState.ShowContent.AddLedger)
                 }
@@ -137,9 +137,9 @@ class CreateAccountWithLedgerViewModel @Inject constructor(
         }
     }
 
-    fun onLinkConnectorClick() {
+    fun onLinkConnectorClick(addDeviceAfterLinking: Boolean) {
         _state.update {
-            it.copy(showContent = CreateAccountWithLedgerUiState.ShowContent.AddLinkConnector)
+            it.copy(showContent = CreateAccountWithLedgerUiState.ShowContent.AddLinkConnector(addDeviceAfterLinking))
         }
     }
 }
@@ -151,8 +151,11 @@ data class CreateAccountWithLedgerUiState(
     val selectedLedgerDeviceId: FactorSource.FactorSourceID.FromHash? = null
 ) : UiState {
 
-    enum class ShowContent {
-        ChooseLedger, AddLedger, LinkNewConnector, AddLinkConnector
+    sealed interface ShowContent {
+        object ChooseLedger : ShowContent
+        object AddLedger : ShowContent
+        data class LinkNewConnector(val addDeviceAfterLinking: Boolean = true) : ShowContent
+        data class AddLinkConnector(val addDeviceAfterLinking: Boolean = true) : ShowContent
     }
 }
 


### PR DESCRIPTION
## Description
Giannis in his refactor work added prompt for linking connector already. Only change I did is that if we try to select ledger and connector is missing, after linking it again we are on "Select ledger" page instead of asking again for linking ledger device