### PR TITLE
[ABW-2384] fix bug in depositor changes rendering on transaction preview

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/AccountDepositSettingsAnalysis.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/AccountDepositSettingsAnalysis.kt
@@ -16,7 +16,7 @@ suspend fun TransactionType.AccountDepositSettings.resolve(
     getProfileUseCase: GetProfileUseCase,
     getResourcesUseCase: GetResourcesUseCase
 ): PreviewType {
-    val involvedAccountAddresses = defaultDepositRuleChanges.keys + resourcePreferenceChanges.keys + defaultDepositRuleChanges.keys
+    val involvedAccountAddresses = defaultDepositRuleChanges.keys + resourcePreferenceChanges.keys + authorizedDepositorsChanges.keys
     val involvedAccounts = getProfileUseCase.accountsOnCurrentNetwork().filter { involvedAccountAddresses.contains(it.address) }
     val result = involvedAccounts.map { involvedAccount ->
         val defaultDepositRule = defaultDepositRuleChanges[involvedAccount.address]


### PR DESCRIPTION
## Description
If only deposit change done was change to depositor list, it was not properly rendered on the transaction review, although the manifest for the actual change (if you approve transaction) is correct