### PR TITLE
Remove Radix Official tag from asset chooser in Transfer Screen

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/FungibleResourceItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/FungibleResourceItem.kt
@@ -24,7 +24,6 @@ import coil.compose.AsyncImage
 import com.babylon.wallet.android.designsystem.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.Resource
-import com.babylon.wallet.android.presentation.account.composable.Tag
 import com.babylon.wallet.android.presentation.ui.composables.ImageSize
 import com.babylon.wallet.android.presentation.ui.composables.rememberImageUrl
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
@@ -114,20 +113,20 @@ fun SelectableFungibleResourceItem(
             )
 
             Spacer(modifier = Modifier.width(RadixTheme.dimensions.paddingSmall))
-        },
-        bottomContent = {
-            resource.tags.find { it == Resource.Tag.Official }?.let { officialTag ->
-                Tag(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(RadixTheme.colors.gray5, shape = RadixTheme.shapes.roundedRectBottomMedium)
-                        .padding(
-                            horizontal = RadixTheme.dimensions.paddingMedium,
-                            vertical = RadixTheme.dimensions.paddingSmall
-                        ),
-                    tag = officialTag
-                )
-            }
         }
+//        bottomContent = {
+//            resource.tags.find { it == Resource.Tag.Official }?.let { _ ->
+//                Tag(
+//                    modifier = Modifier
+//                        .fillMaxWidth()
+//                        .background(RadixTheme.colors.gray5, shape = RadixTheme.shapes.roundedRectBottomMedium)
+//                        .padding(
+//                            horizontal = RadixTheme.dimensions.paddingMedium,
+//                            vertical = RadixTheme.dimensions.paddingSmall
+//                        ),
+//                    tag = officialTag
+//                )
+//            }
+//        }
     )
 }


### PR DESCRIPTION
- we discussed this at one demo session with Matt, that we don't want this Tag to show until we have sorting by tags implemented 