### PR TITLE
Save exactly what cloud has backed up into temporary copy

### DIFF
--- a/profile/src/main/java/rdx/works/profile/domain/backup/BackupProfileToCloudUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/BackupProfileToCloudUseCase.kt
@@ -23,6 +23,7 @@ class BackupProfileToCloudUseCase @Inject constructor(
             writeEntityHeader(tag, len)
             writeEntityData(byteArray, len)
             preferencesManager.updateLastBackupInstant(InstantGenerator())
+            backupProfileRepository.saveTemporaryRestoringSnapshot(snapshot, BackupType.Cloud)
         }
 
         return Result.success(Unit)


### PR DESCRIPTION
### Notes 
* Fixes bug when first time cloud backup has occurred and we need to keep that copy locally so if user deletes the wallet immediately, they can still see it in the restore section.
