### PR TITLE
[ABW-2336] Add gateway url based on developer mode

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -200,6 +200,9 @@ dependencies {
     implementation libs.cameraLifecycle
     implementation libs.cameraView
 
+    // apache commons validator
+    implementation libs.apacheCommonsValidator
+
     // Peerdroid
     implementation project(path: ':peerdroid')
     implementation project(path: ':profile')

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
@@ -63,7 +63,7 @@ import rdx.works.profile.data.model.apppreferences.Radix
 
 @Composable
 fun GatewaysScreen(
-    viewModel: SettingsEditGatewayViewModel,
+    viewModel: GatewaysViewModel,
     onBackClick: () -> Unit,
     onCreateProfile: (String, String) -> Unit,
     modifier: Modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
@@ -72,7 +72,7 @@ fun GatewaysScreen(
     GatewaysContent(
         modifier = modifier,
         onBackClick = onBackClick,
-        onSwitchToClick = viewModel::onAddGateway,
+        onAddGatewayClick = viewModel::onAddGateway,
         newUrl = state.newUrl,
         onNewUrlChanged = viewModel::onNewUrlChanged,
         newUrlValid = state.newUrlValid,
@@ -90,7 +90,7 @@ fun GatewaysScreen(
 private fun GatewaysContent(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit,
-    onSwitchToClick: () -> Unit,
+    onAddGatewayClick: () -> Unit,
     newUrl: String,
     onNewUrlChanged: (String) -> Unit,
     newUrlValid: Boolean,
@@ -132,7 +132,7 @@ private fun GatewaysContent(
         enableImePadding = true,
         sheetContent = {
             AddGatewaySheet(
-                onAddGateway = onSwitchToClick,
+                onAddGatewayClick = onAddGatewayClick,
                 newUrl = newUrl,
                 onNewUrlChanged = onNewUrlChanged,
                 onClose = {
@@ -226,7 +226,7 @@ private fun GatewaysContent(
 
 @Composable
 private fun AddGatewaySheet(
-    onAddGateway: () -> Unit,
+    onAddGatewayClick: () -> Unit,
     newUrl: String,
     onNewUrlChanged: (String) -> Unit,
     onClose: () -> Unit,
@@ -285,7 +285,7 @@ private fun AddGatewaySheet(
         RadixPrimaryButton(
             text = stringResource(R.string.gateways_addNewGateway_addGatewayButtonTitle),
             onClick = {
-                onAddGateway()
+                onAddGatewayClick()
             },
             modifier = Modifier.fillMaxWidth(),
             enabled = newUrlValid,
@@ -384,13 +384,28 @@ fun GatewaysScreenPreview() {
     RadixWalletTheme {
         GatewaysContent(
             onBackClick = {},
-            onSwitchToClick = {},
+            onAddGatewayClick = {},
             newUrl = "",
             onNewUrlChanged = {},
             newUrlValid = false,
-            gatewayList = persistentListOf(),
+            gatewayList = persistentListOf(
+                GatewayWrapper(
+                    gateway = Radix.Gateway(
+                        url = "https://babylon-stokenet-gateway.radixdlt.com/",
+                        Radix.Network.stokenet
+                    ),
+                    selected = true
+                ),
+                GatewayWrapper(
+                    gateway = Radix.Gateway(
+                        url = "https://mainnet.radixdlt.com/",
+                        Radix.Network.mainnet
+                    ),
+                    selected = false
+                )
+            ),
             onDeleteGateway = {},
-            addingGateway = false,
+            addingGateway = true,
             gatewayAddFailure = null,
             onGatewayClick = {},
             oneOffEvent = flow { },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
@@ -133,7 +133,7 @@ class GatewaysViewModel @Inject constructor(
 
         // this is the case where a url has been added when the developer mode was enabled
         // but at the time the user clicks to switch network the developer mode is disabled
-        if (gateway.url.sanitizeAndValidateGatewayUrl(isDevModeEnabled = state.value.isDeveloperModeEnabled) == "/") return
+        if (gateway.url.sanitizeAndValidateGatewayUrl(isDevModeEnabled = state.value.isDeveloperModeEnabled) == null) return
 
         val isGatewayChanged = changeGatewayUseCase(gateway)
         if (isGatewayChanged) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
@@ -12,11 +12,13 @@ import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiState
 import com.babylon.wallet.android.utils.encodeUtf8
 import com.babylon.wallet.android.utils.isValidUrl
-import com.babylon.wallet.android.utils.sanitizeUrl
+import com.babylon.wallet.android.utils.sanitizeAndValidateGatewayUrl
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.profile.data.model.apppreferences.Radix
@@ -25,6 +27,7 @@ import rdx.works.profile.domain.gateway.AddGatewayUseCase
 import rdx.works.profile.domain.gateway.ChangeGatewayUseCase
 import rdx.works.profile.domain.gateway.DeleteGatewayUseCase
 import rdx.works.profile.domain.gateways
+import rdx.works.profile.domain.security
 import javax.inject.Inject
 
 @HiltViewModel
@@ -44,30 +47,37 @@ class SettingsEditGatewayViewModel @Inject constructor(
 
     private fun observeProfile() {
         viewModelScope.launch {
-            getProfileUseCase.gateways.collect { gateways ->
-                val current = gateways.current()
+            combine(
+                getProfileUseCase.gateways,
+                getProfileUseCase.security.map {
+                    it.isDeveloperModeEnabled
+                }
+            ) { gateways, isDeveloperModeEnabled ->
+                Pair(gateways, isDeveloperModeEnabled)
+            }.collect { pair ->
+                val current = pair.first.current()
                 _state.update { state ->
                     state.copy(
                         currentGateway = current,
-                        gatewayList = gateways.saved.toPersistentList().map {
+                        gatewayList = pair.first.saved.toPersistentList().map {
                             GatewayWrapper(
                                 gateway = it,
                                 selected = it.url == current.url
                             )
-                        }.toPersistentList()
+                        }.toPersistentList(),
+                        isDeveloperModeEnabled = pair.second
                     )
                 }
             }
         }
     }
 
-    fun onNewUrlChanged(newUrl: String) {
+    fun onNewUrlChanged(newUrl: String) { // check comment in the isValidUrl extension function
         _state.update { state ->
-            val urlWithHttpsAppended = newUrl.sanitizeUrl()
-            val urlAlreadyAdded =
-                state.gatewayList.any { it.gateway.url == newUrl || it.gateway.url == urlWithHttpsAppended }
+            val sanitizedUrl = newUrl.sanitizeAndValidateGatewayUrl(isDevModeEnabled = state.isDeveloperModeEnabled)
+            val urlAlreadyAdded = state.gatewayList.any { it.gateway.url == newUrl || it.gateway.url == sanitizedUrl }
             state.copy(
-                newUrlValid = !urlAlreadyAdded && (newUrl.isValidUrl() || urlWithHttpsAppended.isValidUrl()),
+                newUrlValid = !urlAlreadyAdded && (newUrl.isValidUrl() || sanitizedUrl.isValidUrl()) && (sanitizedUrl == "/").not(),
                 newUrl = newUrl,
                 gatewayAddFailure = if (urlAlreadyAdded) GatewayAddFailure.AlreadyExist else null
             )
@@ -86,7 +96,7 @@ class SettingsEditGatewayViewModel @Inject constructor(
 
     fun onAddGateway() {
         viewModelScope.launch {
-            val newUrl = state.value.newUrl.sanitizeUrl()
+            val newUrl = state.value.newUrl.sanitizeAndValidateGatewayUrl(isDevModeEnabled = state.value.isDeveloperModeEnabled)
             _state.update { state -> state.copy(addingGateway = true) }
             val newGatewayInfo = networkInfoRepository.getNetworkInfo(newUrl)
             newGatewayInfo.onValue { networkName ->
@@ -116,6 +126,10 @@ class SettingsEditGatewayViewModel @Inject constructor(
     private suspend fun switchGateway(gateway: Radix.Gateway) {
         if (gateway.url == state.value.currentGateway?.url) return
 
+        // this is the case where a url has been added when the developer mode was enabled
+        // but at the time the user clicks to switch network the developer mode is disabled
+        if (gateway.url.sanitizeAndValidateGatewayUrl(isDevModeEnabled = state.value.isDeveloperModeEnabled) == "/") return
+
         val isGatewayChanged = changeGatewayUseCase(gateway)
         if (isGatewayChanged) {
             _state.update { state -> state.copy(addingGateway = false) }
@@ -138,7 +152,8 @@ data class SettingsUiState(
     val newUrl: String = "",
     val newUrlValid: Boolean = false,
     val addingGateway: Boolean = false,
-    val gatewayAddFailure: GatewayAddFailure? = null
+    val gatewayAddFailure: GatewayAddFailure? = null,
+    val isDeveloperModeEnabled: Boolean = false
 ) : UiState
 
 enum class GatewayAddFailure {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
@@ -31,7 +31,7 @@ import rdx.works.profile.domain.security
 import javax.inject.Inject
 
 @HiltViewModel
-class SettingsEditGatewayViewModel @Inject constructor(
+class GatewaysViewModel @Inject constructor(
     private val getProfileUseCase: GetProfileUseCase,
     private val changeGatewayUseCase: ChangeGatewayUseCase,
     private val addGatewayUseCase: AddGatewayUseCase,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
@@ -77,7 +77,7 @@ class GatewaysViewModel @Inject constructor(
             val sanitizedUrl = newUrl.sanitizeAndValidateGatewayUrl(isDevModeEnabled = state.isDeveloperModeEnabled)
             val urlAlreadyAdded = state.gatewayList.any { it.gateway.url == newUrl || it.gateway.url == sanitizedUrl }
             state.copy(
-                newUrlValid = !urlAlreadyAdded && (newUrl.isValidUrl() || sanitizedUrl.isValidUrl()) && (sanitizedUrl == "/").not(),
+                newUrlValid = !urlAlreadyAdded && (newUrl.isValidUrl() || sanitizedUrl?.isValidUrl() == true),
                 newUrl = newUrl,
                 gatewayAddFailure = if (urlAlreadyAdded) GatewayAddFailure.AlreadyExist else null
             )
@@ -96,8 +96,13 @@ class GatewaysViewModel @Inject constructor(
 
     fun onAddGateway() {
         viewModelScope.launch {
-            val newUrl = state.value.newUrl.sanitizeAndValidateGatewayUrl(isDevModeEnabled = state.value.isDeveloperModeEnabled)
+            val newUrl = state.value
+                .newUrl
+                .sanitizeAndValidateGatewayUrl(isDevModeEnabled = state.value.isDeveloperModeEnabled)
+                ?: return@launch
+
             _state.update { state -> state.copy(addingGateway = true) }
+
             val newGatewayInfo = networkInfoRepository.getNetworkInfo(newUrl)
             newGatewayInfo.onValue { networkName ->
                 addGatewayUseCase(Radix.Gateway(newUrl, Radix.Network.forName(networkName)))

--- a/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import com.radixdlt.bip39.wordlists.WORDLIST_ENGLISH
+import org.apache.commons.validator.routines.InetAddressValidator
+import org.apache.commons.validator.routines.UrlValidator
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.text.DecimalFormat
@@ -70,6 +72,7 @@ fun String.formatDecimalSeparator(): String {
     }
 }
 
+// TODO this does not work for IPv6 thus we can't add a IPv6 address in gateway settings
 fun String.isValidUrl(): Boolean {
     return Patterns.WEB_URL.matcher(this).matches()
 }
@@ -90,16 +93,44 @@ fun String.decodeUtf8(): String {
     return URLDecoder.decode(this, "UTF-8")
 }
 
-fun String.sanitizeUrl(): String {
-    return if (this.startsWith("https://")) {
-        this
-    } else {
-        "https://$this"
-    }.let {
-        if (it.endsWith('/').not()) {
-            "$it/"
+// see the SanitizeAndValidateGatewayUrlTest for better understanding
+fun String.sanitizeAndValidateGatewayUrl(isDevModeEnabled: Boolean = false): String {
+    val ipValidator = InetAddressValidator.getInstance()
+    val urlValidator = UrlValidator.getInstance()
+
+    return if (isDevModeEnabled) { // when dev mode is enabled we can accept IPs, IP:Port, http, and https
+        if (urlValidator.isValid(this)) { // valid url meaning that contains http or https
+            if (this.endsWith('/').not()) {
+                "$this/"
+            } else {
+                this
+            }
         } else {
-            it
+            val urlToValidate = this.removeSuffix("/")
+            if (ipValidator.isValidInet6Address(urlToValidate)) {
+                "http://[$urlToValidate]/"
+            } else if (urlToValidate.startsWith("https://")) {
+                urlToValidate.substring(0, 8) + '[' + urlToValidate.substring(8) + "]/"
+            } else if (urlToValidate.startsWith("http://")) {
+                urlToValidate.substring(0, 7) + '[' + urlToValidate.substring(7) + "]/"
+            } else {
+                "http://$urlToValidate/"
+            }
+        }
+    } else { // when dev mode is disabled we should not accept ONLY https - no IPs
+        val urlWithoutHttp = this.removePrefix("http://").removePrefix("https://")
+        if (urlWithoutHttp.contains(":")) { // if true it means it has a port or it is an IPv6
+            "/" // then do not accept it
+        } else {
+            // now we need to check also for
+            val urlToValidate = urlWithoutHttp
+                .substringBefore("/")
+                .removeSuffix("/")
+            if (ipValidator.isValidInet4Address(urlToValidate) || ipValidator.isValidInet6Address(urlToValidate)) {
+                "/" // then do not accept it
+            } else {
+                "https://$urlToValidate/"
+            }
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
@@ -94,7 +94,7 @@ fun String.decodeUtf8(): String {
 }
 
 // see the SanitizeAndValidateGatewayUrlTest for better understanding
-fun String.sanitizeAndValidateGatewayUrl(isDevModeEnabled: Boolean = false): String {
+fun String.sanitizeAndValidateGatewayUrl(isDevModeEnabled: Boolean = false): String? {
     val ipValidator = InetAddressValidator.getInstance()
     val urlValidator = UrlValidator.getInstance()
 
@@ -120,14 +120,14 @@ fun String.sanitizeAndValidateGatewayUrl(isDevModeEnabled: Boolean = false): Str
     } else { // when dev mode is disabled we should not accept ONLY https - no IPs
         val urlWithoutHttp = this.removePrefix("http://").removePrefix("https://")
         if (urlWithoutHttp.contains(":")) { // if true it means it has a port or it is an IPv6
-            "/" // then do not accept it
+            null // then do not accept it
         } else {
             // now we need to check also for
             val urlToValidate = urlWithoutHttp
                 .substringBefore("/")
                 .removeSuffix("/")
             if (ipValidator.isValidInet4Address(urlToValidate) || ipValidator.isValidInet6Address(urlToValidate)) {
-                "/" // then do not accept it
+                null // then do not accept it
             } else {
                 "https://$urlToValidate/"
             }

--- a/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
@@ -117,7 +117,7 @@ fun String.sanitizeAndValidateGatewayUrl(isDevModeEnabled: Boolean = false): Str
                 "http://$urlToValidate/"
             }
         }
-    } else { // when dev mode is disabled we should not accept ONLY https - no IPs
+    } else { // when dev mode is disabled we should accept ONLY https - no IPs
         val urlWithoutHttp = this.removePrefix("http://").removePrefix("https://")
         if (urlWithoutHttp.contains(":")) { // if true it means it has a port or it is an IPv6
             null // then do not accept it

--- a/app/src/test/java/com/babylon/wallet/android/presentation/settings/editgateway/GatewaysViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/settings/editgateway/GatewaysViewModelTest.kt
@@ -7,7 +7,7 @@ import com.babylon.wallet.android.domain.common.Result
 import com.babylon.wallet.android.presentation.TestDispatcherRule
 import com.babylon.wallet.android.presentation.settings.appsettings.gateways.GatewayAddFailure
 import com.babylon.wallet.android.presentation.settings.appsettings.gateways.SettingsEditGatewayEvent
-import com.babylon.wallet.android.presentation.settings.appsettings.gateways.SettingsEditGatewayViewModel
+import com.babylon.wallet.android.presentation.settings.appsettings.gateways.GatewaysViewModel
 import com.babylon.wallet.android.utils.isValidUrl
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -28,11 +28,11 @@ import rdx.works.profile.domain.gateway.ChangeGatewayUseCase
 import rdx.works.profile.domain.gateway.DeleteGatewayUseCase
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class SettingsEditGatewayViewModelTest {
+class GatewaysViewModelTest {
     @get:Rule
     val coroutineRule = TestDispatcherRule()
 
-    private lateinit var vm: SettingsEditGatewayViewModel
+    private lateinit var vm: GatewaysViewModel
 
     private val getProfileUseCase = mockk<GetProfileUseCase>()
     private val changeGatewayUseCase = mockk<ChangeGatewayUseCase>()
@@ -44,7 +44,7 @@ class SettingsEditGatewayViewModelTest {
 
     @Before
     fun setUp() = runTest {
-        vm = SettingsEditGatewayViewModel(
+        vm = GatewaysViewModel(
             getProfileUseCase = getProfileUseCase,
             changeGatewayUseCase = changeGatewayUseCase,
             addGatewayUseCase = addGatewayUseCase,

--- a/app/src/test/java/com/babylon/wallet/android/utils/SanitizeAndValidateGatewayUrlTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/utils/SanitizeAndValidateGatewayUrlTest.kt
@@ -8,90 +8,74 @@ class SanitizeAndValidateGatewayUrlTest {
     @Test
     fun `given dev mode is disabled when gateway url is IPv4 then do not accept it`() {
         val inputIP1 = "198.161.9.9"
-        val expectedIP1 = "/" // not accepted
         val actualIP1 = inputIP1.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP1, actualIP1)
+        Assert.assertNull(actualIP1)
 
         val inputIP2 = "198.161.9.9/"
-        val expectedIP2 = "/" // not accepted
         val actualIP2 = inputIP2.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP2, actualIP2)
+        Assert.assertNull(actualIP2)
 
         val inputIP3 = "http://198.161.9.9"
-        val expectedIP3 = "/" // not accepted
         val actualIP3 = inputIP3.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP3, actualIP3)
+        Assert.assertNull(actualIP3)
 
         val inputIP4 = "https://198.161.9.9"
-        val expectedIP4 = "/" // not accepted
         val actualIP4 = inputIP4.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP4, actualIP4)
+        Assert.assertNull(actualIP4)
 
         val inputIP5 = "https://198.161.9.9/"
-        val expectedIP5 = "/" // not accepted
         val actualIP5 = inputIP5.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP5, actualIP5)
+        Assert.assertNull(actualIP5)
 
         val inputIP6 = "https://198.161.9.9:456/test"
-        val expectedIP6 = "/" // not accepted
         val actualIP6 = inputIP6.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP6, actualIP6)
+        Assert.assertNull(actualIP6)
 
         val inputIP7 = "https://198.161.9.9:456/test/test"
-        val expectedIP7 = "/" // not accepted
         val actualIP7 = inputIP7.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP7, actualIP7)
+        Assert.assertNull(actualIP7)
     }
 
     @Test
     fun `given dev mode is disabled when gateway url is IPv6 then do not accept it`() {
         val inputIP1 = "2001:db8:3333:4444:5555:6666:7777:8888"
-        val expectedIP1 = "/" // not accepted
         val actualIP1 = inputIP1.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP1, actualIP1)
+        Assert.assertNull(actualIP1)
 
         val inputIP2 = "[2001:db8:3333:4444:5555:6666:7777:8888]"
-        val expectedIP2 = "/" // not accepted
         val actualIP2 = inputIP2.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP2, actualIP2)
+        Assert.assertNull(actualIP2)
 
         val inputIP3 = "http://2001:db8:3333:4444:5555:6666:7777:8888"
-        val expectedIP3 = "/" // not accepted
         val actualIP3 = inputIP3.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP3, actualIP3)
+        Assert.assertNull(actualIP3)
 
         val inputIP4 = "https://2001:db8:3333:4444:5555:6666:7777:8888"
-        val expectedIP4 = "/" // not accepted
         val actualIP4 = inputIP4.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP4, actualIP4)
+        Assert.assertNull(actualIP4)
 
         val inputIP5 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]/"
-        val expectedIP5 = "/" // not accepted
         val actualIP5 = inputIP5.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP5, actualIP5)
+        Assert.assertNull(actualIP5)
 
         val inputIP6 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]:456/test"
-        val expectedIP6 = "/" // not accepted
         val actualIP6 = inputIP6.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedIP6, actualIP6)
+        Assert.assertNull(actualIP6)
     }
 
     @Test
     fun `given dev mode is disabled when gateway url is a domain url with port then do not accept it`() {
         val inputDomain1 = "www.network.com:456"
-        val expectedDomain1 = "/" // not accepted
         val actualDomain1 = inputDomain1.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedDomain1, actualDomain1)
+        Assert.assertNull(actualDomain1)
 
         val inputDomain2 = "https://www.network.com:456"
-        val expectedDomain2 = "/" // not accepted
         val actualDomain2 = inputDomain2.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedDomain2, actualDomain2)
+        Assert.assertNull(actualDomain2)
 
         val inputDomain3 = "http://2847478384-network.radixdlt.com:456/test/test"
-        val expectedDomain3 = "/" // not accepted
         val actualDomain3 = inputDomain3.sanitizeAndValidateGatewayUrl()
-        Assert.assertEquals(expectedDomain3, actualDomain3)
+        Assert.assertNull(actualDomain3)
     }
 
     @Test

--- a/app/src/test/java/com/babylon/wallet/android/utils/SanitizeAndValidateGatewayUrlTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/utils/SanitizeAndValidateGatewayUrlTest.kt
@@ -1,0 +1,328 @@
+package com.babylon.wallet.android.utils
+
+import org.junit.Test
+import org.junit.Assert
+
+class SanitizeAndValidateGatewayUrlTest {
+
+    @Test
+    fun `given dev mode is disabled when gateway url is IPv4 then do not accept it`() {
+        val inputIP1 = "198.161.9.9"
+        val expectedIP1 = "/" // not accepted
+        val actualIP1 = inputIP1.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP1, actualIP1)
+
+        val inputIP2 = "198.161.9.9/"
+        val expectedIP2 = "/" // not accepted
+        val actualIP2 = inputIP2.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP2, actualIP2)
+
+        val inputIP3 = "http://198.161.9.9"
+        val expectedIP3 = "/" // not accepted
+        val actualIP3 = inputIP3.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP3, actualIP3)
+
+        val inputIP4 = "https://198.161.9.9"
+        val expectedIP4 = "/" // not accepted
+        val actualIP4 = inputIP4.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP4, actualIP4)
+
+        val inputIP5 = "https://198.161.9.9/"
+        val expectedIP5 = "/" // not accepted
+        val actualIP5 = inputIP5.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP5, actualIP5)
+
+        val inputIP6 = "https://198.161.9.9:456/test"
+        val expectedIP6 = "/" // not accepted
+        val actualIP6 = inputIP6.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP6, actualIP6)
+
+        val inputIP7 = "https://198.161.9.9:456/test/test"
+        val expectedIP7 = "/" // not accepted
+        val actualIP7 = inputIP7.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP7, actualIP7)
+    }
+
+    @Test
+    fun `given dev mode is disabled when gateway url is IPv6 then do not accept it`() {
+        val inputIP1 = "2001:db8:3333:4444:5555:6666:7777:8888"
+        val expectedIP1 = "/" // not accepted
+        val actualIP1 = inputIP1.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP1, actualIP1)
+
+        val inputIP2 = "[2001:db8:3333:4444:5555:6666:7777:8888]"
+        val expectedIP2 = "/" // not accepted
+        val actualIP2 = inputIP2.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP2, actualIP2)
+
+        val inputIP3 = "http://2001:db8:3333:4444:5555:6666:7777:8888"
+        val expectedIP3 = "/" // not accepted
+        val actualIP3 = inputIP3.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP3, actualIP3)
+
+        val inputIP4 = "https://2001:db8:3333:4444:5555:6666:7777:8888"
+        val expectedIP4 = "/" // not accepted
+        val actualIP4 = inputIP4.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP4, actualIP4)
+
+        val inputIP5 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]/"
+        val expectedIP5 = "/" // not accepted
+        val actualIP5 = inputIP5.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP5, actualIP5)
+
+        val inputIP6 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]:456/test"
+        val expectedIP6 = "/" // not accepted
+        val actualIP6 = inputIP6.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedIP6, actualIP6)
+    }
+
+    @Test
+    fun `given dev mode is disabled when gateway url is a domain url with port then do not accept it`() {
+        val inputDomain1 = "www.network.com:456"
+        val expectedDomain1 = "/" // not accepted
+        val actualDomain1 = inputDomain1.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain1, actualDomain1)
+
+        val inputDomain2 = "https://www.network.com:456"
+        val expectedDomain2 = "/" // not accepted
+        val actualDomain2 = inputDomain2.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain2, actualDomain2)
+
+        val inputDomain3 = "http://2847478384-network.radixdlt.com:456/test/test"
+        val expectedDomain3 = "/" // not accepted
+        val actualDomain3 = inputDomain3.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain3, actualDomain3)
+    }
+
+    @Test
+    fun `given dev mode is disabled when gateway url is a domain url without http or https then convert it to https and accept it`(){
+        val inputDomain1 = "www.network.com"
+        val expectedDomain1 = "https://www.network.com/"
+        val actualDomain1 = inputDomain1.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain1, actualDomain1)
+
+        val inputDomain2 = "www.network.com/"
+        val expectedDomain2 = "https://www.network.com/"
+        val actualDomain2 = inputDomain2.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain2, actualDomain2)
+
+        val inputDomain3 = "www.network.com/test/"
+        val expectedDomain3 = "https://www.network.com/"
+        val actualDomain3 = inputDomain3.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain3, actualDomain3)
+
+        val inputDomain4 = "www.network.com/test/"
+        val expectedDomain4 = "https://www.network.com/"
+        val actualDomain4 = inputDomain4.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain4, actualDomain4)
+    }
+
+    @Test
+    fun `given dev mode is disabled when gateway url is a domain url with http then convert it to https and accept it`() {
+        val inputDomain1 = "http://www.network.com"
+        val expectedDomain1 = "https://www.network.com/"
+        val actualDomain1 = inputDomain1.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain1, actualDomain1)
+
+        val inputDomain2 = "http://www.network.com/"
+        val expectedDomain2 = "https://www.network.com/"
+        val actualDomain2 = inputDomain2.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain2, actualDomain2)
+
+        val inputDomain3 = "http://www.network.com/test"
+        val expectedDomain3 = "https://www.network.com/"
+        val actualDomain3 = inputDomain3.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain3, actualDomain3)
+    }
+
+    @Test
+    fun `given dev mode is disabled when gateway url is a domain url with https then accept it`() {
+        val inputDomain1 = "https://www.network.com"
+        val expectedDomain1 = "https://www.network.com/"
+        val actualDomain1 = inputDomain1.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain1, actualDomain1)
+
+        val inputDomain2 = "https://2847478384-network.radixdlt.com"
+        val expectedDomain2 = "https://2847478384-network.radixdlt.com/"
+        val actualDomain2 = inputDomain2.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain2, actualDomain2)
+
+        val inputDomain3 = "https://www.network.com/test"
+        val expectedDomain3 = "https://www.network.com/"
+        val actualDomain3 = inputDomain3.sanitizeAndValidateGatewayUrl()
+        Assert.assertEquals(expectedDomain3, actualDomain3)
+    }
+
+    @Test
+    fun `given dev mode is enabled when gateway url is IPv4 without http or https then append http and accept it`() {
+        val inputIP1 = "198.161.9.9"
+        val expectedIP1 = "http://198.161.9.9/"
+        val actualIP1 = inputIP1.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP1, actualIP1)
+
+        val inputIP2 = "198.161.9.9/"
+        val expectedIP2 = "http://198.161.9.9/"
+        val actualIP2  = inputIP2.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP2, actualIP2)
+
+        val inputIP3 = "198.161.9.9:456"
+        val expectedIP3 = "http://198.161.9.9:456/"
+        val actualIP3 = inputIP3.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP3, actualIP3)
+
+        val inputIP4 = "198.161.9.9:456/"
+        val expectedIP4 = "http://198.161.9.9:456/"
+        val actualIP4 = inputIP4.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP4, actualIP4)
+    }
+
+    @Test
+    fun `given dev mode is enabled when gateway url is IPv4 then accept it`() {
+        val inputIP1 = "http://198.161.9.9"
+        val expectedIP1 = "http://198.161.9.9/"
+        val actualIP1 = inputIP1.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP1, actualIP1)
+
+        val inputIP2 = "https://198.161.9.9"
+        val expectedIP2 = "https://198.161.9.9/"
+        val actualIP2 = inputIP2.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP2, actualIP2)
+
+        val inputIP3 = "https://198.161.9.9/"
+        val expectedIP3 = "https://198.161.9.9/"
+        val actualIP3 = inputIP3.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP3, actualIP3)
+
+        val inputIP4 = "http://198.161.9.9:456"
+        val expectedIP4 = "http://198.161.9.9:456/"
+        val actualIP4 = inputIP4.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP4, actualIP4)
+
+        val inputIP5 = "https://198.161.9.9:456"
+        val expectedIP5 = "https://198.161.9.9:456/"
+        val actualIP5 = inputIP5.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP5, actualIP5)
+
+        val inputIP6 = "http://198.161.9.9:456/"
+        val expectedIP6 = "http://198.161.9.9:456/"
+        val actualIP6 = inputIP6.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP6, actualIP6)
+
+        val inputIP7 = "https://198.161.9.9:456/test"
+        val expectedIP7 = "https://198.161.9.9:456/test/"
+        val actualIP7 = inputIP7.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIP7, actualIP7)
+    }
+
+    @Test
+    fun `given dev mode is enabled when gateway url is IPv6 without http or https then append http and accept it`() {
+        val inputIPv6_1 = "2001:db8:3333:4444:5555:6666:7777:8888"
+        val expectedIPv6_1 = "http://[2001:db8:3333:4444:5555:6666:7777:8888]/"
+        val actualIPv6_1 = inputIPv6_1.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_1, actualIPv6_1)
+
+        val inputIPv6_2 = "[2001:db8:3333:4444:5555:6666:7777:8888]"
+        val expectedIPv6_2 = "http://[2001:db8:3333:4444:5555:6666:7777:8888]/"
+        val actualIPv6_2 = inputIPv6_2.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_2, actualIPv6_2)
+
+        val inputIPv6_3 = "2001:db8:3333:4444:5555:6666:7777:8888/"
+        val expectedIPv6_3 = "http://[2001:db8:3333:4444:5555:6666:7777:8888]/"
+        val actualIPv6_3 = inputIPv6_3.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_3, actualIPv6_3)
+
+        val inputIPv6_4 = "[1fff:0:a88:85a3::ac1f]:8001/"
+        val expectedIPv6_4 = "http://[1fff:0:a88:85a3::ac1f]:8001/"
+        val actualIPv6_4 = inputIPv6_4.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_4, actualIPv6_4)
+
+        val inputIPv6_5 = "[1fff:0:a88:85a3::ac1f]:8001/test"
+        val expectedIPv6_5 = "http://[1fff:0:a88:85a3::ac1f]:8001/test/"
+        val actualIPv6_5 = inputIPv6_5.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_5, actualIPv6_5)
+    }
+
+    @Test
+    fun `given dev mode is enabled when gateway url is IPv6 then accept it`() {
+        val inputIPv6_1 = "http://2001:db8:1111:2222:3333:4444:5555:6666"
+        val expectedIPv6_1 = "http://[2001:db8:1111:2222:3333:4444:5555:6666]/"
+        val actualIPv6_1 = inputIPv6_1.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_1, actualIPv6_1)
+
+        val inputIPv6_2 = "https://2001:db8:8888:7777:6666:5555:4444:3333"
+        val expectedIPv6_2 = "https://[2001:db8:8888:7777:6666:5555:4444:3333]/"
+        val actualIPv6_2 = inputIPv6_2.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_2, actualIPv6_2)
+
+        val inputIPv6_3 = "http://[1fff:0:a88:85a3::ac1f]:8001/"
+        val expectedIPv6_3 = "http://[1fff:0:a88:85a3::ac1f]:8001/"
+        val actualIPv6_3 = inputIPv6_3.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_3, actualIPv6_3)
+
+        val inputIPv6_4 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]/"
+        val expectedIPv6_4 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]/"
+        val actualIPv6_4 = inputIPv6_4.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_4, actualIPv6_4)
+
+        val inputIPv6_5 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]:453"
+        val expectedIPv6_5 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]:453/"
+        val actualIPv6_5 = inputIPv6_5.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_5, actualIPv6_5)
+
+        val inputIPv6_6 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]:453/test"
+        val expectedIPv6_6 = "https://[2001:db8:3333:4444:5555:6666:7777:8888]:453/test/"
+        val actualIPv6_6 = inputIPv6_6.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedIPv6_6, actualIPv6_6)
+    }
+
+    @Test
+    fun `given dev mode is enabled when gateway url is a domain url without http or https then append http and accept it`() {
+        val inputDomain1 = "www.network.com"
+        val expectedDomain1 = "http://www.network.com/"
+        val actualIDomain1 = inputDomain1.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedDomain1, actualIDomain1)
+
+        val inputDomain2 = "www.network.com/"
+        val expectedDomain2 = "http://www.network.com/"
+        val actualIDomain2 = inputDomain2.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedDomain2, actualIDomain2)
+
+        val inputDomain3 = "www.network.com:456"
+        val expectedDomain3 = "http://www.network.com:456/"
+        val actualIDomain3 = inputDomain3.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedDomain3, actualIDomain3)
+
+        val inputDomain4 = "www.network.com:456/test"
+        val expectedDomain4 = "http://www.network.com:456/test/"
+        val actualIDomain4 = inputDomain4.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedDomain4, actualIDomain4)
+    }
+
+    @Test
+    fun `given dev mode is enabled when gateway url is a domain url then accept it`() {
+        val inputDomain1 = "http://www.network.com"
+        val expectedDomain1 = "http://www.network.com/"
+        val actualIDomain1 = inputDomain1.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedDomain1, actualIDomain1)
+
+        val inputDomain2 = "https://www.network.com"
+        val expectedDomain2 = "https://www.network.com/"
+        val actualIDomain2 = inputDomain2.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedDomain2, actualIDomain2)
+
+        val inputDomain3 = "https://www.network.com:456"
+        val expectedDomain3 = "https://www.network.com:456/"
+        val actualIDomain3 = inputDomain3.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedDomain3, actualIDomain3)
+
+        val inputDomain4 = "https://2847478384-network.radixdlt.com"
+        val expectedDomain4 = "https://2847478384-network.radixdlt.com/"
+        val actualIDomain4 = inputDomain4.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedDomain4, actualIDomain4)
+
+        val inputDomain5 = "http://2847478384-network.radixdlt.com/test"
+        val expectedDomain5 = "http://2847478384-network.radixdlt.com/test/"
+        val actualIDomain5 = inputDomain5.sanitizeAndValidateGatewayUrl(isDevModeEnabled = true)
+        Assert.assertEquals(expectedDomain5, actualIDomain5)
+    }
+}

--- a/gradle/libraries.versions.toml
+++ b/gradle/libraries.versions.toml
@@ -48,6 +48,7 @@ ktor = "2.3.4"
 slf4j = "2.0.9"
 turbine = "1.0.0"
 zxing = "3.5.2"
+apacheCommonsValidator = "1.7"
 
 [libraries]
 androidxCore = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
@@ -119,3 +120,4 @@ composeUiTestManifest = { module = "androidx.compose.ui:ui-test-manifest", versi
 slf4j = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 zxing = { module = "com.google.zxing:core", version.ref = "zxing" }
+apacheCommonsValidator = { module = "commons-validator:commons-validator", version.ref = "apacheCommonsValidator" }


### PR DESCRIPTION
## Description
[Gateway settings: support HTTP:PORT on dev mode](https://radixdlt.atlassian.net/browse/ABW-2336)

This PR adds logic when adding a new gateway url:
If developer mode is enabled almost any url is accepted, but with developer mode disabled we allow only https url.

### Important Note
Current implementation fails only when trying to add an IPv6. See the comments for more details.
Due to Android version compatibility we can't use other APIs because either they require minsdk 29 or 34.

