### PR TITLE
[ABW-2372] Show network name instead of id when a dApp logins from another network

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/DappRequestFailure.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/DappRequestFailure.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.data.dapp.model.LedgerErrorCode
 import com.babylon.wallet.android.data.dapp.model.WalletErrorType
+import rdx.works.profile.data.model.apppreferences.Radix
 
 @Suppress("CyclomaticComplexMethod")
 sealed class DappRequestFailure(msg: String? = null) : Exception(msg.orEmpty()) {
@@ -14,7 +15,15 @@ sealed class DappRequestFailure(msg: String? = null) : Exception(msg.orEmpty()) 
     data object UnacceptableManifest : DappRequestFailure()
     data object InvalidPersona : DappRequestFailure()
     data class FailedToSignAuthChallenge(val msg: String = "") : DappRequestFailure(msg)
-    data class WrongNetwork(val currentNetworkId: Int, val requestNetworkId: Int) : DappRequestFailure()
+    data class WrongNetwork(
+        val currentNetworkId: Int,
+        val requestNetworkId: Int
+    ) : DappRequestFailure() {
+        val currentNetworkName: String
+            get() = runCatching { Radix.Network.fromId(currentNetworkId) }.getOrNull()?.name.orEmpty().replaceFirstChar(Char::titlecase)
+        val requestNetworkName: String
+            get() = runCatching { Radix.Network.fromId(requestNetworkId) }.getOrNull()?.name.orEmpty().replaceFirstChar(Char::titlecase)
+    }
 
     sealed class TransactionApprovalFailure : DappRequestFailure() {
         data object ConvertManifest : TransactionApprovalFailure()
@@ -96,7 +105,8 @@ sealed class DappRequestFailure(msg: String? = null) : Exception(msg.orEmpty()) 
             TransactionApprovalFailure.PrepareNotarizedTransaction -> R.string.error_transactionFailure_prepare
             RejectedByUser -> R.string.error_transactionFailure_rejectedByUser
             TransactionApprovalFailure.SubmitNotarizedTransaction -> R.string.error_transactionFailure_submit
-            is WrongNetwork -> R.string.error_transactionFailure_network
+            // Cannot use the correct error resource, since the correct one needs parameters to work
+            is WrongNetwork -> R.string.common_somethingWentWrong
             TransactionApprovalFailure.FailedToFindAccountWithEnoughFundsToLockFee ->
                 R.string.error_transactionFailure_noFundsToApproveTransaction
             DappVerificationFailure.RadixJsonNotFound -> R.string.dAppRequest_validationOutcome_shortExplanationBadContent

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
@@ -9,16 +9,22 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.babylon.wallet.android.R
+import com.babylon.wallet.android.data.transaction.DappRequestFailure
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.RequiredPersonaFields
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
 import com.babylon.wallet.android.presentation.dapp.InitialAuthorizedLoginRoute
+import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUiMessageHandler
+import kotlinx.coroutines.flow.filterIsInstance
 
 @Composable
 fun DappAuthorizedLoginScreen(
@@ -32,11 +38,8 @@ fun DappAuthorizedLoginScreen(
     modifier: Modifier = Modifier
 ) {
     LaunchedEffect(Unit) {
-        viewModel.oneOffEvent.collect { event ->
-            when (event) {
-                Event.RejectLogin -> onBackClick()
-                else -> {}
-            }
+        viewModel.oneOffEvent.filterIsInstance<Event.RejectLogin>().collect {
+            onBackClick()
         }
     }
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -76,6 +79,45 @@ fun DappAuthorizedLoginScreen(
         ) {
             FullscreenCircularProgressContent()
         }
+
+        when (val dialogState = state.failureDialog) {
+            is DAppLoginUiState.FailureDialog.Closed -> {}
+            is DAppLoginUiState.FailureDialog.Open -> {
+                BasicPromptAlertDialog(
+                    finish = { viewModel.onAcknowledgeFailureDialog() },
+                    title = {
+                        Text(
+                            text = stringResource(id = R.string.error_dappRequest_invalidRequest),
+                            style = RadixTheme.typography.body1Header,
+                            color = RadixTheme.colors.gray1
+                        )
+                    },
+                    text = {
+                        val failure = dialogState.dappRequestException.failure
+                        val errorMessage = if (failure is DappRequestFailure.WrongNetwork) {
+                            // This shows why we need to improve the exception structure.
+                            // It was impossible to define this resource as toDescriptionRes() since it also needs
+                            // parameters passed into it.
+                            stringResource(
+                                id = R.string.dAppRequest_requestWrongNetworkAlert_message,
+                                failure.requestNetworkName,
+                                failure.currentNetworkName
+                            )
+                        } else {
+                            stringResource(id = dialogState.dappRequestException.failure.toDescriptionRes())
+                        }
+                        Text(
+                            text = errorMessage,
+                            style = RadixTheme.typography.body2Regular,
+                            color = RadixTheme.colors.gray1
+                        )
+                    },
+                    confirmText = stringResource(id = R.string.common_cancel),
+                    dismissText = null
+                )
+            }
+        }
+
         SnackbarUiMessageHandler(
             message = state.uiMessage,
             onMessageShown = viewModel::onMessageShown,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/DappLoginUnauthorizedNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/DappLoginUnauthorizedNavGraph.kt
@@ -26,10 +26,14 @@ fun NavGraphBuilder.dappLoginUnauthorizedNavGraph(navController: NavController) 
             navController,
             navigateToChooseAccount = { numberOfAccounts, isExactAccountsCount ->
                 navController.chooseAccountsOneTime(numberOfAccounts, isExactAccountsCount)
+            },
+            navigateToOneTimePersonaData = {
+                navController.personaDataOnetimeUnauthorized(it)
+            },
+            onLoginFlowComplete = {
+                navController.popBackStack(ROUTE_DAPP_LOGIN_UNAUTHORIZED_GRAPH, true)
             }
-        ) {
-            navController.personaDataOnetimeUnauthorized(it)
-        }
+        )
         chooseAccountsOneTime(
             exitRequestFlow = {
                 navController.popBackStack()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginNav.kt
@@ -31,7 +31,8 @@ fun NavController.dAppLoginUnauthorized(requestId: String) {
 fun NavGraphBuilder.dAppLoginUnauthorized(
     navController: NavController,
     navigateToChooseAccount: (Int, Boolean) -> Unit,
-    navigateToOneTimePersonaData: (RequiredPersonaFields) -> Unit
+    navigateToOneTimePersonaData: (RequiredPersonaFields) -> Unit,
+    onLoginFlowComplete: () -> Unit
 ) {
     composable(
         route = ROUTE_DAPP_LOGIN_UNAUTHORIZED_SCREEN,
@@ -48,7 +49,8 @@ fun NavGraphBuilder.dAppLoginUnauthorized(
         DappUnauthorizedLoginScreen(
             viewModel = vm,
             navigateToOneTimePersonaData = navigateToOneTimePersonaData,
-            navigateToChooseAccount = navigateToChooseAccount
+            navigateToChooseAccount = navigateToChooseAccount,
+            onLoginFlowComplete = onLoginFlowComplete
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
@@ -12,21 +12,30 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.babylon.wallet.android.R
+import com.babylon.wallet.android.data.transaction.DappRequestFailure
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.RequiredPersonaFields
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
 import com.babylon.wallet.android.presentation.dapp.InitialUnauthorizedLoginRoute
+import com.babylon.wallet.android.presentation.dapp.unauthorized.login.DAppUnauthorizedLoginUiState.FailureDialog
+import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUiMessageHandler
+import kotlinx.coroutines.flow.filterIsInstance
 
 @Composable
 fun DappUnauthorizedLoginScreen(
     viewModel: DAppUnauthorizedLoginViewModel,
     navigateToChooseAccount: (Int, Boolean) -> Unit,
     navigateToOneTimePersonaData: (RequiredPersonaFields) -> Unit,
+    onLoginFlowComplete: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -38,6 +47,12 @@ fun DappUnauthorizedLoginScreen(
         is InitialUnauthorizedLoginRoute.OnetimePersonaData -> navigateToOneTimePersonaData(route.requiredPersonaFields)
         null -> {}
     }
+    LaunchedEffect(Unit) {
+        viewModel.oneOffEvent.filterIsInstance<Event.RejectLogin>().collect {
+            onLoginFlowComplete()
+        }
+    }
+
     Box(
         modifier = modifier
             .systemBarsPadding()
@@ -53,6 +68,45 @@ fun DappUnauthorizedLoginScreen(
         ) {
             FullscreenCircularProgressContent()
         }
+
+        when (val dialogState = state.failureDialog) {
+            is FailureDialog.Closed -> {}
+            is FailureDialog.Open -> {
+                BasicPromptAlertDialog(
+                    finish = { viewModel.onAcknowledgeFailureDialog() },
+                    title = {
+                        Text(
+                            text = stringResource(id = R.string.error_dappRequest_invalidRequest),
+                            style = RadixTheme.typography.body1Header,
+                            color = RadixTheme.colors.gray1
+                        )
+                    },
+                    text = {
+                        val failure = dialogState.dappRequestException.failure
+                        val errorMessage = if (failure is DappRequestFailure.WrongNetwork) {
+                            // This shows why we need to improve the exception structure.
+                            // It was impossible to define this resource as toDescriptionRes() since it also needs
+                            // parameters passed into it.
+                            stringResource(
+                                id = R.string.dAppRequest_requestWrongNetworkAlert_message,
+                                failure.requestNetworkName,
+                                failure.currentNetworkName
+                            )
+                        } else {
+                            stringResource(id = dialogState.dappRequestException.failure.toDescriptionRes())
+                        }
+                        Text(
+                            text = errorMessage,
+                            style = RadixTheme.typography.body2Regular,
+                            color = RadixTheme.colors.gray1
+                        )
+                    },
+                    confirmText = stringResource(id = R.string.common_cancel),
+                    dismissText = null
+                )
+            }
+        }
+
         SnackbarUiMessageHandler(
             message = state.uiMessage,
             onMessageShown = viewModel::onMessageShown,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
@@ -90,7 +90,7 @@ class SettingsEditGatewayViewModel @Inject constructor(
             _state.update { state -> state.copy(addingGateway = true) }
             val newGatewayInfo = networkInfoRepository.getNetworkInfo(newUrl)
             newGatewayInfo.onValue { networkName ->
-                addGatewayUseCase(Radix.Gateway(newUrl, Radix.Network.forName(networkName)))
+                addGatewayUseCase(Radix.Gateway(newUrl, Radix.Network.fromName(networkName)))
                 _state.update { state ->
                     state.copy(addingGateway = false, newUrl = "", newUrlValid = false)
                 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -344,7 +344,7 @@
   <string name="dAppRequest_validationOutcome_invalidRequestMessage">Could not validate the dApp.</string>
   <string name="dAppRequest_requestMalformedAlert_message">Request received from dApp is invalid.</string>
   <string name="dAppRequest_requestPersonaNotFoundAlert_message">dApp specified an invalid Persona.</string>
-  <string name="dAppRequest_requestWrongNetworkAlert_message">dApp made a requested intended for network %s, but you are currently connected to %s.</string>
+  <string name="dAppRequest_requestWrongNetworkAlert_message">dApp made a request intended for network %s, but you are currently connected to %s.</string>
   <string name="dAppRequest_responseFailureAlert_message">Failed to send request response to dApp.</string>
   <string name="dAppRequest_completion_title">Success</string>
   <string name="dAppRequest_completion_subtitle">Request from %s complete</string>
@@ -492,7 +492,7 @@
   <string name="error_transactionFailure_epoch">Failed to get epoch</string>
   <string name="error_transactionFailure_header">Failed to build transaction header</string>
   <string name="error_transactionFailure_manifest">Failed to convert transaction manifest</string>
-  <string name="error_transactionFailure_network">Wrong network</string>
+  <string name="error_transactionFailure_network">dApp made a request intended for %s network, but you are currently connected to %s network.</string>
   <string name="error_transactionFailure_noFundsToApproveTransaction">No funds to approve transaction</string>
   <string name="error_transactionFailure_pollStatus">Failed to poll transaction status</string>
   <string name="error_transactionFailure_prepare">Failed to prepare transaction</string>

--- a/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Radix.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Radix.kt
@@ -74,10 +74,14 @@ object Radix {
                 return listOf(mainnet, stokenet, hammunet, nebunet, kisharnet, mardunet, enkinet, ansharnet, zabanet)
             }
 
-            fun forName(name: String): Network {
+            fun fromName(name: String): Network {
                 return allKnownNetworks().first { network ->
                     network.name == name
                 }
+            }
+
+            fun fromId(id: Int): Network {
+                return allKnownNetworks().first { it.id == id }
             }
         }
     }


### PR DESCRIPTION
### Description
[Android: When receiving a Dapp request on wrong network, display network name instead of id.](https://radixdlt.atlassian.net/browse/ABW-2372)

### Notes
* Both login screens show a dialog, and when the error is related to `WrongNetwork` use the specific error message.
