### PR TITLE
Change gateway to mainnet after restoring backup

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -16,6 +16,8 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.profile.data.model.MnemonicWithPassphrase
+import rdx.works.profile.data.model.apppreferences.Radix
+import rdx.works.profile.data.model.apppreferences.changeGateway
 import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.pernetwork.Network
@@ -53,7 +55,7 @@ class RestoreMnemonicsViewModel @Inject constructor(
         viewModelScope.launch {
             val factorSources = when (args) {
                 is RestoreMnemonicsArgs.RestoreProfile -> {
-                    val profile = getTemporaryRestoringProfileForBackupUseCase(args.backupType)
+                    val profile = getTemporaryRestoringProfileForBackupUseCase(args.backupType)?.changeGateway(Radix.Gateway.mainnet)
                     val allAccounts = profile?.currentNetwork?.accounts.orEmpty()
 
                     profile?.factorSources
@@ -232,8 +234,8 @@ class RestoreMnemonicsViewModel @Inject constructor(
 
     sealed interface Event : OneOffEvent {
         data class FinishRestoration(val isMovingToMain: Boolean) : Event
-        object CloseApp : Event
-        object MoveToNextWord : Event
+        data object CloseApp : Event
+        data object MoveToNextWord : Event
     }
 }
 

--- a/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
@@ -2,6 +2,8 @@ package rdx.works.profile.domain.backup
 
 import rdx.works.core.InstantGenerator
 import rdx.works.core.preferences.PreferencesManager
+import rdx.works.profile.data.model.apppreferences.Radix
+import rdx.works.profile.data.model.apppreferences.changeGateway
 import rdx.works.profile.data.repository.BackupProfileRepository
 import rdx.works.profile.data.repository.DeviceInfoRepository
 import rdx.works.profile.data.repository.ProfileRepository
@@ -15,7 +17,8 @@ class RestoreProfileFromBackupUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(backupType: BackupType) {
-        val profile = backupProfileRepository.getTemporaryRestoringProfile(backupType)
+        // always restore backup on mainnet
+        val profile = backupProfileRepository.getTemporaryRestoringProfile(backupType)?.changeGateway(Radix.Gateway.mainnet)
 
         if (profile != null) {
             val newDeviceName = deviceInfoRepository.getDeviceInfo().displayName


### PR DESCRIPTION
## Description
- since we always have mainnet in `.preset` that we set in profile init, we just need to change gateway on the profile object just before restoring. Done this changeGateway call in 2 places - actual backup restoring use case and when loading profile in restore mnemonic screen, so that we show list of mainnet accounts instead of accounts on a network that was set to default at the moment of doing backup