### PR TITLE
Fix displayed error

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/entity/EntityRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/entity/EntityRepository.kt
@@ -90,9 +90,10 @@ class EntityRepositoryImpl @Inject constructor(
             explicitMetadata = explicitMetadataForAssets,
             isRefreshing = isRefreshing
         )
-        val stateVersion = listOfEntityDetailsResponsesResult.value()?.firstOrNull()?.ledgerState?.stateVersion
-            ?: return Result.Error()
+
         return listOfEntityDetailsResponsesResult.switchMap { accountDetailsResponses ->
+            val stateVersion = accountDetailsResponses.firstOrNull()?.ledgerState?.stateVersion ?: return Result.Error()
+
             val resourceAddresses = accountDetailsResponses.map { stateEntityDetailsResponse ->
                 stateEntityDetailsResponse.items.map { stateEntityDetailsResponseItem ->
                     stateEntityDetailsResponseItem.allResourceAddresses

--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/UiMessage.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/UiMessage.kt
@@ -75,7 +75,7 @@ sealed class UiMessage(val id: String = UUIDGenerator.uuid().toString()) {
 
         override fun getMessage(context: Context): String = userFriendlyDescription?.let {
             context.getString(it)
-        } ?: nonUserFriendlyDescription.orEmpty()
+        } ?: nonUserFriendlyDescription ?: context.getString(R.string.common_somethingWentWrong)
 
         companion object {
             fun from(error: Throwable?) = ErrorMessage(


### PR DESCRIPTION
### Notes (optional)
* When the resulting message of an exception is empty we use the `common_somethingWentWrong` error message.
* Try getting the ledger state only when the response is successful.