### PR TITLE
[ABW-2295] Encode default empty list values

### DIFF
--- a/profile/src/main/java/rdx/works/profile/data/model/pernetwork/PersonaData.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/pernetwork/PersonaData.kt
@@ -3,6 +3,7 @@
 package rdx.works.profile.data.model.pernetwork
 
 import kotlinx.serialization.Contextual
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -28,18 +29,23 @@ data class PersonaData(
     val companyName: IdentifiedEntry<PersonaDataField.CompanyName>? = null,
 
     @SerialName("emailAddresses")
+    @EncodeDefault
     val emailAddresses: List<IdentifiedEntry<PersonaDataField.Email>> = emptyList(),
 
     @SerialName("phoneNumbers")
+    @EncodeDefault
     val phoneNumbers: List<IdentifiedEntry<PersonaDataField.PhoneNumber>> = emptyList(),
 
     @SerialName("urls")
+    @EncodeDefault
     val urls: List<IdentifiedEntry<PersonaDataField.Url>> = emptyList(),
 
     @SerialName("postalAddresses")
+    @EncodeDefault
     val postalAddresses: List<IdentifiedEntry<PersonaDataField.PostalAddress>> = emptyList(),
 
     @SerialName("creditCards")
+    @EncodeDefault
     val creditCards: List<IdentifiedEntry<PersonaDataField.CreditCard>> = emptyList()
 
 ) {


### PR DESCRIPTION
## Description
[[Android] Persona data default values are not serialised](https://radixdlt.atlassian.net/browse/ABW-2295)

### Notes 
In general default values in profile **MUST** be serialised. Otherwise iOS cannot read them.
Simply applying a default value in the constructor does not mean that it will be serialised. We need to annotate it with 
```
@EncodeDefault
data class Inner(
   val value: List<Boolean> = emptyList()
) 

data class Outer(
   val inner: Inner
)

val outer = Outer(inner = Inner())
println(outer.serialise())

// This will produce
{ 
    inner: {}
}

// And not 
{ 
    inner: {
       value: []
    }
}
```