### PR TITLE
[ABW-2292] Fixes in Olympia import flow/seed phrase input/ledger connection

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/MockUiProvider.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/MockUiProvider.kt
@@ -75,7 +75,8 @@ object MockUiProvider {
             publicKey = "publicKey1",
             accountName = "account one",
             derivationPath = DerivationPath(path = "path", scheme = DerivationPathScheme.BIP_44_OLYMPIA),
-            newBabylonAddress = "babylon_account_address_1"
+            newBabylonAddress = "babylon_account_address_1",
+            appearanceId = 0
         ),
 
         OlympiaAccountDetails(
@@ -85,7 +86,8 @@ object MockUiProvider {
             publicKey = "publicKey2",
             accountName = "account two",
             derivationPath = DerivationPath(path = "path", scheme = DerivationPathScheme.BIP_44_OLYMPIA),
-            newBabylonAddress = "babylon_account_address_2"
+            newBabylonAddress = "babylon_account_address_2",
+            appearanceId = 1
         ),
         OlympiaAccountDetails(
             index = 2,
@@ -94,7 +96,8 @@ object MockUiProvider {
             publicKey = "publicKey3",
             accountName = "account three",
             derivationPath = DerivationPath(path = "path", scheme = DerivationPathScheme.BIP_44_OLYMPIA),
-            newBabylonAddress = "babylon_account_address_3"
+            newBabylonAddress = "babylon_account_address_3",
+            appearanceId = 3
         ),
     )
 

--- a/profile/src/main/java/rdx/works/profile/data/model/factorsources/DeviceFactorSource.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/factorsources/DeviceFactorSource.kt
@@ -28,6 +28,9 @@ data class DeviceFactorSource(
     val isBabylon: Boolean
         get() = common.cryptoParameters == Common.CryptoParameters.babylon
 
+    val isOlympia: Boolean
+        get() = common.cryptoParameters == Common.CryptoParameters.olympiaBackwardsCompatible
+
     companion object {
 
         fun babylon(

--- a/profile/src/main/java/rdx/works/profile/domain/account/GetFactorSourceIdForOlympiaAccountsUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/account/GetFactorSourceIdForOlympiaAccountsUseCase.kt
@@ -28,8 +28,8 @@ class GetFactorSourceIdForOlympiaAccountsUseCase @Inject constructor(
                     deviceFactorSource.id
                 }
                 .forEach { fromHashId ->
-                    val mnemonic = requireNotNull(mnemonicRepository.readMnemonic(fromHashId).getOrNull())
-                    if (mnemonic.validatePublicKeysOf(olympiaAccounts)) {
+                    val mnemonic = mnemonicRepository.readMnemonic(fromHashId).getOrNull()
+                    if (mnemonic?.validatePublicKeysOf(olympiaAccounts) == true) {
                         return@withContext fromHashId
                     }
                 }

--- a/profile/src/test/java/rdx/works/profile/OlympiaWalletImportDataFormatTest.kt
+++ b/profile/src/test/java/rdx/works/profile/OlympiaWalletImportDataFormatTest.kt
@@ -5,6 +5,7 @@ package rdx.works.profile
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import okio.ByteString.Companion.decodeBase64
@@ -12,10 +13,13 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import rdx.works.profile.data.model.MnemonicWithPassphrase
+import rdx.works.profile.data.model.Profile
 import rdx.works.profile.data.model.apppreferences.Radix
+import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.gateway.GetCurrentGatewayUseCase
 import rdx.works.profile.olympiaimport.OlympiaWalletDataParser
 import java.io.File
+import java.time.Instant
 
 internal class OlympiaWalletExportFormatTest {
 
@@ -24,12 +28,14 @@ internal class OlympiaWalletExportFormatTest {
     private lateinit var testVectors: List<TestVector>
 
     private val getCurrentGatewayUseCase = mockk<GetCurrentGatewayUseCase>()
+    private val getProfileUseCase = mockk<GetProfileUseCase>()
 
-    private val parser = OlympiaWalletDataParser(getCurrentGatewayUseCase)
+    private val parser = OlympiaWalletDataParser(getCurrentGatewayUseCase, getProfileUseCase)
 
     @Before
     fun setUp() {
-        coEvery { getCurrentGatewayUseCase() } returns Radix.Gateway("", Radix.Network.hammunet)
+        coEvery { getCurrentGatewayUseCase() } returns Radix.Gateway("", Radix.Gateway.default.network)
+        coEvery { getProfileUseCase() } returns flowOf(Profile.init("", "", Instant.now()))
         val testVectorsContent = File("src/test/resources/raw/import_olympia_wallet_parse_test.json").readText()
         testVectors = json.decodeFromString(testVectorsContent)
     }

--- a/profile/src/test/java/rdx/works/profile/domain/account/MigrateOlympiaAccountsUseCaseTest.kt
+++ b/profile/src/test/java/rdx/works/profile/domain/account/MigrateOlympiaAccountsUseCaseTest.kt
@@ -155,7 +155,8 @@ internal class MigrateOlympiaAccountsUseCaseTest {
                 publicKey = publicKey.toHexString(),
                 accountName = "Olympia $index",
                 derivationPath = derivationPath,
-                newBabylonAddress = "empty"
+                newBabylonAddress = "empty",
+                appearanceId = index
             )
         }
         return accounts


### PR DESCRIPTION
## Description
- fixed crash when importing accounts for which seed phrase exist
- fixed ledger linked connector screens not showing
- fixed seed phrase input padding
- fixed biometric prompts flow so that we only ask for it if we need it - either to check if olympia mnemonic exist, or if we add new factor source and want to import accounts with it. Current version asked for it even if we imported hardware accounts - which does not need biometrics.
## What to test: naming convention 
S - olympia software account
H - olympia hardare account
OW - Olympia wallet
RW - Radix Babylon Wallet

Sample Flows to test (each flow can be done with/without fresh wallet install, to mix things up): 
- export from OW S1 and H1 accounts, import into RW. Try that again  with same QR code.
Export from OW S2 and H2 accounts, import them into RW. 
- Import only S accounts from OW into RW. Next, import different S accounts into RW.
- Import only H accounts from OW into RW. Next, import different H accounts into RW.

