### PR TITLE
Return exception instead of throwing one when validating dApps on dev mode == off

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/dappmetadata/DAppRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/dappmetadata/DAppRepository.kt
@@ -100,7 +100,7 @@ class DAppRepositoryImpl @Inject constructor(
                 }
             }
         } else {
-            throw DappRequestException(DappRequestFailure.DappVerificationFailure.UnknownWebsite)
+            kotlin.Result.failure(DappRequestException(DappRequestFailure.DappVerificationFailure.UnknownWebsite))
         }
     }
 


### PR DESCRIPTION
### Notes
If running a dApp in http and trying to connect with dev mode closed, then the app crashed. It was easy to validate by running ROLA client on localhost https://github.com/radixdlt/rola/tree/main/examples/typescript-full-stack and getting a request. Now it just returns the error

