### PR TITLE
ABW-2424 - Guarantee index increased for multiple assertions.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/manifest/ManifestExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/manifest/ManifestExtensions.kt
@@ -3,8 +3,11 @@
 package com.babylon.wallet.android.data.manifest
 
 import com.babylon.wallet.android.data.dapp.model.TransactionType
+import com.babylon.wallet.android.domain.model.GuaranteeAssertion
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.domain.model.TransactionManifestData
+import com.babylon.wallet.android.domain.model.Transferable
+import com.babylon.wallet.android.utils.toRETDecimalString
 import com.radixdlt.ret.Address
 import com.radixdlt.ret.Decimal
 import com.radixdlt.ret.Instruction
@@ -49,6 +52,34 @@ fun TransactionManifest.addGuaranteeInstructionToManifest(
     ),
     blobs = blobs()
 )
+
+fun TransactionManifest.addAssertions(
+    depositing: List<Transferable.Depositing>
+): TransactionManifest {
+    var startIndex = 0
+    var manifest = this
+
+    depositing.forEach {
+        when (val assertion = it.guaranteeAssertion) {
+            is GuaranteeAssertion.ForAmount -> {
+                manifest = manifest.addGuaranteeInstructionToManifest(
+                    address = it.transferable.resourceAddress,
+                    guaranteedAmount = assertion.amount.toRETDecimalString(),
+                    index = assertion.instructionIndex.toInt() + startIndex
+                )
+                startIndex++
+            }
+
+            is GuaranteeAssertion.ForNFT -> {
+                // Will be implemented later
+            }
+
+            null -> {}
+        }
+    }
+
+    return manifest
+}
 
 private fun lockFeeInstruction(
     addressToLockFee: String,


### PR DESCRIPTION
## Description
https://radixdlt.atlassian.net/browse/ABW-2424

### Notes (optional)
Where sending transaction that involves multiple assertions the app did not increase index for the subsequent insertions.
So right now it is fixed the same way as IOS has done.

Steps to test on Stokenet:
1. Send the following manifest (with your accounts etc):
```
CALL_METHOD
    Address("account_tdx_2_12yr3w52llr4gz8jfwxrd4rhwwpd3fsv9uz69uucfr96n43hp79fwtr")
    "withdraw"
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("4")
;

TAKE_FROM_WORKTOP
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("2")
    Bucket("bucket1")
;
CALL_METHOD
    Address("component_tdx_2_1cqm76npjd0y87grsvt0cpplqw25atu9934d7rgraejf895el9x0zkm")
    "buy_gumball"
    Bucket("bucket1")
;

CALL_METHOD
    Address("account_tdx_2_12xjussgnx4tsqtne7t88u5am8ll93a2sth0qwwglcllycpn0fnwv5l")
    "try_deposit_batch_or_abort"
    Expression("ENTIRE_WORKTOP")
    Enum<0u8>()
;

CALL_METHOD
    Address("account_tdx_2_12yr3w52llr4gz8jfwxrd4rhwwpd3fsv9uz69uucfr96n43hp79fwtr")
    "withdraw"
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("4")
;

TAKE_FROM_WORKTOP
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("2")
    Bucket("bucket2")
;
CALL_METHOD
    Address("component_tdx_2_1cqm76npjd0y87grsvt0cpplqw25atu9934d7rgraejf895el9x0zkm")
    "buy_gumball"
    Bucket("bucket2")
;

CALL_METHOD
    Address("account_tdx_2_12xjussgnx4tsqtne7t88u5am8ll93a2sth0qwwglcllycpn0fnwv5l")
    "try_deposit_batch_or_abort"
    Expression("ENTIRE_WORKTOP")
    Enum<0u8>()
;
```

Make sure that transaction succeeds.

You can also check that manifest contains assertions inserted as in the following manifest:

```
CALL_METHOD
    Address("account_tdx_2_12yr3w52llr4gz8jfwxrd4rhwwpd3fsv9uz69uucfr96n43hp79fwtr")
    "lock_fee"
    Decimal("0.955863522880499995")
;
CALL_METHOD
    Address("account_tdx_2_12yr3w52llr4gz8jfwxrd4rhwwpd3fsv9uz69uucfr96n43hp79fwtr")
    "withdraw"
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("4")
;
TAKE_FROM_WORKTOP
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("2")
    Bucket("bucket1")
;
CALL_METHOD
    Address("component_tdx_2_1cqm76npjd0y87grsvt0cpplqw25atu9934d7rgraejf895el9x0zkm")
    "buy_gumball"
    Bucket("bucket1")
;
ASSERT_WORKTOP_CONTAINS
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("3")
;
ASSERT_WORKTOP_CONTAINS
    Address("resource_tdx_2_1t48yzlu36vwwkeq7thmwxzqstc6et372rvlekf6qpeyvg55wkz04r8")
    Decimal("1")
;
CALL_METHOD
    Address("account_tdx_2_12xjussgnx4tsqtne7t88u5am8ll93a2sth0qwwglcllycpn0fnwv5l")
    "try_deposit_batch_or_abort"
    Expression("ENTIRE_WORKTOP")
    Enum<0u8>()
;
CALL_METHOD
    Address("account_tdx_2_12yr3w52llr4gz8jfwxrd4rhwwpd3fsv9uz69uucfr96n43hp79fwtr")
    "withdraw"
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("4")
;
TAKE_FROM_WORKTOP
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("2")
    Bucket("bucket2")
;
CALL_METHOD
    Address("component_tdx_2_1cqm76npjd0y87grsvt0cpplqw25atu9934d7rgraejf895el9x0zkm")
    "buy_gumball"
    Bucket("bucket2")
;
ASSERT_WORKTOP_CONTAINS
    Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc")
    Decimal("3")
;
ASSERT_WORKTOP_CONTAINS
    Address("resource_tdx_2_1t48yzlu36vwwkeq7thmwxzqstc6et372rvlekf6qpeyvg55wkz04r8")
    Decimal("1")
;
CALL_METHOD
    Address("account_tdx_2_12xjussgnx4tsqtne7t88u5am8ll93a2sth0qwwglcllycpn0fnwv5l")
    "try_deposit_batch_or_abort"
    Expression("ENTIRE_WORKTOP")
    Enum<0u8>()
;
```
