### PR TITLE
ABW-2398 - Tip not accepting decimals, only whole numbers.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFees.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFees.kt
@@ -113,7 +113,7 @@ data class TransactionFees(
      */
     @Suppress("MagicNumber")
     val effectiveTip: BigDecimal
-        get() = tipPercentageBigDecimal?.divide(
+        get() = tipPercentageNumber?.toBigDecimal()?.divide(
             BigDecimal(100)
         )?.multiply(
             totalExecutionCost.add(
@@ -143,8 +143,8 @@ data class TransactionFees(
             )
         )
 
-    private val tipPercentageBigDecimal: BigDecimal?
-        get() = tipPercentage?.toBigDecimalOrNull()
+    private val tipPercentageNumber: Int?
+        get() = tipPercentage?.toIntOrNull()
 
     @Suppress("MagicNumber")
     val feePaddingAmountToDisplay: String
@@ -165,8 +165,7 @@ data class TransactionFees(
         get() = tipPercentage ?: "0"
 
     val tipPercentageForTransaction: UShort
-        get() = tipPercentage?.toLong()?.toUShort()
-            ?: TransactionConfig.TIP_PERCENTAGE
+        get() = tipPercentageNumber?.toUShort() ?: TransactionConfig.TIP_PERCENTAGE
 
     companion object {
         private val PERCENT_15 = BigDecimal(0.15)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFees.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFees.kt
@@ -113,7 +113,7 @@ data class TransactionFees(
      */
     @Suppress("MagicNumber")
     val effectiveTip: BigDecimal
-        get() = tipPercentageNumber?.toBigDecimal()?.divide(
+        get() = tipPercentageNumber?.toLong()?.toBigDecimal()?.divide(
             BigDecimal(100)
         )?.multiply(
             totalExecutionCost.add(
@@ -143,8 +143,8 @@ data class TransactionFees(
             )
         )
 
-    private val tipPercentageNumber: Int?
-        get() = tipPercentage?.toIntOrNull()
+    private val tipPercentageNumber: UShort?
+        get() = tipPercentage?.toUShortOrNull()
 
     @Suppress("MagicNumber")
     val feePaddingAmountToDisplay: String
@@ -165,7 +165,7 @@ data class TransactionFees(
         get() = tipPercentage ?: "0"
 
     val tipPercentageForTransaction: UShort
-        get() = tipPercentageNumber?.toUShort() ?: TransactionConfig.TIP_PERCENTAGE
+        get() = tipPercentageNumber ?: TransactionConfig.TIP_PERCENTAGE
 
     companion object {
         private val PERCENT_15 = BigDecimal(0.15)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFeesDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFeesDelegate.kt
@@ -65,7 +65,7 @@ class TransactionFeesDelegate(
         state.update { state ->
             state.copy(
                 transactionFees = transactionFees.copy(
-                    tipPercentage = tipPercentage
+                    tipPercentage = tipPercentage.filter { it.isDigit() }
                 )
             )
         }


### PR DESCRIPTION
## Description
https://radixdlt.atlassian.net/browse/ABW-2398

### Screenshots (optional)

https://github.com/radixdlt/babylon-wallet-android/assets/108684750/d53e9afc-d6fd-4efb-843b-57b0f7c7ce2a

### Notes (optional)
Tip percentage field cannot accept decimals, only whole numbers (integers)