### PR TITLE
ABW-2359 - Deposit instruction fix

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/prepare/PrepareManifestDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/prepare/PrepareManifestDelegate.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import rdx.works.core.ret.BabylonManifestBuilder
 import rdx.works.core.ret.buildSafely
+import rdx.works.profile.data.model.factorsources.FactorSourceKind
 import rdx.works.profile.data.model.pernetwork.Network
 import rdx.works.profile.data.repository.MnemonicRepository
 import timber.log.Timber
@@ -130,30 +131,30 @@ class PrepareManifestDelegate(
         }
     }
 
-    private suspend fun BabylonManifestBuilder.deposit(targetAccount: TargetAccount, bucket: ManifestBuilderBucket) = apply {
-        val isUserAccount = targetAccount.isUserAccount
-        // TODO Temporary revert of checking if the receiving account is a ledger account
-        val isSoftwareAccount = true // !targetAccount.isLedgerAccount
+    private suspend fun BabylonManifestBuilder.deposit(targetAccount: TargetAccount, bucket: ManifestBuilderBucket) =
+        apply {
+            val isUserAccount = targetAccount.isUserAccount
+            // TODO Temporary revert of checking if the receiving account is a ledger account
+            val isSoftwareAccount = true // !targetAccount.isLedgerAccount
 
-        // Accounts' mnemonic that does not need recovery
-        val mnemonicHasBeenImported = targetAccount.factorSourceId?.let {
-            mnemonicRepository.mnemonicExist(it).not()
-        } ?: false
+            val isAccountAbleToSign = targetAccount.factorSourceId?.let {
+                it.kind == FactorSourceKind.LEDGER_HQ_HARDWARE_WALLET ||
+                        (it.kind == FactorSourceKind.DEVICE && mnemonicRepository.mnemonicExist(it))
+            } ?: false
 
-        // We use deposit instruction only for owned software accounts that mnemonic doesnt need recovery
-        // or in other words mnemonic for this account has been imported
-        if (isUserAccount && isSoftwareAccount && mnemonicHasBeenImported) {
-            accountDeposit(
-                toAddress = Address(targetAccount.address),
-                fromBucket = bucket
-            )
-        } else {
-            accountTryDepositOrAbort(
-                toAddress = Address(targetAccount.address),
-                fromBucket = bucket
-            )
+            // we want to use try_deposit_or_abort for account that we are not controlling and are not able to sign tx
+            if (isUserAccount && isSoftwareAccount && isAccountAbleToSign) {
+                accountDeposit(
+                    toAddress = Address(targetAccount.address),
+                    fromBucket = bucket
+                )
+            } else {
+                accountTryDepositOrAbort(
+                    toAddress = Address(targetAccount.address),
+                    fromBucket = bucket
+                )
+            }
         }
-    }
 
     /**
      * Sums all the amount needed to be withdrawn for each fungible

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/prepare/PrepareManifestDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/prepare/PrepareManifestDelegate.kt
@@ -139,7 +139,7 @@ class PrepareManifestDelegate(
 
             val isAccountAbleToSign = targetAccount.factorSourceId?.let {
                 it.kind == FactorSourceKind.LEDGER_HQ_HARDWARE_WALLET ||
-                        (it.kind == FactorSourceKind.DEVICE && mnemonicRepository.mnemonicExist(it))
+                    (it.kind == FactorSourceKind.DEVICE && mnemonicRepository.mnemonicExist(it))
             } ?: false
 
             // we want to use try_deposit_or_abort for account that we are not controlling and are not able to sign tx

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/prepare/PrepareManifestDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/prepare/PrepareManifestDelegate.kt
@@ -134,8 +134,10 @@ class PrepareManifestDelegate(
         val isUserAccount = targetAccount.isUserAccount
         // TODO Temporary revert of checking if the receiving account is a ledger account
         val isSoftwareAccount = true // !targetAccount.isLedgerAccount
+
+        // Accounts' mnemonic that does not need recovery
         val mnemonicHasBeenImported = targetAccount.factorSourceId?.let {
-            mnemonicRepository.mnemonicExist(it)
+            mnemonicRepository.mnemonicExist(it).not()
         } ?: false
 
         // We use deposit instruction only for owned software accounts that mnemonic doesnt need recovery


### PR DESCRIPTION
## Description
https://radixdlt.atlassian.net/browse/ABW-2359

### Screenshots (optional)
<img src="image_url" width="300">

### Notes (optional)
The issue here was that logic for whether mnemonicHasBeenImported was wrong.
The logic there should be the same as we use for display "Please Recover your account" on the account card on the home view.
If we cannot find mnemonic it means account does not need recovery and in this case we should use deposit instruction not try_deposit_or_abort.

IOS logic once again for comparison, please focus on ** userHasAccessToMnemonic** part -> https://github.com/radixdlt/babylon-wallet-ios/pull/800/files

Please test transfer from Software account to Ledger account and vice versa. Both flows should trigger ledger signing request .