### PR TITLE
Make display name nullable

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
@@ -109,8 +109,8 @@ class AuthorizeSpecifiedPersonaUseCase @Inject constructor(
         authorizedPersonaSimple: Network.AuthorizedDapp.AuthorizedPersonaSimple,
         hasOngoingPersonaDataRequest: Boolean,
         persona: Network.Persona
-    ): Result<String> {
-        var operationResult: Result<String> = Result.failure(DappRequestFailure.InvalidRequest)
+    ): Result<String?> {
+        var operationResult: Result<String?> = Result.failure(DappRequestFailure.InvalidRequest)
         val selectedAccounts: List<Selectable<Network.Account>> = getAccountsWithGrantedAccess(
             request,
             authorizedDapp,
@@ -168,7 +168,7 @@ class AuthorizeSpecifiedPersonaUseCase @Inject constructor(
         selectedAccounts: List<Selectable<Network.Account>>,
         selectedPersonaData: PersonaData?,
         authorizedDapp: Network.AuthorizedDapp
-    ): Result<String> {
+    ): Result<String?> {
         return buildAuthorizedDappResponseUseCase(
             request = request,
             selectedPersona = persona,
@@ -250,5 +250,5 @@ class AuthorizeSpecifiedPersonaUseCase @Inject constructor(
 
 data class DAppData(
     val requestId: String,
-    val name: String
+    val name: String?
 )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -504,8 +504,7 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
         val dApp = authorizedDapp
         val date = LocalDateTime.now().toISO8601String()
         if (dApp == null) {
-            // TODO do we really need to save the dapp with "Unknown dApp"? Seems wrong!
-            val dAppName = state.value.dappWithMetadata?.name.orEmpty().ifEmpty { "Unknown dApp" }
+            val dAppName = state.value.dappWithMetadata?.name?.ifEmpty { null }
             mutex.withLock {
                 editedDapp = Network.AuthorizedDapp(
                     request.metadata.networkId,

--- a/profile/src/main/java/rdx/works/profile/data/model/pernetwork/Network.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/pernetwork/Network.kt
@@ -354,7 +354,7 @@ data class Network(
 
         @SerialName("dAppDefinitionAddress") val dAppDefinitionAddress: String,
 
-        @SerialName("displayName") val displayName: String,
+        @SerialName("displayName") val displayName: String? = null,
 
         @SerialName("referencesToAuthorizedPersonas") val referencesToAuthorizedPersonas: List<AuthorizedPersonaSimple>
     ) {


### PR DESCRIPTION
Related conversation https://rdxworks.slack.com/archives/C031A0V1A1W/p1695822271215249.

In general iOS saves `displayName` as nullable non-empty string. We don't have a non-empty string object unfortunately to reuse, but we should make the the property by nullable instead. Also if the name is empty we should still save it as null. Please take a careful look at this.