### PR TITLE
ABW-2439 - Deposit guarantee not rounded and saved exactly as user en…

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesScreen.kt
@@ -177,7 +177,7 @@ fun DepositGuaranteesContentPreview() {
             state = DepositGuaranteesViewModel.State(
                 isDepositInputValid = true,
                 depositGuarantee = "100",
-                depositGuaranteeDouble = null
+                depositGuaranteeBigDecimal = null
             ),
             onDepositGuaranteeChanged = {},
             onDepositGuaranteeIncreased = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesScreen.kt
@@ -176,8 +176,7 @@ fun DepositGuaranteesContentPreview() {
         DepositGuaranteesContent(
             state = DepositGuaranteesViewModel.State(
                 isDepositInputValid = true,
-                depositGuarantee = "100",
-                depositGuaranteeBigDecimal = null
+                depositGuarantee = "100"
             ),
             onDepositGuaranteeChanged = {},
             onDepositGuaranteeIncreased = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesViewModel.kt
@@ -33,8 +33,7 @@ class DepositGuaranteesViewModel @Inject constructor(
         _state.update { state ->
             state.copy(
                 isDepositInputValid = updatedDepositGuarantee != null,
-                depositGuarantee = depositGuarantee,
-                depositGuaranteeBigDecimal = updatedDepositGuarantee
+                depositGuarantee = depositGuarantee
             )
         }
 
@@ -73,8 +72,7 @@ class DepositGuaranteesViewModel @Inject constructor(
             _state.update { state ->
                 state.copy(
                     isDepositInputValid = true,
-                    depositGuarantee = depositGuarantee.multiply(HUNDRED).stripTrailingZeros().toPlainString(),
-                    depositGuaranteeBigDecimal = depositGuarantee
+                    depositGuarantee = depositGuarantee.multiply(HUNDRED).stripTrailingZeros().toPlainString()
                 )
             }
         } else {
@@ -88,8 +86,7 @@ class DepositGuaranteesViewModel @Inject constructor(
 
     data class State(
         val isDepositInputValid: Boolean = true,
-        val depositGuarantee: String? = null,
-        val depositGuaranteeBigDecimal: BigDecimal? = null
+        val depositGuarantee: String? = null
     ) : UiState
 
     companion object {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesViewModel.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.defaultDepositGuarantee
 import rdx.works.profile.domain.depositguarantees.ChangeDefaultDepositGuaranteeUseCase
-import java.text.DecimalFormat
+import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
@@ -23,24 +23,24 @@ class DepositGuaranteesViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            updateDepositGuarantee(depositGuarantee = getProfileUseCase.defaultDepositGuarantee())
+            updateDepositGuarantee(depositGuarantee = getProfileUseCase.defaultDepositGuarantee().toBigDecimal())
         }
     }
 
     fun onDepositGuaranteeChanged(depositGuarantee: String) {
-        val updatedDepositGuarantee = depositGuarantee.toDoubleOrNull()?.div(HUNDRED)
+        val updatedDepositGuarantee = depositGuarantee.toBigDecimalOrNull()?.divide(HUNDRED)
 
         _state.update { state ->
             state.copy(
                 isDepositInputValid = updatedDepositGuarantee != null,
                 depositGuarantee = depositGuarantee,
-                depositGuaranteeDouble = updatedDepositGuarantee
+                depositGuaranteeBigDecimal = updatedDepositGuarantee
             )
         }
 
         viewModelScope.launch {
             updatedDepositGuarantee?.let { depositGuarantee ->
-                changeDefaultDepositGuaranteeUseCase.invoke(defaultDepositGuarantee = depositGuarantee)
+                changeDefaultDepositGuaranteeUseCase.invoke(defaultDepositGuarantee = depositGuarantee.toDouble())
             }
         }
     }
@@ -48,7 +48,7 @@ class DepositGuaranteesViewModel @Inject constructor(
     fun onDepositGuaranteeIncreased() {
         viewModelScope.launch {
             changeAndUpdateDepositGuarantee(
-                updatedDepositGuarantee = getProfileUseCase.defaultDepositGuarantee().plus(DEPOSIT_CHANGE_THRESHOLD)
+                updatedDepositGuarantee = getProfileUseCase.defaultDepositGuarantee().toBigDecimal().add(DEPOSIT_CHANGE_THRESHOLD)
             )
         }
     }
@@ -56,25 +56,25 @@ class DepositGuaranteesViewModel @Inject constructor(
     fun onDepositGuaranteeDecreased() {
         viewModelScope.launch {
             changeAndUpdateDepositGuarantee(
-                updatedDepositGuarantee = getProfileUseCase.defaultDepositGuarantee().minus(DEPOSIT_CHANGE_THRESHOLD)
+                updatedDepositGuarantee = getProfileUseCase.defaultDepositGuarantee().toBigDecimal().subtract(DEPOSIT_CHANGE_THRESHOLD)
             )
         }
     }
 
-    private suspend fun changeAndUpdateDepositGuarantee(updatedDepositGuarantee: Double?) {
+    private suspend fun changeAndUpdateDepositGuarantee(updatedDepositGuarantee: BigDecimal?) {
         updateDepositGuarantee(depositGuarantee = updatedDepositGuarantee)
         updatedDepositGuarantee?.let { depositGuarantee ->
-            changeDefaultDepositGuaranteeUseCase.invoke(defaultDepositGuarantee = depositGuarantee)
+            changeDefaultDepositGuaranteeUseCase.invoke(defaultDepositGuarantee = depositGuarantee.toDouble())
         }
     }
 
-    private fun updateDepositGuarantee(depositGuarantee: Double?) {
+    private fun updateDepositGuarantee(depositGuarantee: BigDecimal?) {
         if (depositGuarantee != null) {
             _state.update { state ->
                 state.copy(
                     isDepositInputValid = true,
-                    depositGuarantee = DecimalFormat("0.#").format(depositGuarantee.times(HUNDRED)),
-                    depositGuaranteeDouble = depositGuarantee
+                    depositGuarantee = depositGuarantee.multiply(HUNDRED).stripTrailingZeros().toPlainString(),
+                    depositGuaranteeBigDecimal = depositGuarantee
                 )
             }
         } else {
@@ -89,11 +89,11 @@ class DepositGuaranteesViewModel @Inject constructor(
     data class State(
         val isDepositInputValid: Boolean = true,
         val depositGuarantee: String? = null,
-        val depositGuaranteeDouble: Double? = null
+        val depositGuaranteeBigDecimal: BigDecimal? = null
     ) : UiState
 
     companion object {
-        private const val DEPOSIT_CHANGE_THRESHOLD = 0.001
-        private const val HUNDRED = 100
+        private val DEPOSIT_CHANGE_THRESHOLD = BigDecimal("0.001")
+        private val HUNDRED = BigDecimal("100")
     }
 }

--- a/app/src/test/java/com/babylon/wallet/android/presentation/settings/accountsecurity/DepositGuaranteesViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/settings/accountsecurity/DepositGuaranteesViewModelTest.kt
@@ -17,7 +17,6 @@ import org.junit.Test
 import rdx.works.profile.data.model.apppreferences.Transaction
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.depositguarantees.ChangeDefaultDepositGuaranteeUseCase
-import java.math.BigDecimal
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DepositGuaranteesViewModelTest : StateViewModelTest<DepositGuaranteesViewModel>() {
@@ -49,7 +48,6 @@ class DepositGuaranteesViewModelTest : StateViewModelTest<DepositGuaranteesViewM
             val item = expectMostRecentItem()
             assert(item.isDepositInputValid)
             assert(item.depositGuarantee == "150")
-            assert(item.depositGuaranteeBigDecimal == BigDecimal("1.5"))
         }
     }
 
@@ -67,7 +65,6 @@ class DepositGuaranteesViewModelTest : StateViewModelTest<DepositGuaranteesViewM
         val state = vm.state.first()
         assert(state.isDepositInputValid)
         assert(state.depositGuarantee == "150.1")
-        assert(state.depositGuaranteeBigDecimal == BigDecimal("1.501"))
         coVerify(exactly = 1) { changeDefaultDepositGuaranteeUseCase.invoke(1.501) }
     }
 
@@ -85,7 +82,6 @@ class DepositGuaranteesViewModelTest : StateViewModelTest<DepositGuaranteesViewM
         val state = vm.state.first()
         assert(state.isDepositInputValid)
         assert(state.depositGuarantee == "149.9")
-        assert(state.depositGuaranteeBigDecimal == BigDecimal("1.499"))
         coVerify(exactly = 1) { changeDefaultDepositGuaranteeUseCase.invoke(1.499) }
     }
 
@@ -106,7 +102,6 @@ class DepositGuaranteesViewModelTest : StateViewModelTest<DepositGuaranteesViewM
         val state = vm.state.first()
         assert(state.isDepositInputValid)
         assert(state.depositGuarantee == "200")
-        assert(state.depositGuaranteeBigDecimal == BigDecimal("2.0"))
         coVerify(exactly = 1) { changeDefaultDepositGuaranteeUseCase.invoke(2.0) }
     }
 
@@ -128,7 +123,6 @@ class DepositGuaranteesViewModelTest : StateViewModelTest<DepositGuaranteesViewM
         val state = vm.state.first()
         assert(!state.isDepositInputValid)
         assert(state.depositGuarantee == ".")
-        assert(state.depositGuaranteeBigDecimal == null)
         coVerify(exactly = 0) { changeDefaultDepositGuaranteeUseCase.invoke(any()) }
     }
 
@@ -150,7 +144,6 @@ class DepositGuaranteesViewModelTest : StateViewModelTest<DepositGuaranteesViewM
         val state = vm.state.first()
         assert(state.isDepositInputValid)
         assert(state.depositGuarantee == "99.9999")
-        assert(state.depositGuaranteeBigDecimal == BigDecimal("0.999999"))
         coVerify(exactly = 1) { changeDefaultDepositGuaranteeUseCase.invoke(any()) }
     }
 }


### PR DESCRIPTION
…tered it.

## Description
https://radixdlt.atlassian.net/browse/ABW-2439

### Screenshots (optional)

https://github.com/radixdlt/babylon-wallet-android/assets/108684750/6a34236a-69ce-493c-9d81-dd844d870ba6

### Notes (optional)
Before we used to round the number to nearest however we should not apply any rounding and saved deposit guarantee exactly as user entered.
