### PR TITLE
[ABW-1759] Update insufficient balance check.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
@@ -239,7 +239,7 @@ class TransactionClient @Inject constructor(
             if (withdrawnFromCandidate != null) {
                 return Result.success(
                     FeePayerSearchResult(
-                        feePayerAddressFromManifest = withdrawnFromCandidate,
+                        feePayerAddress = withdrawnFromCandidate,
                         candidates = candidates
                     )
                 )
@@ -255,7 +255,7 @@ class TransactionClient @Inject constructor(
             if (depositedIntoCandidate != null) {
                 return Result.success(
                     FeePayerSearchResult(
-                        feePayerAddressFromManifest = depositedIntoCandidate,
+                        feePayerAddress = depositedIntoCandidate,
                         candidates = candidates
                     )
                 )
@@ -271,7 +271,7 @@ class TransactionClient @Inject constructor(
             if (requiringAuthCandidate != null) {
                 return Result.success(
                     FeePayerSearchResult(
-                        feePayerAddressFromManifest = requiringAuthCandidate,
+                        feePayerAddress = requiringAuthCandidate,
                         candidates = candidates
                     )
                 )

--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/model/FeePayerSearchResult.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/model/FeePayerSearchResult.kt
@@ -4,16 +4,9 @@ import rdx.works.profile.data.model.pernetwork.Network
 import java.math.BigDecimal
 
 data class FeePayerSearchResult(
-    val feePayerAddressFromManifest: String? = null,
+    val feePayerAddress: String? = null,
     val candidates: List<FeePayerCandidate> = emptyList(),
-    val insufficientBalanceToPayTheFee: Boolean = false
 ) {
-
-    fun candidateXrdBalance(candidateAddress: String? = feePayerAddressFromManifest): BigDecimal =
-        candidates.find { candidate ->
-            candidate.account.address == candidateAddress
-        }?.xrdAmount ?: BigDecimal.ZERO
-
     data class FeePayerCandidate(
         val account: Network.Account,
         val xrdAmount: BigDecimal

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -105,9 +105,7 @@ fun TransactionReviewScreen(
         onFeePaddingAmountChanged = viewModel::onFeePaddingAmountChanged,
         onTipPercentageChanged = viewModel::onTipPercentageChanged,
         onViewDefaultModeClick = viewModel::onViewDefaultModeClick,
-        onViewAdvancedModeClick = viewModel::onViewAdvancedModeClick,
-        noFeePayerSelected = state.noFeePayerSelected,
-        insufficientBalanceToPayTheFee = state.insufficientBalanceToPayTheFee
+        onViewAdvancedModeClick = viewModel::onViewAdvancedModeClick
     )
 
     state.interactionState?.let {
@@ -166,9 +164,7 @@ private fun TransactionPreviewContent(
     onFeePaddingAmountChanged: (String) -> Unit,
     onTipPercentageChanged: (String) -> Unit,
     onViewDefaultModeClick: () -> Unit,
-    onViewAdvancedModeClick: () -> Unit,
-    noFeePayerSelected: Boolean,
-    insufficientBalanceToPayTheFee: Boolean
+    onViewAdvancedModeClick: () -> Unit
 ) {
     val modalBottomSheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
@@ -202,7 +198,7 @@ private fun TransactionPreviewContent(
                 modifier = Modifier.navigationBarsPadding(),
                 sheetState = state.sheetState,
                 transactionFees = state.transactionFees,
-                insufficientBalanceToPayTheFee = state.feePayerSearchResult?.insufficientBalanceToPayTheFee ?: false,
+                insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
                 onGuaranteesCloseClick = onGuaranteesCloseClick,
                 onGuaranteesApplyClick = onGuaranteesApplyClick,
                 onGuaranteeValueChanged = onGuaranteeValueChanged,
@@ -262,8 +258,8 @@ private fun TransactionPreviewContent(
                             ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5)
                             NetworkFeeContent(
                                 fees = state.transactionFees,
-                                noFeePayerSelected = noFeePayerSelected,
-                                insufficientBalanceToPayTheFee = insufficientBalanceToPayTheFee,
+                                noFeePayerSelected = state.noFeePayerSelected,
+                                insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
                                 onCustomizeClick = onCustomizeClick
                             )
                             SlideToSignButton(
@@ -319,8 +315,8 @@ private fun TransactionPreviewContent(
                             }
                             NetworkFeeContent(
                                 fees = state.transactionFees,
-                                noFeePayerSelected = noFeePayerSelected,
-                                insufficientBalanceToPayTheFee = insufficientBalanceToPayTheFee,
+                                noFeePayerSelected = state.noFeePayerSelected,
+                                insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
                                 onCustomizeClick = onCustomizeClick
                             )
                             SlideToSignButton(
@@ -487,9 +483,7 @@ fun TransactionPreviewContentPreview() {
             onFeePaddingAmountChanged = {},
             onTipPercentageChanged = {},
             onViewDefaultModeClick = {},
-            onViewAdvancedModeClick = {},
-            noFeePayerSelected = false,
-            insufficientBalanceToPayTheFee = false,
+            onViewAdvancedModeClick = {}
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -106,9 +106,7 @@ class TransactionAnalysisDelegate(
                     transactionFees = transactionFees,
                     isLoading = false,
                     previewType = previewType,
-                    feePayerSearchResult = feePayerResult.copy(
-                        insufficientBalanceToPayTheFee = feePayerResult.candidateXrdBalance() < transactionFees.defaultTransactionFee
-                    ),
+                    feePayerSearchResult = feePayerResult,
                     defaultSignersCount = notaryAndSigners.signers.count()
                 )
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFeesDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFeesDelegate.kt
@@ -21,9 +21,9 @@ class TransactionFeesDelegate(
             }
         } else {
             state.value.feePayerSearchResult?.let { feePayerResult ->
-                if (feePayerResult.feePayerAddressFromManifest != null) {
+                if (feePayerResult.feePayerAddress != null) {
                     // Candidate selected
-                    getProfileUseCase.accountOnCurrentNetwork(withAddress = feePayerResult.feePayerAddressFromManifest)
+                    getProfileUseCase.accountOnCurrentNetwork(withAddress = feePayerResult.feePayerAddress)
                         ?.let { feePayerCandidate ->
                             state.update { state ->
                                 state.candidateSelectedState(feePayerCandidate)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
@@ -100,10 +100,10 @@ class TransactionSubmitDelegate(
     ) {
         state.value.feePayerSearchResult?.let { feePayerResult ->
             state.update { it.copy(isSubmitting = false) }
-            if (feePayerResult.feePayerAddressFromManifest != null) {
+            if (feePayerResult.feePayerAddress != null) {
                 signAndSubmit(
                     transactionRequest = state.value.request,
-                    feePayerAddress = feePayerResult.feePayerAddressFromManifest,
+                    feePayerAddress = feePayerResult.feePayerAddress,
                     manifest = manifest,
                     deviceBiometricAuthenticationProvider = deviceBiometricAuthenticationProvider
                 )

--- a/app/src/test/java/com/babylon/wallet/android/data/transaction/TransactionClientTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/data/transaction/TransactionClientTest.kt
@@ -77,7 +77,7 @@ internal class TransactionClientTest {
             val addressToLockFee = transactionClient.findFeePayerInManifest(
                 manifest,
                 TransactionConfig.DEFAULT_LOCK_FEE.toBigDecimal()
-            ).getOrThrow().feePayerAddressFromManifest
+            ).getOrThrow().feePayerAddress
             manifest = manifest.addLockFeeInstructionToManifest(addressToLockFee!!, TransactionConfig.DEFAULT_LOCK_FEE.toBigDecimal())
             val signingEntities = transactionClient.getSigningEntities(manifest)
             Assert.assertEquals(1, signingEntities.size)
@@ -97,7 +97,7 @@ internal class TransactionClientTest {
                 manifest,
                 TransactionConfig.DEFAULT_LOCK_FEE.toBigDecimal()
             ).getOrThrow()
-            assert(addressToLockFee.feePayerAddressFromManifest != null)
+            assert(addressToLockFee.feePayerAddress != null)
             assert(addressToLockFee.candidates.size == 2)
         }
 
@@ -109,7 +109,7 @@ internal class TransactionClientTest {
             manifest,
             TransactionConfig.DEFAULT_LOCK_FEE.toBigDecimal()
         ).getOrNull()
-        assert(feePayerResult?.feePayerAddressFromManifest == null)
+        assert(feePayerResult?.feePayerAddress == null)
         assert(feePayerResult?.candidates?.size == 2)
     }
 


### PR DESCRIPTION
[Android - Production version 1.0.3 build #14  | Transfer token | Issue when submitting a transaction of MAX account balance](https://radixdlt.atlassian.net/browse/ABW-1759)

## Description
There was a thread on slack that on Android specifically we do many transactions that result to a lot of insufficient balance errors. 
I checked the code and I found out that we don't actually check if the user is maxing out their XRD when withdrawing them from their account and paying from the same account. Then I saw that we have a bug ticket already.

The goal of this PR is to have the state check itself when the balance is insufficient. There is no need to keep this as a property but it can become a backing property since such info can be derived from
1. feePayerResult
2. previewType.transaction.from 