### PR TITLE
[ABW-2385] Remove cache from .well-known check

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/cache/HttpCache.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/cache/HttpCache.kt
@@ -117,6 +117,8 @@ class HttpCacheImpl @Inject constructor(
     }
 
     private suspend fun Call<*>.cacheKeyData(): CacheKeyData {
+        // TODO this needs to change to use the original request's base url and not gateways.
+        // This fails if cache is used with dynamic base urls like the .well-known/radix.json request
         val baseUrl = URL(getCurrentGatewayUseCase().url)
 
         return CacheKeyData(

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/dappmetadata/DAppRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/dappmetadata/DAppRepository.kt
@@ -179,10 +179,6 @@ class DAppRepositoryImpl @Inject constructor(
                 okHttpClient = okHttpClient,
                 jsonConverterFactory = jsonConverterFactory
             ).wellKnownDAppDefinition().execute(
-                cacheParameters = CacheParameters(
-                    httpCache = cache,
-                    timeoutDuration = TimeoutDuration.FIVE_MINUTES
-                ),
                 map = { response -> response.dApps.map { it.dAppDefinitionAddress } },
                 error = {
                     DappRequestException(DappRequestFailure.DappVerificationFailure.RadixJsonNotFound)


### PR DESCRIPTION
Well known requests should be cached, but the current cache solution does not work for dynamic urls. The reason can be discussed but had to do with the fact that this caching mechanism could not produce the expected UX behavior if used as an interceptor (a place were you know about the base url). So the base url for all requests is the gateway's base url. 

The first step to resolve the issue is to remove cache for the well known requests, as they only happen during login.