### PR TITLE
[ABW-2406] Detect no CE connection in add ledger flow

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
@@ -165,7 +165,7 @@ class LedgerMessengerImpl @Inject constructor(
                 }
             }
             is Error -> {
-                emit(Result.failure(Exception("Failed to sign transaction with Ledger", result.exception)))
+                emit(Result.failure(Exception("Failed to connect Ledger device ", result.exception)))
             }
         }
     }.first()

--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
@@ -8,6 +8,7 @@ import com.babylon.wallet.android.data.dapp.model.peerdroidRequestJson
 import com.babylon.wallet.android.data.transaction.DappRequestException
 import com.babylon.wallet.android.data.transaction.DappRequestFailure
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -20,6 +21,7 @@ import javax.inject.Inject
 
 interface LedgerMessenger {
 
+    val isConnected: Flow<Boolean>
     suspend fun sendDeviceInfoRequest(interactionId: String): Result<MessageFromDataChannel.LedgerResponse.GetDeviceInfoResponse>
 
     suspend fun signTransactionRequest(
@@ -55,6 +57,9 @@ interface LedgerMessenger {
 class LedgerMessengerImpl @Inject constructor(
     private val peerdroidClient: PeerdroidClient,
 ) : LedgerMessenger {
+
+    override val isConnected: Flow<Boolean>
+        get() = peerdroidClient.hasAtLeastOneConnection
 
     override suspend fun sendDeviceInfoRequest(interactionId: String): Result<MessageFromDataChannel.LedgerResponse.GetDeviceInfoResponse> {
         val ledgerRequest: LedgerInteractionRequest = LedgerInteractionRequest.GetDeviceInfo(interactionId)

--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/PeerdroidClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/PeerdroidClient.kt
@@ -33,6 +33,7 @@ import javax.inject.Inject
 
 interface PeerdroidClient {
 
+    val hasAtLeastOneConnection: Flow<Boolean>
     suspend fun connect(encryptionKey: ByteArray): Result<Unit>
 
     suspend fun sendMessage(
@@ -45,13 +46,12 @@ interface PeerdroidClient {
     ): Result<Unit>
 
     fun listenForIncomingRequests(): Flow<MessageFromDataChannel.IncomingRequest>
+    fun listenForLedgerResponses(): Flow<MessageFromDataChannel.LedgerResponse>
+    fun listenForIncomingRequestErrors(): Flow<MessageFromDataChannel.Error.DappRequest>
 
     suspend fun deleteLink(connectionPassword: String)
 
     fun terminate()
-    fun listenForLedgerResponses(): Flow<MessageFromDataChannel.LedgerResponse>
-    fun listenForIncomingRequestErrors(): Flow<MessageFromDataChannel.Error.DappRequest>
-    val anyChannelConnected: Flow<Boolean>
 }
 
 class PeerdroidClientImpl @Inject constructor(
@@ -101,7 +101,7 @@ class PeerdroidClientImpl @Inject constructor(
         return listenForIncomingMessages().filterIsInstance()
     }
 
-    override val anyChannelConnected: Flow<Boolean>
+    override val hasAtLeastOneConnection: Flow<Boolean>
         get() = peerdroidConnector.anyChannelConnected
 
     override fun listenForLedgerResponses(): Flow<MessageFromDataChannel.LedgerResponse> {

--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/PeerdroidClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/PeerdroidClient.kt
@@ -51,6 +51,7 @@ interface PeerdroidClient {
     fun terminate()
     fun listenForLedgerResponses(): Flow<MessageFromDataChannel.LedgerResponse>
     fun listenForIncomingRequestErrors(): Flow<MessageFromDataChannel.Error.DappRequest>
+    val anyChannelConnected: Flow<Boolean>
 }
 
 class PeerdroidClientImpl @Inject constructor(
@@ -99,6 +100,9 @@ class PeerdroidClientImpl @Inject constructor(
     override fun listenForIncomingRequestErrors(): Flow<MessageFromDataChannel.Error.DappRequest> {
         return listenForIncomingMessages().filterIsInstance()
     }
+
+    override val anyChannelConnected: Flow<Boolean>
+        get() = peerdroidConnector.anyChannelConnected
 
     override fun listenForLedgerResponses(): Flow<MessageFromDataChannel.LedgerResponse> {
         return listenForIncomingMessages().filterIsInstance()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerScreen.kt
@@ -26,6 +26,7 @@ import com.babylon.wallet.android.domain.SampleDataProvider
 import com.babylon.wallet.android.domain.model.Selectable
 import com.babylon.wallet.android.domain.model.toProfileLedgerDeviceModel
 import com.babylon.wallet.android.presentation.settings.accountsecurity.ledgerhardwarewallets.AddLedgerDeviceViewModel
+import com.babylon.wallet.android.presentation.settings.accountsecurity.ledgerhardwarewallets.ShowLinkConnectorPromptState
 import com.babylon.wallet.android.presentation.settings.appsettings.linkedconnectors.AddLinkConnectorViewModel
 import com.babylon.wallet.android.presentation.ui.composables.AddLedgerDeviceScreen
 import com.babylon.wallet.android.presentation.ui.composables.AddLinkConnectorScreen
@@ -121,13 +122,11 @@ fun CreateAccountWithLedgerScreen(
                 connectorDisplayName = addLinkConnectorState.connectorDisplayName,
                 isNewConnectorContinueButtonEnabled = addLinkConnectorState.isContinueButtonEnabled,
                 onNewConnectorContinueClick = {
-                    coroutineScope.launch {
-                        addLinkConnectorViewModel.onContinueClick()
-                        if (showContent.addDeviceAfterLinking) {
-                            viewModel.showAddLedgerDeviceContent()
-                        } else {
-                            viewModel.onCloseClick()
-                        }
+                    addLinkConnectorViewModel.onContinueClick()
+                    if (showContent.addDeviceAfterLinking) {
+                        viewModel.showAddLedgerDeviceContent()
+                    } else {
+                        viewModel.onCloseClick()
                     }
                 },
                 onNewConnectorCloseClick = {
@@ -163,7 +162,7 @@ fun CreateAccountWithLedgerScreen(
                     viewModel.onCloseClick()
                 },
                 onMessageShown = addLedgerDeviceViewModel::onMessageShown,
-                connectorExtensionConnected = addLedgerDeviceState.connectorExtensionConnected,
+                isLinkConnectionEstablished = addLedgerDeviceState.isLinkConnectionEstablished,
 //                hasP2PLinks = state.hasP2PLinks
             )
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerScreen.kt
@@ -98,7 +98,8 @@ fun CreateAccountWithLedgerScreen(
                     viewModel.onUseLedgerContinueClick(deviceBiometricAuthenticationProvider = {
                         context.biometricAuthenticateSuspend()
                     })
-                }
+                },
+                linkingToConnector = state.linkingToConnector
             )
         }
 
@@ -123,11 +124,7 @@ fun CreateAccountWithLedgerScreen(
                 isNewConnectorContinueButtonEnabled = addLinkConnectorState.isContinueButtonEnabled,
                 onNewConnectorContinueClick = {
                     addLinkConnectorViewModel.onContinueClick()
-                    if (showContent.addDeviceAfterLinking) {
-                        viewModel.showAddLedgerDeviceContent()
-                    } else {
-                        viewModel.onCloseClick()
-                    }
+                    viewModel.onNewConnectorAdded(showContent.addDeviceAfterLinking)
                 },
                 onNewConnectorCloseClick = {
                     addLinkConnectorViewModel.onCloseClick()
@@ -162,8 +159,7 @@ fun CreateAccountWithLedgerScreen(
                     viewModel.onCloseClick()
                 },
                 onMessageShown = addLedgerDeviceViewModel::onMessageShown,
-                isLinkConnectionEstablished = addLedgerDeviceState.isLinkConnectionEstablished,
-//                hasP2PLinks = state.hasP2PLinks
+                isLinkConnectionEstablished = addLedgerDeviceState.isLinkConnectionEstablished && state.linkingToConnector.not()
             )
         }
     }
@@ -176,7 +172,8 @@ private fun ChooseLedgerDeviceContent(
     onLedgerDeviceSelected: (LedgerHardwareWalletFactorSource) -> Unit,
     onUseLedgerContinueClick: () -> Unit,
     onAddLedgerDeviceClick: () -> Unit,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    linkingToConnector: Boolean
 ) {
     BackHandler { onBackClick() }
 
@@ -201,7 +198,8 @@ private fun ChooseLedgerDeviceContent(
                         vertical = RadixTheme.dimensions.paddingDefault
                     )
                     .navigationBarsPadding(),
-                enabled = ledgerDevices.any { it.selected }
+                enabled = ledgerDevices.any { it.selected } && linkingToConnector.not(),
+                isLoading = linkingToConnector
             )
         },
         containerColor = RadixTheme.colors.defaultBackground
@@ -235,7 +233,8 @@ fun CreateAccountWithLedgerScreenPreview() {
             onLedgerDeviceSelected = {},
             onUseLedgerContinueClick = {},
             onAddLedgerDeviceClick = {},
-            onBackClick = {}
+            onBackClick = {},
+            linkingToConnector = false
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -29,6 +30,7 @@ import com.babylon.wallet.android.presentation.settings.appsettings.linkedconnec
 import com.babylon.wallet.android.presentation.ui.composables.AddLedgerDeviceScreen
 import com.babylon.wallet.android.presentation.ui.composables.AddLinkConnectorScreen
 import com.babylon.wallet.android.presentation.ui.composables.BackIconType
+import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.ChooseLedgerDeviceSection
 import com.babylon.wallet.android.presentation.ui.composables.LinkConnectorScreen
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
@@ -60,7 +62,29 @@ fun CreateAccountWithLedgerScreen(
             }
         }
     }
-
+    val promptState = state.showLinkConnectorPromptState
+    if (promptState is ShowLinkConnectorPromptState.Show) {
+        BasicPromptAlertDialog(
+            finish = {
+                viewModel.dismissConnectorPrompt(it, promptState.source)
+            },
+            title = {
+                Text(
+                    text = stringResource(id = R.string.ledgerHardwareDevices_linkConnectorAlert_title),
+                    style = RadixTheme.typography.body1Header,
+                    color = RadixTheme.colors.gray1
+                )
+            },
+            text = {
+                Text(
+                    text = stringResource(id = R.string.ledgerHardwareDevices_linkConnectorAlert_message),
+                    style = RadixTheme.typography.body2Regular,
+                    color = RadixTheme.colors.gray1
+                )
+            },
+            confirmText = stringResource(id = R.string.ledgerHardwareDevices_linkConnectorAlert_continue)
+        )
+    }
     when (val showContent = state.showContent) {
         CreateAccountWithLedgerUiState.ShowContent.ChooseLedger -> {
             ChooseLedgerDeviceContent(
@@ -100,7 +124,7 @@ fun CreateAccountWithLedgerScreen(
                     coroutineScope.launch {
                         addLinkConnectorViewModel.onContinueClick()
                         if (showContent.addDeviceAfterLinking) {
-                            viewModel.onAddLedgerDeviceClick()
+                            viewModel.showAddLedgerDeviceContent()
                         } else {
                             viewModel.onCloseClick()
                         }
@@ -138,7 +162,9 @@ fun CreateAccountWithLedgerScreen(
                     addLedgerDeviceViewModel.initState()
                     viewModel.onCloseClick()
                 },
-                onMessageShown = addLedgerDeviceViewModel::onMessageShown
+                onMessageShown = addLedgerDeviceViewModel::onMessageShown,
+                connectorExtensionConnected = addLedgerDeviceState.connectorExtensionConnected,
+//                hasP2PLinks = state.hasP2PLinks
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -404,9 +404,9 @@ private fun ImportLegacyWalletContent(
             AddLedgerDeviceScreen(
                 modifier = Modifier
                     .fillMaxSize(),
+                showContent = addLedgerSheetState,
                 deviceModel = deviceModel,
                 onSendAddLedgerRequestClick = onContinueWithLedgerClick,
-                showContent = addLedgerSheetState,
                 onConfirmLedgerNameClick = {
                     onConfirmLedgerName(it)
                     onCloseSettings()
@@ -414,7 +414,8 @@ private fun ImportLegacyWalletContent(
                 backIconType = BackIconType.Back,
                 onClose = onCloseSettings,
                 waitingForLedgerResponse = waitingForLedgerResponse,
-                onBackClick = onCloseSettings
+                onBackClick = onCloseSettings,
+                connectorExtensionConnected = true
 
             )
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -117,8 +117,6 @@ fun ImportLegacyWalletScreen(
     val context = LocalContext.current
     val state by viewModel.state.collectAsStateWithLifecycle()
     val addLinkConnectorState by addLinkConnectorViewModel.state.collectAsStateWithLifecycle()
-    val coroutineScope = rememberCoroutineScope()
-
     ImportLegacyWalletContent(
         modifier = modifier,
         onBackClick = viewModel::onBackClick,
@@ -161,10 +159,8 @@ fun ImportLegacyWalletScreen(
         onLinkConnectorQrCodeScanned = addLinkConnectorViewModel::onQrCodeScanned,
         onConnectorDisplayNameChanged = addLinkConnectorViewModel::onConnectorDisplayNameChanged,
         onNewConnectorContinueClick = {
-            coroutineScope.launch {
-                addLinkConnectorViewModel.onContinueClick()
-                viewModel.onNewConnectorAdded()
-            }
+            addLinkConnectorViewModel.onContinueClick()
+            viewModel.onNewConnectorAdded()
         },
         onNewConnectorCloseClick = {
             addLinkConnectorViewModel.onCloseClick()
@@ -415,7 +411,7 @@ private fun ImportLegacyWalletContent(
                 onClose = onCloseSettings,
                 waitingForLedgerResponse = waitingForLedgerResponse,
                 onBackClick = onCloseSettings,
-                connectorExtensionConnected = true
+                isLinkConnectionEstablished = true
 
             )
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletViewModel.kt
@@ -93,7 +93,7 @@ class ImportLegacyWalletViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            peerdroidClient.anyChannelConnected.collect { connected ->
+            peerdroidClient.hasAtLeastOneConnection.collect { connected ->
                 _state.update { it.copy(connectorExtensionConnected = connected) }
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletViewModel.kt
@@ -4,7 +4,6 @@ package com.babylon.wallet.android.presentation.settings.accountsecurity.importl
 
 import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.data.dapp.LedgerMessenger
-import com.babylon.wallet.android.data.dapp.PeerdroidClient
 import com.babylon.wallet.android.data.dapp.model.Curve
 import com.babylon.wallet.android.data.dapp.model.LedgerInteractionRequest
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
@@ -66,8 +65,7 @@ class ImportLegacyWalletViewModel @Inject constructor(
     private val getFactorSourceIdForOlympiaAccountsUseCase: GetFactorSourceIdForOlympiaAccountsUseCase,
     private val getProfileUseCase: GetProfileUseCase,
     private val olympiaWalletDataParser: OlympiaWalletDataParser,
-    private val markImportOlympiaWalletCompleteUseCase: MarkImportOlympiaWalletCompleteUseCase,
-    private val peerdroidClient: PeerdroidClient
+    private val markImportOlympiaWalletCompleteUseCase: MarkImportOlympiaWalletCompleteUseCase
 ) : StateViewModel<ImportLegacyWalletUiState>(), OneOffEventHandler<OlympiaImportEvent> by OneOffEventHandlerImpl() {
 
     private val scannedData = mutableSetOf<String>()
@@ -93,8 +91,8 @@ class ImportLegacyWalletViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            peerdroidClient.hasAtLeastOneConnection.collect { connected ->
-                _state.update { it.copy(connectorExtensionConnected = connected) }
+            ledgerMessenger.isConnected.collect { connected ->
+                _state.update { it.copy(isLinkConnectionEstablished = connected) }
             }
         }
         viewModelScope.launch {
@@ -452,7 +450,7 @@ class ImportLegacyWalletViewModel @Inject constructor(
     fun onContinueWithLedgerClick() {
         viewModelScope.launch {
             if (getProfileUseCase.p2pLinks.first().isNotEmpty()) {
-                if (state.value.connectorExtensionConnected.not()) {
+                if (state.value.isLinkConnectionEstablished.not()) {
                     _state.update {
                         it.copy(shouldShowAddLinkConnectorScreen = true)
                     }
@@ -530,7 +528,7 @@ data class ImportLegacyWalletUiState(
     val shouldShowAddLinkConnectorScreen: Boolean = false,
     val shouldShowAddLedgerDeviceScreen: Boolean = false,
     var existingOlympiaFactorSourceId: FactorSourceID.FromHash? = null,
-    val connectorExtensionConnected: Boolean = false
+    val isLinkConnectionEstablished: Boolean = false
 ) : UiState {
 
     fun mnemonicWithPassphrase(): MnemonicWithPassphrase {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
@@ -77,6 +77,7 @@ fun LedgerHardwareWalletsScreen(
             LedgerHardwareWalletsUiState.ShowContent.AddLedger -> {
                 AddLedgerDeviceScreen(
                     showContent = addLedgerDeviceState.showContent,
+                    uiMessage = addLedgerDeviceState.uiMessage,
                     deviceModel = addLedgerDeviceState.newConnectedLedgerDevice?.model?.toProfileLedgerDeviceModel()?.value,
                     onSendAddLedgerRequestClick = addLedgerDeviceViewModel::onSendAddLedgerRequestClick,
                     onConfirmLedgerNameClick = {
@@ -86,6 +87,7 @@ fun LedgerHardwareWalletsScreen(
                         }
                     },
                     backIconType = BackIconType.Back,
+                    onMessageShown = addLedgerDeviceViewModel::onMessageShown,
                     onClose = {
                         addLedgerDeviceViewModel.initState()
                         viewModel.onCloseClick()
@@ -95,8 +97,7 @@ fun LedgerHardwareWalletsScreen(
                         addLedgerDeviceViewModel.initState()
                         viewModel.onCloseClick()
                     },
-                    onMessageShown = addLedgerDeviceViewModel::onMessageShown,
-                    uiMessage = addLedgerDeviceState.uiMessage
+                    connectorExtensionConnected = addLedgerDeviceState.connectorExtensionConnected
                 )
             }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
@@ -67,7 +67,7 @@ fun LedgerHardwareWalletsScreen(
     if (promptState is ShowLinkConnectorPromptState.Show) {
         BasicPromptAlertDialog(
             finish = {
-                viewModel.dismissConnectorPrompt(it, promptState.source)
+                viewModel.dismissConnectorPrompt(it)
             },
             title = {
                 Text(
@@ -95,7 +95,7 @@ fun LedgerHardwareWalletsScreen(
                     ledgerDevices = state.ledgerDevices,
                     onAddLedgerDeviceClick = viewModel::onAddLedgerDeviceClick,
                     onBackClick = onBackClick,
-                    linkingToConnector = state.linkingToConnector
+                    linkingToConnector = state.isAddLedgerButtonEnabled
                 )
             }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
@@ -95,7 +95,7 @@ fun LedgerHardwareWalletsScreen(
                     ledgerDevices = state.ledgerDevices,
                     onAddLedgerDeviceClick = viewModel::onAddLedgerDeviceClick,
                     onBackClick = onBackClick,
-                    addLedgerEnabled = state.addLedgerEnabled
+                    linkingToConnector = state.linkingToConnector
                 )
             }
 
@@ -164,7 +164,7 @@ private fun LedgerHardwareWalletsContent(
     ledgerDevices: ImmutableList<LedgerHardwareWalletFactorSource>,
     onAddLedgerDeviceClick: () -> Unit,
     onBackClick: () -> Unit,
-    addLedgerEnabled: Boolean,
+    linkingToConnector: Boolean,
 ) {
     BackHandler(onBack = onBackClick)
 
@@ -184,7 +184,7 @@ private fun LedgerHardwareWalletsContent(
                 modifier = Modifier.fillMaxWidth(),
                 ledgerFactorSources = ledgerDevices,
                 onAddLedgerDeviceClick = onAddLedgerDeviceClick,
-                addLedgerEnabled = addLedgerEnabled
+                linkingToConnector = linkingToConnector
             )
         }
     }
@@ -195,7 +195,7 @@ private fun LedgerDeviceDetails(
     modifier: Modifier = Modifier,
     ledgerFactorSources: ImmutableList<LedgerHardwareWalletFactorSource>,
     onAddLedgerDeviceClick: () -> Unit,
-    addLedgerEnabled: Boolean
+    linkingToConnector: Boolean
 ) {
     Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
@@ -213,7 +213,7 @@ private fun LedgerDeviceDetails(
                     .fillMaxWidth(),
                 ledgerDevices = ledgerFactorSources,
                 onAddLedgerDeviceClick = onAddLedgerDeviceClick,
-                addLedgerEnabled = addLedgerEnabled
+                linkingToConnector = linkingToConnector
             )
         } else {
             Text(
@@ -235,7 +235,7 @@ private fun LedgerDeviceDetails(
                 modifier = Modifier
                     .fillMaxWidth(0.7f)
                     .imePadding(),
-                enabled = addLedgerEnabled,
+                enabled = linkingToConnector.not(),
                 throttleClicks = true
             )
         }
@@ -247,7 +247,7 @@ private fun LedgerDevicesListContent(
     modifier: Modifier = Modifier,
     ledgerDevices: ImmutableList<LedgerHardwareWalletFactorSource>,
     onAddLedgerDeviceClick: () -> Unit,
-    addLedgerEnabled: Boolean
+    linkingToConnector: Boolean
 ) {
     LazyColumn(
         modifier,
@@ -281,7 +281,7 @@ private fun LedgerDevicesListContent(
                 text = stringResource(id = R.string.ledgerHardwareDevices_addNewLedger),
                 onClick = onAddLedgerDeviceClick,
                 throttleClicks = true,
-                enabled = addLedgerEnabled
+                enabled = linkingToConnector.not()
             )
         }
     }
@@ -295,7 +295,7 @@ fun LedgerHardwareWalletsScreenEmptyPreview() {
             ledgerDevices = persistentListOf(),
             onAddLedgerDeviceClick = {},
             onBackClick = {},
-            addLedgerEnabled = true
+            linkingToConnector = true
         )
     }
 }
@@ -308,7 +308,7 @@ fun LedgerHardwareWalletsScreenPreview() {
             ledgerDevices = SampleDataProvider().ledgerFactorSourcesSample.toPersistentList(),
             onAddLedgerDeviceClick = {},
             onBackClick = {},
-            addLedgerEnabled = true
+            linkingToConnector = true
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsViewModel.kt
@@ -81,13 +81,13 @@ class LedgerHardwareWalletsViewModel @Inject constructor(
         _state.update {
             it.copy(
                 showContent = LedgerHardwareWalletsUiState.ShowContent.Details,
-                addLedgerEnabled = false
+                linkingToConnector = true
             )
         }
         viewModelScope.launch {
             ledgerMessenger.isConnected.filter { it }.firstOrNull()?.let {
                 _state.update { state ->
-                    state.copy(addLedgerEnabled = true)
+                    state.copy(linkingToConnector = false)
                 }
             }
         }
@@ -118,7 +118,7 @@ data class LedgerHardwareWalletsUiState(
     val ledgerDevices: ImmutableList<LedgerHardwareWalletFactorSource> = persistentListOf(),
     val showLinkConnectorPromptState: ShowLinkConnectorPromptState = ShowLinkConnectorPromptState.None,
     val isLinkConnectionEstablished: Boolean = false,
-    val addLedgerEnabled: Boolean = true
+    val linkingToConnector: Boolean = false
 ) : UiState {
 
     sealed interface ShowContent {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsViewModel.kt
@@ -45,7 +45,7 @@ class LedgerHardwareWalletsViewModel @Inject constructor(
     fun onAddLedgerDeviceClick() {
         viewModelScope.launch {
             if (getProfileUseCase.p2pLinks.first().isEmpty()) {
-                _state.update { it.copy(showContent = LedgerHardwareWalletsUiState.ShowContent.LinkNewConnector(false)) }
+                _state.update { it.copy(showContent = LedgerHardwareWalletsUiState.ShowContent.LinkNewConnector) }
             } else {
                 if (!state.value.isLinkConnectionEstablished) {
                     _state.update {
@@ -62,13 +62,11 @@ class LedgerHardwareWalletsViewModel @Inject constructor(
         }
     }
 
-    fun dismissConnectorPrompt(linkConnector: Boolean, source: ShowLinkConnectorPromptState.Source) {
+    fun dismissConnectorPrompt(linkConnector: Boolean) {
         _state.update {
             it.copy(
                 showContent = if (linkConnector) {
-                    LedgerHardwareWalletsUiState.ShowContent.LinkNewConnector(
-                        source == ShowLinkConnectorPromptState.Source.AddLedgerDevice
-                    )
+                    LedgerHardwareWalletsUiState.ShowContent.LinkNewConnector
                 } else {
                     it.showContent
                 },
@@ -81,13 +79,13 @@ class LedgerHardwareWalletsViewModel @Inject constructor(
         _state.update {
             it.copy(
                 showContent = LedgerHardwareWalletsUiState.ShowContent.Details,
-                linkingToConnector = true
+                isAddLedgerButtonEnabled = true
             )
         }
         viewModelScope.launch {
             ledgerMessenger.isConnected.filter { it }.firstOrNull()?.let {
                 _state.update { state ->
-                    state.copy(linkingToConnector = false)
+                    state.copy(isAddLedgerButtonEnabled = false)
                 }
             }
         }
@@ -101,7 +99,7 @@ class LedgerHardwareWalletsViewModel @Inject constructor(
 
     fun onLinkConnectorClick() {
         _state.update {
-            it.copy(showContent = LedgerHardwareWalletsUiState.ShowContent.AddLinkConnector(false))
+            it.copy(showContent = LedgerHardwareWalletsUiState.ShowContent.AddLinkConnector)
         }
     }
 
@@ -118,13 +116,13 @@ data class LedgerHardwareWalletsUiState(
     val ledgerDevices: ImmutableList<LedgerHardwareWalletFactorSource> = persistentListOf(),
     val showLinkConnectorPromptState: ShowLinkConnectorPromptState = ShowLinkConnectorPromptState.None,
     val isLinkConnectionEstablished: Boolean = false,
-    val linkingToConnector: Boolean = false
+    val isAddLedgerButtonEnabled: Boolean = false
 ) : UiState {
 
     sealed interface ShowContent {
         data object Details : ShowContent
         data object AddLedger : ShowContent
-        data class LinkNewConnector(val addDeviceAfterLinking: Boolean = true) : ShowContent
-        data class AddLinkConnector(val addDeviceAfterLinking: Boolean = true) : ShowContent
+        data object LinkNewConnector : ShowContent
+        data object AddLinkConnector : ShowContent
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,7 +43,6 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAp
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.launch
 import rdx.works.profile.data.model.apppreferences.P2PLink
 
 @Composable
@@ -56,8 +54,6 @@ fun LinkedConnectorsScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val addLinkConnectorState by addLinkConnectorViewModel.state.collectAsStateWithLifecycle()
-    val coroutineScope = rememberCoroutineScope()
-
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.collect { event ->
             when (event) {
@@ -76,10 +72,8 @@ fun LinkedConnectorsScreen(
             connectorDisplayName = addLinkConnectorState.connectorDisplayName,
             isNewConnectorContinueButtonEnabled = addLinkConnectorState.isContinueButtonEnabled,
             onNewConnectorContinueClick = {
-                coroutineScope.launch {
-                    addLinkConnectorViewModel.onContinueClick()
-                    viewModel.onNewConnectorCloseClick()
-                }
+                addLinkConnectorViewModel.onContinueClick()
+                viewModel.onNewConnectorCloseClick()
             },
             onNewConnectorCloseClick = {
                 addLinkConnectorViewModel.onCloseClick()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsViewModel.kt
@@ -70,8 +70,8 @@ class LinkedConnectorsViewModel @Inject constructor(
     }
 }
 
-sealed interface Event : OneOffEvent {
-    object Close : Event
+internal sealed interface Event : OneOffEvent {
+    data object Close : Event
 }
 
 data class LinkedConnectorsUiState(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
@@ -54,7 +54,7 @@ fun AddLedgerDeviceScreen(
     onClose: () -> Unit,
     waitingForLedgerResponse: Boolean,
     onBackClick: () -> Unit,
-    connectorExtensionConnected: Boolean
+    isLinkConnectionEstablished: Boolean
 ) {
     BackHandler(onBack = onBackClick)
 
@@ -140,8 +140,8 @@ fun AddLedgerDeviceScreen(
                                 modifier = Modifier.fillMaxWidth(),
                                 onClick = onSendAddLedgerRequestClick,
                                 text = stringResource(id = com.babylon.wallet.android.R.string.addLedgerDevice_addDevice_continue),
-                                enabled = connectorExtensionConnected,
-                                isLoading = !connectorExtensionConnected
+                                enabled = isLinkConnectionEstablished,
+                                isLoading = !isLinkConnectionEstablished
                             )
                         }
 
@@ -230,7 +230,7 @@ fun AddLedgerDeviceScreenPreview() {
             onClose = {},
             waitingForLedgerResponse = false,
             onBackClick = {},
-            connectorExtensionConnected = true
+            isLinkConnectionEstablished = true
         )
     }
 }
@@ -251,7 +251,7 @@ fun AddLedgerDeviceContentPreview3() {
             onClose = {},
             waitingForLedgerResponse = false,
             onBackClick = {},
-            connectorExtensionConnected = true
+            isLinkConnectionEstablished = true
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
@@ -53,7 +53,8 @@ fun AddLedgerDeviceScreen(
     onMessageShown: () -> Unit = {},
     onClose: () -> Unit,
     waitingForLedgerResponse: Boolean,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    connectorExtensionConnected: Boolean
 ) {
     BackHandler(onBack = onBackClick)
 
@@ -138,7 +139,9 @@ fun AddLedgerDeviceScreen(
                             RadixPrimaryButton(
                                 modifier = Modifier.fillMaxWidth(),
                                 onClick = onSendAddLedgerRequestClick,
-                                text = stringResource(id = com.babylon.wallet.android.R.string.addLedgerDevice_addDevice_continue)
+                                text = stringResource(id = com.babylon.wallet.android.R.string.addLedgerDevice_addDevice_continue),
+                                enabled = connectorExtensionConnected,
+                                isLoading = !connectorExtensionConnected
                             )
                         }
 
@@ -223,10 +226,11 @@ fun AddLedgerDeviceScreenPreview() {
             onSendAddLedgerRequestClick = {},
             onConfirmLedgerNameClick = { },
             backIconType = BackIconType.Back,
+            onMessageShown = {},
             onClose = {},
             waitingForLedgerResponse = false,
-            onMessageShown = {},
-            onBackClick = {}
+            onBackClick = {},
+            connectorExtensionConnected = true
         )
     }
 }
@@ -243,10 +247,11 @@ fun AddLedgerDeviceContentPreview3() {
             onSendAddLedgerRequestClick = {},
             onConfirmLedgerNameClick = { },
             backIconType = BackIconType.Back,
+            onMessageShown = {},
             onClose = {},
             waitingForLedgerResponse = false,
-            onMessageShown = {},
-            onBackClick = {}
+            onBackClick = {},
+            connectorExtensionConnected = true
         )
     }
 }

--- a/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/AddLedgerDeviceViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/AddLedgerDeviceViewModelTest.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.presentation.createaccount.withledger
 
 import app.cash.turbine.test
 import com.babylon.wallet.android.data.dapp.LedgerMessenger
+import com.babylon.wallet.android.data.dapp.PeerdroidClient
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.mockdata.profile
 import com.babylon.wallet.android.presentation.StateViewModelTest
@@ -14,6 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Test
 import rdx.works.core.HexCoded32Bytes
 import rdx.works.profile.data.model.factorsources.LedgerHardwareWalletFactorSource
@@ -28,14 +30,21 @@ class AddLedgerDeviceViewModelTest : StateViewModelTest<AddLedgerDeviceViewModel
 
     private val getProfileUseCaseMock = mockk<GetProfileUseCase>()
     private val ledgerMessengerMock = mockk<LedgerMessenger>()
+    private val peerdroidClient = mockk<PeerdroidClient>()
     private val addLedgerFactorSourceUseCaseMock = mockk<AddLedgerFactorSourceUseCase>()
 
     override fun initVM(): AddLedgerDeviceViewModel {
         return AddLedgerDeviceViewModel(
             getProfileUseCase = getProfileUseCaseMock,
             ledgerMessenger = ledgerMessengerMock,
-            addLedgerFactorSourceUseCase = addLedgerFactorSourceUseCaseMock
+            addLedgerFactorSourceUseCase = addLedgerFactorSourceUseCaseMock,
+            peerdroidClient = peerdroidClient
         )
+    }
+
+    @Before
+    fun setup() {
+        coEvery { peerdroidClient.anyChannelConnected } returns flowOf(true)
     }
 
     @Test

--- a/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/AddLedgerDeviceViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/AddLedgerDeviceViewModelTest.kt
@@ -2,7 +2,6 @@ package com.babylon.wallet.android.presentation.createaccount.withledger
 
 import app.cash.turbine.test
 import com.babylon.wallet.android.data.dapp.LedgerMessenger
-import com.babylon.wallet.android.data.dapp.PeerdroidClient
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.mockdata.profile
 import com.babylon.wallet.android.presentation.StateViewModelTest
@@ -30,21 +29,19 @@ class AddLedgerDeviceViewModelTest : StateViewModelTest<AddLedgerDeviceViewModel
 
     private val getProfileUseCaseMock = mockk<GetProfileUseCase>()
     private val ledgerMessengerMock = mockk<LedgerMessenger>()
-    private val peerdroidClient = mockk<PeerdroidClient>()
     private val addLedgerFactorSourceUseCaseMock = mockk<AddLedgerFactorSourceUseCase>()
 
     override fun initVM(): AddLedgerDeviceViewModel {
         return AddLedgerDeviceViewModel(
             getProfileUseCase = getProfileUseCaseMock,
             ledgerMessenger = ledgerMessengerMock,
-            addLedgerFactorSourceUseCase = addLedgerFactorSourceUseCaseMock,
-            peerdroidClient = peerdroidClient
+            addLedgerFactorSourceUseCase = addLedgerFactorSourceUseCaseMock
         )
     }
 
     @Before
     fun setup() {
-        coEvery { peerdroidClient.anyChannelConnected } returns flowOf(true)
+        coEvery { ledgerMessengerMock.isConnected } returns flowOf(true)
     }
 
     @Test

--- a/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/CreateAccountWithLedgerViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/CreateAccountWithLedgerViewModelTest.kt
@@ -2,7 +2,6 @@ package com.babylon.wallet.android.presentation.createaccount.withledger
 
 import app.cash.turbine.test
 import com.babylon.wallet.android.data.dapp.LedgerMessenger
-import com.babylon.wallet.android.data.dapp.PeerdroidClient
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.mockdata.profile
 import com.babylon.wallet.android.presentation.StateViewModelTest
@@ -39,19 +38,18 @@ internal class CreateAccountWithLedgerViewModelTest : StateViewModelTest<CreateA
     private val addLedgerFactorSourceUseCase = mockk<AddLedgerFactorSourceUseCase>()
     private val ensureBabylonFactorSourceExistUseCase = mockk<EnsureBabylonFactorSourceExistUseCase>()
     private val eventBus = mockk<AppEventBus>()
-    private val peerdroidClient = mockk<PeerdroidClient>()
 
     private val firstDeviceId = "5f47ec336e9e7891bff04004c817201e73c097b6b1e1b3a26bc501e0010996f5"
     private val secondDeviceId = "5f07ec336e9e7891bff04004c817201e73c097b6b1e1b3a26bc501e0010196f5"
 
     override fun initVM(): CreateAccountWithLedgerViewModel {
-        return CreateAccountWithLedgerViewModel(getProfileUseCase, ledgerMessenger, ensureBabylonFactorSourceExistUseCase, eventBus, peerdroidClient)
+        return CreateAccountWithLedgerViewModel(getProfileUseCase, ledgerMessenger, ensureBabylonFactorSourceExistUseCase, eventBus)
     }
 
     @Before
     override fun setUp() {
         super.setUp()
-        coEvery { peerdroidClient.anyChannelConnected } returns flowOf(true)
+        coEvery { ledgerMessenger.isConnected } returns flowOf(true)
         coEvery { eventBus.sendEvent(any()) } just Runs
         coEvery { getProfileUseCase() } returns flowOf(profile())
         coEvery {

--- a/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/CreateAccountWithLedgerViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/CreateAccountWithLedgerViewModelTest.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.presentation.createaccount.withledger
 
 import app.cash.turbine.test
 import com.babylon.wallet.android.data.dapp.LedgerMessenger
+import com.babylon.wallet.android.data.dapp.PeerdroidClient
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.mockdata.profile
 import com.babylon.wallet.android.presentation.StateViewModelTest
@@ -38,17 +39,19 @@ internal class CreateAccountWithLedgerViewModelTest : StateViewModelTest<CreateA
     private val addLedgerFactorSourceUseCase = mockk<AddLedgerFactorSourceUseCase>()
     private val ensureBabylonFactorSourceExistUseCase = mockk<EnsureBabylonFactorSourceExistUseCase>()
     private val eventBus = mockk<AppEventBus>()
+    private val peerdroidClient = mockk<PeerdroidClient>()
 
     private val firstDeviceId = "5f47ec336e9e7891bff04004c817201e73c097b6b1e1b3a26bc501e0010996f5"
     private val secondDeviceId = "5f07ec336e9e7891bff04004c817201e73c097b6b1e1b3a26bc501e0010196f5"
 
     override fun initVM(): CreateAccountWithLedgerViewModel {
-        return CreateAccountWithLedgerViewModel(getProfileUseCase, ledgerMessenger, ensureBabylonFactorSourceExistUseCase, eventBus)
+        return CreateAccountWithLedgerViewModel(getProfileUseCase, ledgerMessenger, ensureBabylonFactorSourceExistUseCase, eventBus, peerdroidClient)
     }
 
     @Before
     override fun setUp() {
         super.setUp()
+        coEvery { peerdroidClient.anyChannelConnected } returns flowOf(true)
         coEvery { eventBus.sendEvent(any()) } just Runs
         coEvery { getProfileUseCase() } returns flowOf(profile())
         coEvery {

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -14,7 +14,6 @@ import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.factorsources.LedgerHardwareWalletFactorSource
 import rdx.works.profile.data.model.pernetwork.DerivationPath
-import rdx.works.profile.data.model.pernetwork.Network
 import rdx.works.profile.data.model.pernetwork.nextAccountIndex
 import rdx.works.profile.data.repository.ProfileRepository
 import rdx.works.profile.data.repository.profile
@@ -50,17 +49,10 @@ val GetProfileUseCase.deviceFactorSources
 val GetProfileUseCase.deviceFactorSourcesWithAccounts
     get() = invoke().map { profile ->
         val deviceFactorSources = profile.factorSources.filterIsInstance<DeviceFactorSource>()
-
-        val factorSourcesWithAccounts = mutableMapOf<DeviceFactorSource, MutableList<Network.Account>>()
-        profile.currentNetwork.accounts.forEach { account ->
-            val deviceFactorSource = deviceFactorSources.find { it.id == account.factorSourceId() }
-            if (deviceFactorSource != null) {
-                val accounts = factorSourcesWithAccounts.getOrPut(deviceFactorSource) { mutableListOf() }
-                accounts.add(account)
-            }
+        val allAccountsOnNetwork = profile.currentNetwork.accounts
+        deviceFactorSources.associateWith { deviceFactorSource ->
+            allAccountsOnNetwork.filter { it.factorSourceId() == deviceFactorSource.id }
         }
-
-        factorSourcesWithAccounts.mapValues { it.value.toList() }
     }
 
 val GetProfileUseCase.ledgerFactorSources


### PR DESCRIPTION
## Description
- added possibility to check if are connected to any CE
- changed generic error for ledger request 
- used connection state in ledger flows to display link connector screen when we disconnect CE in browser
## Test cases:
- adding ledger in create account/settings/olympia import.
- ledger flow is implemented a bit differently in olympia import compared to create account/settings, so please be aware of that.
- after linking ledger in any flow, please disconnect in browser, and verify if we are asked to link again when adding/trying to use ledger device again