### PR TITLE
[ABW-2411]properly compute derivation path for ledger account creation right af…

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountNav.kt
@@ -19,7 +19,7 @@ import com.google.accompanist.navigation.animation.composable
 const val ARG_NETWORK_URL = "arg_network_url"
 
 @VisibleForTesting
-const val ARG_NETWORK_NAME = "arg_network_name"
+const val ARG_NETWORK_ID = "arg_network_id"
 
 @VisibleForTesting
 const val ARG_SWITCH_NETWORK = "arg_switch_network"
@@ -27,13 +27,13 @@ const val ARG_SWITCH_NETWORK = "arg_switch_network"
 const val ROUTE_CREATE_ACCOUNT = "create_account_route" +
     "?$ARG_REQUEST_SOURCE={$ARG_REQUEST_SOURCE}" +
     "&$ARG_NETWORK_URL={$ARG_NETWORK_URL}" +
-    "&$ARG_NETWORK_NAME={$ARG_NETWORK_NAME}" +
+    "&$ARG_NETWORK_ID={$ARG_NETWORK_ID}" +
     "&$ARG_SWITCH_NETWORK={$ARG_SWITCH_NETWORK}"
 
 internal class CreateAccountNavArgs(
     val requestSource: CreateAccountRequestSource?,
     val networkUrlEncoded: String?,
-    val networkName: String?,
+    val networkId: Int,
     val switchNetwork: Boolean?,
 ) {
     constructor(savedStateHandle: SavedStateHandle) : this(
@@ -41,7 +41,7 @@ internal class CreateAccountNavArgs(
             ARG_REQUEST_SOURCE
         ),
         savedStateHandle.get<String>(ARG_NETWORK_URL),
-        savedStateHandle.get<String>(ARG_NETWORK_NAME),
+        checkNotNull(savedStateHandle.get<Int>(ARG_NETWORK_ID)),
         savedStateHandle.get<Boolean>(ARG_SWITCH_NETWORK)
     )
 }
@@ -49,7 +49,7 @@ internal class CreateAccountNavArgs(
 fun NavController.createAccountScreen(
     requestSource: CreateAccountRequestSource = CreateAccountRequestSource.FirstTime,
     networkUrl: String? = null,
-    networkName: String? = null,
+    networkId: Int = -1,
     switchNetwork: Boolean? = null,
     navOptions: NavOptions? = null
 ) {
@@ -57,8 +57,8 @@ fun NavController.createAccountScreen(
     networkUrl?.let {
         route += "&$ARG_NETWORK_URL=$it"
     }
-    networkName?.let {
-        route += "&$ARG_NETWORK_NAME=$it"
+    networkId.let {
+        route += "&$ARG_NETWORK_ID=$it"
     }
     switchNetwork?.let {
         route += "&$ARG_SWITCH_NETWORK=$it"
@@ -73,7 +73,7 @@ fun NavController.createAccountScreen(
 fun NavGraphBuilder.createAccountScreen(
     onBackClick: () -> Unit,
     onContinueClick: (accountId: String, requestSource: CreateAccountRequestSource?) -> Unit,
-    onAddLedgerDevice: () -> Unit
+    onAddLedgerDevice: (Int) -> Unit
 ) {
     markAsHighPriority(route = ROUTE_CREATE_ACCOUNT)
     composable(
@@ -87,9 +87,9 @@ fun NavGraphBuilder.createAccountScreen(
                 type = NavType.StringType
                 nullable = true
             },
-            navArgument(ARG_NETWORK_NAME) {
-                type = NavType.StringType
-                nullable = true
+            navArgument(ARG_NETWORK_ID) {
+                type = NavType.IntType
+                defaultValue = -1 // no network id, use current network
             },
             navArgument(ARG_SWITCH_NETWORK) {
                 type = NavType.BoolType

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountNav.kt
@@ -13,6 +13,7 @@ import androidx.navigation.navArgument
 import com.babylon.wallet.android.presentation.account.createaccount.confirmation.ARG_REQUEST_SOURCE
 import com.babylon.wallet.android.presentation.account.createaccount.confirmation.CreateAccountRequestSource
 import com.babylon.wallet.android.presentation.navigation.markAsHighPriority
+import com.babylon.wallet.android.utils.Constants
 import com.google.accompanist.navigation.animation.composable
 
 @VisibleForTesting
@@ -49,7 +50,7 @@ internal class CreateAccountNavArgs(
 fun NavController.createAccountScreen(
     requestSource: CreateAccountRequestSource = CreateAccountRequestSource.FirstTime,
     networkUrl: String? = null,
-    networkId: Int = -1,
+    networkId: Int = Constants.USE_CURRENT_NETWORK,
     switchNetwork: Boolean? = null,
     navOptions: NavOptions? = null
 ) {
@@ -89,7 +90,7 @@ fun NavGraphBuilder.createAccountScreen(
             },
             navArgument(ARG_NETWORK_ID) {
                 type = NavType.IntType
-                defaultValue = -1 // no network id, use current network
+                defaultValue = Constants.USE_CURRENT_NETWORK
             },
             navArgument(ARG_SWITCH_NETWORK) {
                 type = NavType.BoolType

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountScreen.kt
@@ -47,7 +47,7 @@ fun CreateAccountScreen(
         accountId: String,
         requestSource: CreateAccountRequestSource?,
     ) -> Unit = { _: String, _: CreateAccountRequestSource? -> },
-    onAddLedgerDevice: () -> Unit
+    onAddLedgerDevice: (Int) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     BackHandler(onBack = viewModel::onBackClick)
@@ -80,7 +80,7 @@ fun CreateAccountScreen(
                     event.requestSource
                 )
 
-                is CreateAccountEvent.AddLedgerDevice -> onAddLedgerDevice()
+                is CreateAccountEvent.AddLedgerDevice -> onAddLedgerDevice(event.networkId)
                 is CreateAccountEvent.Dismiss -> onBackClick()
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountViewModel.kt
@@ -123,7 +123,7 @@ class CreateAccountViewModel @Inject constructor(
             }
 
             if (state.value.useLedgerSelected) {
-                sendEvent(CreateAccountEvent.AddLedgerDevice)
+                sendEvent(CreateAccountEvent.AddLedgerDevice(args.networkId))
             } else {
                 handleAccountCreate { name, networkId ->
                     createAccountWithDeviceFactorSourceUseCase(
@@ -150,8 +150,8 @@ class CreateAccountViewModel @Inject constructor(
         var networkId: NetworkId? = null
         if (switchNetwork) {
             val networkUrl = args.networkUrlEncoded!!.decodeUtf8()
-            val networkName = args.networkName!!
-            networkId = switchNetworkUseCase(networkUrl, networkName)
+            val id = args.networkId
+            networkId = switchNetworkUseCase(networkUrl, id)
         }
         return networkId
     }
@@ -182,6 +182,6 @@ internal sealed interface CreateAccountEvent : OneOffEvent {
         val requestSource: CreateAccountRequestSource?,
     ) : CreateAccountEvent
 
-    data object AddLedgerDevice : CreateAccountEvent
+    data class AddLedgerDevice(val networkId: Int) : CreateAccountEvent
     data object Dismiss : CreateAccountEvent
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerNav.kt
@@ -1,18 +1,33 @@
 package com.babylon.wallet.android.presentation.account.createaccount.withledger
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import com.babylon.wallet.android.presentation.navigation.markAsHighPriority
 import com.google.accompanist.navigation.animation.composable
 
-private const val ROUTE_CREATE_ACCOUNT_WITH_LEDGER = "route_create_account_with_ledger"
+@VisibleForTesting
+const val ARG_NETWORK_ID = "arg_network_id"
 
-fun NavController.createAccountWithLedger() {
+private const val ROUTE_CREATE_ACCOUNT_WITH_LEDGER = "route_create_account_with_ledger?$ARG_NETWORK_ID={$ARG_NETWORK_ID}"
+
+internal class CreateAccountWithLedgerArgs(
+    val networkId: Int,
+) {
+    constructor(savedStateHandle: SavedStateHandle) : this(
+        checkNotNull(savedStateHandle.get<Int>(ARG_NETWORK_ID))
+    )
+}
+
+fun NavController.createAccountWithLedger(networkId: Int = -1) {
     navigate(
-        route = ROUTE_CREATE_ACCOUNT_WITH_LEDGER
+        route = "route_create_account_with_ledger?$ARG_NETWORK_ID=$networkId"
     )
 }
 
@@ -29,7 +44,13 @@ fun NavGraphBuilder.createAccountWithLedger(
         },
         exitTransition = {
             slideOutOfContainer(AnimatedContentScope.SlideDirection.Down)
-        }
+        },
+        arguments = listOf(
+            navArgument(ARG_NETWORK_ID) {
+                type = NavType.IntType
+                defaultValue = -1 // no network id, use current network
+            }
+        )
     ) {
         CreateAccountWithLedgerScreen(
             viewModel = hiltViewModel(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerNav.kt
@@ -10,6 +10,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.babylon.wallet.android.presentation.navigation.markAsHighPriority
+import com.babylon.wallet.android.utils.Constants
 import com.google.accompanist.navigation.animation.composable
 
 @VisibleForTesting
@@ -25,7 +26,7 @@ internal class CreateAccountWithLedgerArgs(
     )
 }
 
-fun NavController.createAccountWithLedger(networkId: Int = -1) {
+fun NavController.createAccountWithLedger(networkId: Int = Constants.USE_CURRENT_NETWORK) {
     navigate(
         route = "route_create_account_with_ledger?$ARG_NETWORK_ID=$networkId"
     )
@@ -48,7 +49,7 @@ fun NavGraphBuilder.createAccountWithLedger(
         arguments = listOf(
             navArgument(ARG_NETWORK_ID) {
                 type = NavType.IntType
-                defaultValue = -1 // no network id, use current network
+                defaultValue = Constants.USE_CURRENT_NETWORK
             }
         )
     ) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerViewModel.kt
@@ -13,6 +13,7 @@ import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiState
 import com.babylon.wallet.android.utils.AppEvent
 import com.babylon.wallet.android.utils.AppEventBus
+import com.babylon.wallet.android.utils.Constants
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -128,7 +129,7 @@ class CreateAccountWithLedgerViewModel @Inject constructor(
     }
 
     private suspend fun networkIdToCreateAccountOn(): Int {
-        return if (args.networkId == -1) {
+        return if (args.networkId == Constants.USE_CURRENT_NETWORK) {
             getCurrentGatewayUseCase.invoke().network.id
         } else {
             args.networkId

--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -181,7 +181,7 @@ fun NavigationHost(
                 )
             },
             onAddLedgerDevice = {
-                navController.createAccountWithLedger()
+                navController.createAccountWithLedger(networkId = it)
             }
         )
         createAccountWithLedger(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsNav.kt
@@ -112,11 +112,11 @@ private fun NavGraphBuilder.settingsGateway(navController: NavController) {
             onBackClick = {
                 navController.popBackStack()
             },
-            onCreateProfile = { url, networkName ->
+            onCreateProfile = { url, networkId ->
                 navController.createAccountScreen(
                     CreateAccountRequestSource.Gateways,
                     url,
-                    networkName,
+                    networkId,
                     true
                 )
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
@@ -65,7 +65,7 @@ import rdx.works.profile.data.model.apppreferences.Radix
 fun GatewaysScreen(
     viewModel: GatewaysViewModel,
     onBackClick: () -> Unit,
-    onCreateProfile: (String, String) -> Unit,
+    onCreateProfile: (String, Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -99,7 +99,7 @@ private fun GatewaysContent(
     addingGateway: Boolean,
     gatewayAddFailure: GatewayAddFailure?,
     onGatewayClick: (Radix.Gateway) -> Unit,
-    onCreateProfile: (String, String) -> Unit,
+    onCreateProfile: (String, Int) -> Unit,
     oneOffEvent: Flow<SettingsEditGatewayEvent>
 ) {
     val bottomSheetState =
@@ -114,7 +114,7 @@ private fun GatewaysContent(
         oneOffEvent.collect {
             when (it) {
                 is SettingsEditGatewayEvent.CreateProfileOnNetwork -> {
-                    onCreateProfile(it.newUrl, it.networkName)
+                    onCreateProfile(it.newUrl, it.networkId)
                 }
                 else -> {
                     scope.launch {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.gateway.AddGatewayUseCase
-import rdx.works.profile.domain.gateway.ChangeGatewayUseCase
+import rdx.works.profile.domain.gateway.ChangeGatewayIfNetworkExistUseCase
 import rdx.works.profile.domain.gateway.DeleteGatewayUseCase
 import rdx.works.profile.domain.gateways
 import rdx.works.profile.domain.security
@@ -33,7 +33,7 @@ import javax.inject.Inject
 @HiltViewModel
 class GatewaysViewModel @Inject constructor(
     private val getProfileUseCase: GetProfileUseCase,
-    private val changeGatewayUseCase: ChangeGatewayUseCase,
+    private val changeGatewayIfNetworkExistUseCase: ChangeGatewayIfNetworkExistUseCase,
     private val addGatewayUseCase: AddGatewayUseCase,
     private val deleteGatewayUseCase: DeleteGatewayUseCase,
     private val networkInfoRepository: NetworkInfoRepository,
@@ -135,12 +135,12 @@ class GatewaysViewModel @Inject constructor(
         // but at the time the user clicks to switch network the developer mode is disabled
         if (gateway.url.sanitizeAndValidateGatewayUrl(isDevModeEnabled = state.value.isDeveloperModeEnabled) == null) return
 
-        val isGatewayChanged = changeGatewayUseCase(gateway)
+        val isGatewayChanged = changeGatewayIfNetworkExistUseCase(gateway)
         if (isGatewayChanged) {
             _state.update { state -> state.copy(addingGateway = false) }
         } else {
             val urlEncoded = gateway.url.encodeUtf8()
-            sendEvent(SettingsEditGatewayEvent.CreateProfileOnNetwork(urlEncoded, gateway.network.name))
+            sendEvent(SettingsEditGatewayEvent.CreateProfileOnNetwork(urlEncoded, gateway.network.id))
         }
     }
 }
@@ -148,7 +148,7 @@ class GatewaysViewModel @Inject constructor(
 @VisibleForTesting
 internal sealed interface SettingsEditGatewayEvent : OneOffEvent {
     data object GatewayAdded : SettingsEditGatewayEvent
-    data class CreateProfileOnNetwork(val newUrl: String, val networkName: String) : SettingsEditGatewayEvent
+    data class CreateProfileOnNetwork(val newUrl: String, val networkId: Int) : SettingsEditGatewayEvent
 }
 
 data class SettingsUiState(

--- a/app/src/main/java/com/babylon/wallet/android/utils/Constants.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/Constants.kt
@@ -4,4 +4,5 @@ object Constants {
     const val VM_STOP_TIMEOUT_MS = 5000L
     const val DELAY_300_MS = 300L
     const val ACCOUNT_NAME_MAX_LENGTH = 30
+    const val USE_CURRENT_NETWORK = -1
 }

--- a/app/src/test/java/com/babylon/wallet/android/presentation/settings/editgateway/GatewaysViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/settings/editgateway/GatewaysViewModelTest.kt
@@ -24,7 +24,7 @@ import org.junit.Test
 import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.gateway.AddGatewayUseCase
-import rdx.works.profile.domain.gateway.ChangeGatewayUseCase
+import rdx.works.profile.domain.gateway.ChangeGatewayIfNetworkExistUseCase
 import rdx.works.profile.domain.gateway.DeleteGatewayUseCase
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -35,7 +35,7 @@ class GatewaysViewModelTest {
     private lateinit var vm: GatewaysViewModel
 
     private val getProfileUseCase = mockk<GetProfileUseCase>()
-    private val changeGatewayUseCase = mockk<ChangeGatewayUseCase>()
+    private val changeGatewayIfNetworkExistUseCase = mockk<ChangeGatewayIfNetworkExistUseCase>()
     private val addGatewayUseCase = mockk<AddGatewayUseCase>()
     private val deleteGatewayUseCase = mockk<DeleteGatewayUseCase>()
     private val networkInfoRepository = mockk<NetworkInfoRepository>()
@@ -46,13 +46,13 @@ class GatewaysViewModelTest {
     fun setUp() = runTest {
         vm = GatewaysViewModel(
             getProfileUseCase = getProfileUseCase,
-            changeGatewayUseCase = changeGatewayUseCase,
+            changeGatewayIfNetworkExistUseCase = changeGatewayIfNetworkExistUseCase,
             addGatewayUseCase = addGatewayUseCase,
             deleteGatewayUseCase = deleteGatewayUseCase,
             networkInfoRepository = networkInfoRepository
         )
         every { getProfileUseCase() } returns flowOf(profile)
-        coEvery { changeGatewayUseCase(any()) } returns true
+        coEvery { changeGatewayIfNetworkExistUseCase(any()) } returns true
         coEvery { addGatewayUseCase(any()) } returns Unit
         coEvery { networkInfoRepository.getNetworkInfo(any()) } returns Result.Success("nebunet")
         mockkStatic("com.babylon.wallet.android.utils.StringExtensionsKt")
@@ -90,7 +90,7 @@ class GatewaysViewModelTest {
         val sampleUrl = Radix.Gateway.kisharnet.url
         val gateway = Radix.Gateway(sampleUrl, Radix.Network.kisharnet)
         vm.onNewUrlChanged(sampleUrl)
-        coEvery { changeGatewayUseCase(gateway) } returns false
+        coEvery { changeGatewayIfNetworkExistUseCase(gateway) } returns false
         vm.onGatewayClick(Radix.Gateway(sampleUrl, Radix.Network.kisharnet))
         advanceUntilIdle()
         vm.oneOffEvent.test {
@@ -104,10 +104,10 @@ class GatewaysViewModelTest {
         val sampleUrl = Radix.Gateway.kisharnet.url
         val gateway = Radix.Gateway(sampleUrl, Radix.Network.kisharnet)
         vm.onNewUrlChanged(sampleUrl)
-        coEvery { changeGatewayUseCase(gateway) } returns true
+        coEvery { changeGatewayIfNetworkExistUseCase(gateway) } returns true
         vm.onGatewayClick(Radix.Gateway(sampleUrl, Radix.Network.kisharnet))
         advanceUntilIdle()
-        coVerify(exactly = 1) { changeGatewayUseCase(gateway) }
+        coVerify(exactly = 1) { changeGatewayIfNetworkExistUseCase(gateway) }
     }
 
     @Test
@@ -117,7 +117,7 @@ class GatewaysViewModelTest {
         vm.onNewUrlChanged(sampleUrl)
         vm.onGatewayClick(gateway)
         advanceUntilIdle()
-        coVerify(exactly = 0) { changeGatewayUseCase(gateway) }
+        coVerify(exactly = 0) { changeGatewayIfNetworkExistUseCase(gateway) }
         assert(vm.state.value.gatewayAddFailure == GatewayAddFailure.AlreadyExist)
     }
 

--- a/profile/src/main/java/rdx/works/profile/data/model/pernetwork/Network.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/pernetwork/Network.kt
@@ -568,7 +568,7 @@ fun Profile.addNetworkIfDoesNotExist(
 fun Profile.nextAccountIndex(
     forNetworkId: NetworkId
 ): Int {
-    return networks.first { it.networkID == forNetworkId.value }.accounts.size
+    return networks.firstOrNull { it.networkID == forNetworkId.value }?.accounts?.size ?: 0
 }
 
 fun Profile.nextPersonaIndex(

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -3,7 +3,6 @@ package rdx.works.profile.domain
 import com.radixdlt.ret.Address
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import rdx.works.core.PUBLIC_KEY_HASH_LENGTH
@@ -67,10 +66,6 @@ suspend fun GetProfileUseCase.factorSourceById(
     id: FactorSource.FactorSourceID
 ) = factorSources.first().firstOrNull { factorSource ->
     factorSource.id == id
-}
-
-suspend fun GetProfileUseCase.networkExist(networkId: Int): Network? {
-    return invoke().firstOrNull()?.networks?.find { network -> network.networkID == networkId }
 }
 
 suspend fun GetProfileUseCase.accountsOnCurrentNetwork() = accountsOnCurrentNetwork.first()

--- a/profile/src/main/java/rdx/works/profile/domain/account/SwitchNetworkUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/account/SwitchNetworkUseCase.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.apppreferences.changeGateway
+import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.pernetwork.addNetworkIfDoesNotExist
 import rdx.works.profile.data.repository.ProfileRepository
 import rdx.works.profile.data.repository.profile
@@ -18,15 +19,19 @@ class SwitchNetworkUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(
         networkUrl: String,
-        networkName: String
+        networkId: Int
     ): NetworkId {
         return withContext(defaultDispatcher) {
             val profile = profileRepository.profile.first()
-
+            val networkIdToSwitch = if (networkId == -1) {
+                profile.currentNetwork.networkID
+            } else {
+                networkId
+            }
             val gateway = Radix.Gateway(
                 url = networkUrl,
                 network = Radix.Network.allKnownNetworks().first { network ->
-                    network.name == networkName
+                    network.id == networkIdToSwitch
                 }
             )
             val updatedProfile = profile.addNetworkIfDoesNotExist(gateway.network.networkId()).changeGateway(gateway)

--- a/profile/src/main/java/rdx/works/profile/domain/gateway/ChangeGatewayIfNetworkExistUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/gateway/ChangeGatewayIfNetworkExistUseCase.kt
@@ -7,7 +7,7 @@ import rdx.works.profile.data.repository.ProfileRepository
 import rdx.works.profile.data.repository.profile
 import javax.inject.Inject
 
-class ChangeGatewayUseCase @Inject constructor(
+class ChangeGatewayIfNetworkExistUseCase @Inject constructor(
     private val profileRepository: ProfileRepository
 ) {
 

--- a/profile/src/test/java/rdx/works/profile/domain/account/SwitchNetworkUseCaseTest.kt
+++ b/profile/src/test/java/rdx/works/profile/domain/account/SwitchNetworkUseCaseTest.kt
@@ -41,7 +41,7 @@ internal class SwitchNetworkUseCaseTest {
 
     @Test
     fun `switching network changes profile current network`() = testScope.runTest {
-        val changedNetworkId = useCase.invoke(Radix.Gateway.kisharnet.url, Radix.Network.kisharnet.name)
+        val changedNetworkId = useCase.invoke(Radix.Gateway.kisharnet.url, Radix.Network.kisharnet.id)
         val updatedProfile = slot<Profile>()
         coVerify(exactly = 1) { profileRepository.saveProfile(capture(updatedProfile)) }
         assert(updatedProfile.captured.appPreferences.gateways.current().url == Radix.Gateway.kisharnet.url)


### PR DESCRIPTION
## Description
Issue is described in details [here](https://rdxworks.slack.com/archives/C05TD4RMF6W/p1696496663185939). I'm open for improvements here, I don't really like that default -1 value for networkId, but was not sure how I can make it better in reasonable time. Still I think passing id instead of name is already an improvement
## Test scenarios
- to reproduce crash, switch gateway to a new one (it only happens on initial switch when we are asked to create an account)
- create account with ledger - app will crash
Problem here was that we send derive ledger account request BEFORE we switch network, and we used current network nexAccountIndex. For software accounts we switch network in profile just moment before we create new account, so there is no issue here. Please note that after the crash, even without the fix, app behave as expected, because network is already there.