### PR TITLE
ABW-2380 request crashes

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/IncomingRequestRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/IncomingRequestRepository.kt
@@ -106,7 +106,9 @@ class IncomingRequestRepositoryImpl @Inject constructor() : IncomingRequestRepos
         val queueItem = requestQueue.find {
             it is QueueItem.RequestItem && it.incomingRequest.id == requestId && it.incomingRequest is IncomingRequest.UnauthorizedRequest
         }
-        Timber.w("Unauthorized request with id $requestId is null")
+        if (queueItem == null) {
+            Timber.w("Unauthorized request with id $requestId is null")
+        }
         return (queueItem as? QueueItem.RequestItem)?.incomingRequest as? IncomingRequest.UnauthorizedRequest
     }
 
@@ -114,7 +116,9 @@ class IncomingRequestRepositoryImpl @Inject constructor() : IncomingRequestRepos
         val queueItem = requestQueue.find {
             it is QueueItem.RequestItem && it.incomingRequest.id == requestId && it.incomingRequest is IncomingRequest.TransactionRequest
         }
-        Timber.w("Transaction request with id $requestId is null")
+        if (queueItem == null) {
+            Timber.w("Transaction request with id $requestId is null")
+        }
         return (queueItem as? QueueItem.RequestItem)?.incomingRequest as? IncomingRequest.TransactionRequest
     }
 
@@ -122,7 +126,9 @@ class IncomingRequestRepositoryImpl @Inject constructor() : IncomingRequestRepos
         val queueItem = requestQueue.find {
             it is QueueItem.RequestItem && it.incomingRequest.id == requestId && it.incomingRequest is IncomingRequest.AuthorizedRequest
         }
-        Timber.w("Authorized request with id $requestId is null")
+        if (queueItem == null) {
+            Timber.w("Authorized request with id $requestId is null")
+        }
         return (queueItem as? QueueItem.RequestItem)?.incomingRequest as? IncomingRequest.AuthorizedRequest
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/IncomingRequestRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/IncomingRequestRepository.kt
@@ -23,11 +23,11 @@ interface IncomingRequestRepository {
 
     suspend fun resumeIncomingRequests()
 
-    fun getUnauthorizedRequest(requestId: String): IncomingRequest.UnauthorizedRequest
+    fun getUnauthorizedRequest(requestId: String): IncomingRequest.UnauthorizedRequest?
 
-    fun getTransactionWriteRequest(requestId: String): IncomingRequest.TransactionRequest
+    fun getTransactionWriteRequest(requestId: String): IncomingRequest.TransactionRequest?
 
-    fun getAuthorizedRequest(requestId: String): IncomingRequest.AuthorizedRequest
+    fun getAuthorizedRequest(requestId: String): IncomingRequest.AuthorizedRequest?
 
     fun removeAll()
 
@@ -102,40 +102,28 @@ class IncomingRequestRepositoryImpl @Inject constructor() : IncomingRequestRepos
         }
     }
 
-    override fun getUnauthorizedRequest(requestId: String): IncomingRequest.UnauthorizedRequest {
+    override fun getUnauthorizedRequest(requestId: String): IncomingRequest.UnauthorizedRequest? {
         val queueItem = requestQueue.find {
             it is QueueItem.RequestItem && it.incomingRequest.id == requestId && it.incomingRequest is IncomingRequest.UnauthorizedRequest
         }
-
-        requireNotNull(queueItem) {
-            "IncomingRequestRepository does not contain this request"
-        }
-
-        return (queueItem as QueueItem.RequestItem).incomingRequest as IncomingRequest.UnauthorizedRequest
+        Timber.w("Unauthorized request with id $requestId is null")
+        return (queueItem as? QueueItem.RequestItem)?.incomingRequest as? IncomingRequest.UnauthorizedRequest
     }
 
-    override fun getTransactionWriteRequest(requestId: String): IncomingRequest.TransactionRequest {
+    override fun getTransactionWriteRequest(requestId: String): IncomingRequest.TransactionRequest? {
         val queueItem = requestQueue.find {
             it is QueueItem.RequestItem && it.incomingRequest.id == requestId && it.incomingRequest is IncomingRequest.TransactionRequest
         }
-
-        requireNotNull(queueItem) {
-            "IncomingRequestRepository does not contain this request"
-        }
-
-        return (queueItem as QueueItem.RequestItem).incomingRequest as IncomingRequest.TransactionRequest
+        Timber.w("Transaction request with id $requestId is null")
+        return (queueItem as? QueueItem.RequestItem)?.incomingRequest as? IncomingRequest.TransactionRequest
     }
 
-    override fun getAuthorizedRequest(requestId: String): IncomingRequest.AuthorizedRequest {
+    override fun getAuthorizedRequest(requestId: String): IncomingRequest.AuthorizedRequest? {
         val queueItem = requestQueue.find {
             it is QueueItem.RequestItem && it.incomingRequest.id == requestId && it.incomingRequest is IncomingRequest.AuthorizedRequest
         }
-
-        requireNotNull(queueItem) {
-            "IncomingRequestRepository does not contain this request"
-        }
-
-        return (queueItem as QueueItem.RequestItem).incomingRequest as IncomingRequest.AuthorizedRequest
+        Timber.w("Authorized request with id $requestId is null")
+        return (queueItem as? QueueItem.RequestItem)?.incomingRequest as? IncomingRequest.AuthorizedRequest
     }
 
     override fun removeAll() {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/InitialAuthorizedLoginRoute.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/InitialAuthorizedLoginRoute.kt
@@ -3,7 +3,7 @@ package com.babylon.wallet.android.presentation.dapp
 import com.babylon.wallet.android.domain.model.RequiredPersonaFields
 
 sealed interface InitialAuthorizedLoginRoute {
-    data class SelectPersona(val reqId: String) : InitialAuthorizedLoginRoute
+    data class SelectPersona(val dappDefinitionAddress: String) : InitialAuthorizedLoginRoute
     data class Permission(
         val numberOfAccounts: Int,
         val isExactAccountsCount: Boolean,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/DappLoginAuthorizedNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/DappLoginAuthorizedNavGraph.kt
@@ -39,8 +39,8 @@ fun NavGraphBuilder.dappLoginAuthorizedNavGraph(navController: NavController) {
             navigateToOneTimePersonaData = {
                 navController.personaDataOnetimeAuthorized(it)
             },
-            navigateToSelectPersona = { reqeustId ->
-                navController.selectPersona(reqeustId)
+            navigateToSelectPersona = { dappDefinitionAddress ->
+                navController.selectPersona(dappDefinitionAddress)
             }
         ) { personaAddress, requiredFields ->
             navController.personaDataOngoing(personaAddress, requiredFields)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
@@ -47,7 +47,7 @@ fun ChooseAccountsScreen(
                 is Event.LoginFlowCompleted -> onLoginFlowComplete()
                 is Event.PersonaDataOngoing -> onPersonaOngoingData(event)
                 is Event.PersonaDataOnetime -> onPersonaDataOnetime(event)
-                is Event.RejectLogin -> onLoginFlowComplete()
+                is Event.CloseLoginFlow -> onLoginFlowComplete()
                 is Event.RequestCompletionBiometricPrompt -> {
                     if (event.requestDuringSigning) {
                         sharedViewModel.completeRequestHandling(deviceBiometricAuthenticationProvider = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
@@ -38,7 +38,7 @@ fun DappAuthorizedLoginScreen(
     modifier: Modifier = Modifier
 ) {
     LaunchedEffect(Unit) {
-        viewModel.oneOffEvent.filterIsInstance<Event.RejectLogin>().collect {
+        viewModel.oneOffEvent.filterIsInstance<Event.CloseLoginFlow>().collect {
             onBackClick()
         }
     }
@@ -61,7 +61,7 @@ fun DappAuthorizedLoginScreen(
             route.oneTime,
             route.showBack
         )
-        is InitialAuthorizedLoginRoute.SelectPersona -> navigateToSelectPersona(route.reqId)
+        is InitialAuthorizedLoginRoute.SelectPersona -> navigateToSelectPersona(route.dappDefinitionAddress)
         else -> {}
     }
     Box(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/permission/LoginPermissionScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/permission/LoginPermissionScreen.kt
@@ -57,7 +57,7 @@ fun LoginPermissionScreen(
         viewModel.oneOffEvent.collect { event ->
             when (event) {
                 is Event.ChooseAccounts -> onChooseAccounts(event)
-                is Event.RejectLogin -> onCompleteFlow()
+                is Event.CloseLoginFlow -> onCompleteFlow()
                 else -> {}
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
@@ -81,7 +81,7 @@ fun PersonaDataOngoingScreen(
                 is Event.LoginFlowCompleted -> onLoginFlowComplete()
                 is Event.ChooseAccounts -> onChooseAccounts(event)
                 is Event.PersonaDataOnetime -> onPersonaDataOnetime(event)
-                is Event.RejectLogin -> onLoginFlowComplete()
+                is Event.CloseLoginFlow -> onLoginFlowComplete()
                 is Event.RequestCompletionBiometricPrompt -> {
                     if (event.requestDuringSigning) {
                         sharedViewModel.completeRequestHandling(deviceBiometricAuthenticationProvider = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaNav.kt
@@ -15,18 +15,18 @@ import com.babylon.wallet.android.presentation.dapp.authorized.login.ROUTE_DAPP_
 import com.google.accompanist.navigation.animation.composable
 
 @VisibleForTesting
-internal const val ARG_REQUEST_ID = "request_id"
+internal const val ARG_DAPP_DEFINITION_ADDRESS = "dapp_definition_address"
 
-const val ROUTE_SELECT_PERSONA = "select_persona/{$ARG_REQUEST_ID}"
+const val ROUTE_SELECT_PERSONA = "select_persona/{$ARG_DAPP_DEFINITION_ADDRESS}"
 
-internal class SelectPersonaArgs(val requestId: String) {
-    constructor(savedStateHandle: SavedStateHandle) : this(checkNotNull(savedStateHandle[ARG_REQUEST_ID]) as String)
+internal class SelectPersonaArgs(val dappDefinitionAddress: String) {
+    constructor(savedStateHandle: SavedStateHandle) : this(checkNotNull(savedStateHandle[ARG_DAPP_DEFINITION_ADDRESS]) as String)
 }
 
 fun NavController.selectPersona(
-    requestId: String
+    dappDefinitionAddress: String
 ) {
-    navigate("select_persona/$requestId")
+    navigate("select_persona/$dappDefinitionAddress")
 }
 
 @OptIn(ExperimentalAnimationApi::class)
@@ -44,7 +44,7 @@ fun NavGraphBuilder.selectPersona(
     composable(
         route = ROUTE_SELECT_PERSONA,
         arguments = listOf(
-            navArgument(ARG_REQUEST_ID) {
+            navArgument(ARG_DAPP_DEFINITION_ADDRESS) {
                 type = NavType.StringType
             }
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
@@ -73,7 +73,7 @@ fun SelectPersonaScreen(
     LaunchedEffect(Unit) {
         sharedViewModel.oneOffEvent.collect { event ->
             when (event) {
-                Event.RejectLogin -> onBackClick()
+                Event.CloseLoginFlow -> onBackClick()
                 is Event.LoginFlowCompleted -> onLoginFlowComplete()
                 is Event.ChooseAccounts -> onChooseAccounts(event)
                 is Event.DisplayPermission -> onDisplayPermission(event)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaViewModel.kt
@@ -2,7 +2,6 @@ package com.babylon.wallet.android.presentation.dapp.authorized.selectpersona
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
 import com.babylon.wallet.android.presentation.common.OneOffEvent
 import com.babylon.wallet.android.presentation.common.OneOffEventHandler
 import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
@@ -32,15 +31,10 @@ class SelectPersonaViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val dAppConnectionRepository: DAppConnectionRepository,
     private val getProfileUseCase: GetProfileUseCase,
-    private val preferencesManager: PreferencesManager,
-    incomingRequestRepository: IncomingRequestRepository
+    private val preferencesManager: PreferencesManager
 ) : StateViewModel<SelectPersonaUiState>(), OneOffEventHandler<DAppSelectPersonaEvent> by OneOffEventHandlerImpl() {
 
     private val args = SelectPersonaArgs(savedStateHandle)
-
-    private val authorizedRequest = incomingRequestRepository.getAuthorizedRequest(
-        args.requestId
-    )
 
     private var authorizedDapp: Network.AuthorizedDapp? = null
 
@@ -48,9 +42,7 @@ class SelectPersonaViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            authorizedDapp = dAppConnectionRepository.getAuthorizedDapp(
-                authorizedRequest.requestMetadata.dAppDefinitionAddress
-            )
+            authorizedDapp = dAppConnectionRepository.getAuthorizedDapp(args.dappDefinitionAddress)
             val allAuthorizedPersonas = authorizedDapp?.referencesToAuthorizedPersonas
             _state.update { state ->
                 val personas = generatePersonasListForDisplay(
@@ -72,9 +64,7 @@ class SelectPersonaViewModel @Inject constructor(
     private fun observePersonas() {
         viewModelScope.launch {
             getProfileUseCase.personasOnCurrentNetwork.collect { personas ->
-                authorizedDapp = dAppConnectionRepository.getAuthorizedDapp(
-                    authorizedRequest.requestMetadata.dAppDefinitionAddress
-                )
+                authorizedDapp = dAppConnectionRepository.getAuthorizedDapp(args.dappDefinitionAddress)
                 val allAuthorizedPersonas = authorizedDapp?.referencesToAuthorizedPersonas
                 _state.update { state ->
                     val personasListForDisplay = generatePersonasListForDisplay(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
@@ -45,7 +45,7 @@ fun OneTimeChooseAccountsScreen(
             when (event) {
                 is Event.LoginFlowCompleted -> onLoginFlowComplete()
                 is Event.PersonaDataOnetime -> onPersonaOnetime(event.requiredPersonaFields)
-                Event.RejectLogin -> onLoginFlowComplete()
+                Event.CloseLoginFlow -> onLoginFlowComplete()
                 is Event.RequestCompletionBiometricPrompt -> {
                     if (event.requestDuringSigning) {
                         sharedViewModel.sendRequestResponse(deviceBiometricAuthenticationProvider = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
@@ -48,7 +48,7 @@ fun DappUnauthorizedLoginScreen(
         null -> {}
     }
     LaunchedEffect(Unit) {
-        viewModel.oneOffEvent.filterIsInstance<Event.RejectLogin>().collect {
+        viewModel.oneOffEvent.filterIsInstance<Event.CloseLoginFlow>().collect {
             onLoginFlowComplete()
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/personaonetime/PersonaDataOnetimeScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/personaonetime/PersonaDataOnetimeScreen.kt
@@ -75,7 +75,7 @@ fun PersonaDataOnetimeScreen(
         sharedViewModel.oneOffEvent.collect { event ->
             when (event) {
                 is Event.LoginFlowCompleted -> onLoginFlowComplete()
-                Event.RejectLogin -> onLoginFlowCancelled()
+                Event.CloseLoginFlow -> onLoginFlowCancelled()
                 is Event.RequestCompletionBiometricPrompt -> {
                     if (event.requestDuringSigning) {
                         sharedViewModel.sendRequestResponse(deviceBiometricAuthenticationProvider = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
@@ -84,13 +84,14 @@ class TransactionStatusDialogViewModel @Inject constructor(
                 }.onFailure { error ->
                     if (!status.isInternal) {
                         (error as? DappRequestException)?.let { exception ->
-                            val request = incomingRequestRepository.getTransactionWriteRequest(status.requestId)
-                            dAppMessenger.sendWalletInteractionResponseFailure(
-                                remoteConnectorId = request.remoteConnectorId,
-                                requestId = status.requestId,
-                                error = exception.failure.toWalletErrorType(),
-                                message = exception.failure.getDappMessage()
-                            )
+                            incomingRequestRepository.getTransactionWriteRequest(status.requestId)?.let { transactionRequest ->
+                                dAppMessenger.sendWalletInteractionResponseFailure(
+                                    remoteConnectorId = transactionRequest.remoteConnectorId,
+                                    requestId = status.requestId,
+                                    error = exception.failure.toWalletErrorType(),
+                                    message = exception.failure.getDappMessage()
+                                )
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -38,7 +38,7 @@ class TransactionAnalysisDelegate(
 ) {
 
     suspend fun analyse() {
-        state.value.request.transactionManifestData.toTransactionManifest().onSuccess {
+        state.value.requestNonNull.transactionManifestData.toTransactionManifest().onSuccess {
             startAnalysis(it)
         }.onFailure { error ->
             reportFailure(error)
@@ -63,7 +63,7 @@ class TransactionAnalysisDelegate(
         manifest: TransactionManifest,
         notaryAndSigners: NotaryAndSigners
     ) = this.onSuccess { analysis ->
-        val previewType = if (state.value.request.isInternal.not() && analysis.reservedInstructions.isNotEmpty()) {
+        val previewType = if (state.value.requestNonNull.isInternal.not() && analysis.reservedInstructions.isNotEmpty()) {
             // wallet unacceptable manifest
             state.update {
                 it.copy(

--- a/app/src/test/java/com/babylon/wallet/android/presentation/dapp/selectpersona/SelectPersonaViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/dapp/selectpersona/SelectPersonaViewModelTest.kt
@@ -2,14 +2,12 @@ package com.babylon.wallet.android.presentation.dapp.selectpersona
 
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
-import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
 import com.babylon.wallet.android.domain.SampleDataProvider
-import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.fakes.DAppConnectionRepositoryFake
 import com.babylon.wallet.android.mockdata.profile
 import com.babylon.wallet.android.presentation.StateViewModelTest
+import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.ARG_DAPP_DEFINITION_ADDRESS
 import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.SelectPersonaViewModel
-import com.babylon.wallet.android.presentation.dapp.unauthorized.login.ARG_REQUEST_ID
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -26,40 +24,17 @@ import rdx.works.profile.domain.GetProfileUseCase
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class SelectPersonaViewModelTest : StateViewModelTest<SelectPersonaViewModel>() {
 
-    private val incomingRequestRepository = mockk<IncomingRequestRepository>()
     private val getProfileUseCase = mockk<GetProfileUseCase>()
     private val savedStateHandle = mockk<SavedStateHandle>()
     private val preferencesManager = mockk<PreferencesManager>()
     private val dAppConnectionRepository = DAppConnectionRepositoryFake()
-
-    private val requestWithNonExistingDappAddress = MessageFromDataChannel.IncomingRequest.AuthorizedRequest(
-        remoteConnectorId = "1",
-        interactionId = "1",
-        requestMetadata = MessageFromDataChannel.IncomingRequest.RequestMetadata(
-            11,
-            "",
-            "address",
-            false
-        ),
-        authRequest = MessageFromDataChannel.IncomingRequest.AuthorizedRequest.AuthRequest.LoginRequest.WithoutChallenge,
-        oneTimeAccountsRequestItem = null,
-        ongoingAccountsRequestItem = MessageFromDataChannel.IncomingRequest.AccountsRequestItem(
-            true,
-            MessageFromDataChannel.IncomingRequest.NumberOfValues(
-                1,
-                MessageFromDataChannel.IncomingRequest.NumberOfValues.Quantifier.AtLeast
-            ),
-            null
-        )
-    )
 
     override fun initVM(): SelectPersonaViewModel {
         return SelectPersonaViewModel(
             savedStateHandle,
             dAppConnectionRepository,
             getProfileUseCase,
-            preferencesManager,
-            incomingRequestRepository
+            preferencesManager
         )
     }
 
@@ -69,7 +44,7 @@ internal class SelectPersonaViewModelTest : StateViewModelTest<SelectPersonaView
         coEvery { preferencesManager.firstPersonaCreated } returns flow {
             emit(true)
         }
-        every { savedStateHandle.get<String>(ARG_REQUEST_ID) } returns "1"
+        every { savedStateHandle.get<String>(ARG_DAPP_DEFINITION_ADDRESS) } returns "address1"
         every { getProfileUseCase() } returns flowOf(
             profile(
                 personas = listOf(
@@ -78,7 +53,6 @@ internal class SelectPersonaViewModelTest : StateViewModelTest<SelectPersonaView
                 )
             )
         )
-        coEvery { incomingRequestRepository.getAuthorizedRequest(any()) } returns requestWithNonExistingDappAddress
     }
 
     @Test

--- a/core/src/main/java/rdx/works/core/EncryptionHelper.kt
+++ b/core/src/main/java/rdx/works/core/EncryptionHelper.kt
@@ -173,7 +173,7 @@ const val AES_ALGORITHM = "AES"
 private const val AES_GCM_NOPADDING = "AES/GCM/NoPadding"
 private const val AES_KEY_SIZE = 256
 private const val GCM_IV_LENGTH = 12
-private const val KEY_AUTHORIZATION_SECONDS = 10
+private const val KEY_AUTHORIZATION_SECONDS = 30 // seem that some low end devices take very long time to generate BDFS mnemonic
 private const val AUTH_TAG_LENGTH = 128 // bit
 
 sealed class KeySpec(val alias: String) {


### PR DESCRIPTION
## Description
- allow IncomingRequestRepository to return null for requests
- every view model that uses requests (dapp login flows and transaction review) is now checking up front if requests is not null, and if it is null, we break handling the flow
## Test scenarios
Crash was happening when user left app on dapp login flow/transaction review, system killed app, user reopened app from recent apps and view model accessed requests, which were no longer there since IncomingRequestRepository was recreated. 
Land on any dapp login flow or transaction review, background the app, kill process via Logcat/right click/kill process, and then try to re-open app from recent. Before this change, in every flow (authorized/unauthorized login and transaction review) app will crash.