### PR TITLE
[ABW-2299] Keep listening for p2plinks after restore

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
@@ -71,7 +71,6 @@ class MainViewModel @Inject constructor(
             }
         }
         .onCompletion {
-            Timber.d("Peerdroid is terminating")
             terminatePeerdroid()
         }
         .shareIn(
@@ -125,9 +124,8 @@ class MainViewModel @Inject constructor(
         if (encryptionKey != null) {
             when (val result = peerdroidClient.connect(encryptionKey = encryptionKey)) {
                 is Result.Success -> {
-                    Timber.d("Link connection established")
                     if (incomingDappRequestsJob == null) {
-                        Timber.d("Listen for incoming requests from dapps")
+                        Timber.d("\uD83E\uDD16 Listen for incoming requests from dapps")
                         // We must run this only once
                         // otherwise for each new link connection
                         // we create a new job to collect messages from the same stream (messagesFromRemoteClients).
@@ -140,7 +138,7 @@ class MainViewModel @Inject constructor(
                                     val remoteConnectorId = incomingRequest.remoteConnectorId
                                     val requestId = incomingRequest.id
                                     Timber.d(
-                                        "📯 wallet received incoming request from remote connector $remoteConnectorId with id $requestId"
+                                        "\uD83E\uDD16 wallet received incoming request from remote connector $remoteConnectorId with id $requestId"
                                     )
                                     processIncomingRequest(incomingRequest)
                                 }
@@ -159,7 +157,7 @@ class MainViewModel @Inject constructor(
                 }
 
                 is Result.Error -> {
-                    Timber.e("Failed to establish link connection: ${result.message}")
+                    Timber.e("\uD83E\uDD16 Failed to establish link connection: ${result.message}")
                 }
 
                 else -> {}
@@ -208,6 +206,7 @@ class MainViewModel @Inject constructor(
     }
 
     private fun terminatePeerdroid() {
+        Timber.d("\uD83E\uDD16 Peerdroid is terminating")
         incomingDappRequestsJob?.cancel()
         incomingDappRequestsJob = null
         processingDappRequestJob?.cancel()
@@ -216,7 +215,6 @@ class MainViewModel @Inject constructor(
         incomingDappRequestErrorsJob = null
         peerdroidClient.terminate()
         incomingRequestRepository.removeAll()
-        Timber.d("Peerdroid terminated")
     }
 
     fun onInvalidRequestMessageShown() {

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
@@ -53,7 +53,7 @@ internal class PeerdroidLinkImpl(
         addConnectionDeferred = CompletableDeferred()
         // get connection id from encryption key
         val connectionId = encryptionKey.blake2Hash().toHexString()
-        Timber.d("🛠️️ add new connection for connection id: $connectionId")
+        Timber.d("🛠️️ add new link connection with connection id: $connectionId")
 
         withContext(ioDispatcher) {
             // Leave this method here because WebRTC takes too long to initialize its components
@@ -94,7 +94,7 @@ internal class PeerdroidLinkImpl(
                         Timber.d("🛠️️ ⬇️ connector extension is connected with id: ${incomingMessage.remoteClientId} 📬")
                     }
                     is SignalingServerMessage.RemoteData.Offer -> {
-                        Timber.d("🛠️️ ⬇️  offer received from connector extension: ${incomingMessage.remoteClientId}")
+                        Timber.d("🛠️️ ⬇️ offer received from connector extension: ${incomingMessage.remoteClientId}")
                         setRemoteDescriptionFromOffer(incomingMessage)
                         createAndSendAnswerToRemoteClient()
                     }

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -1,7 +1,6 @@
 package rdx.works.profile.domain
 
 import com.radixdlt.ret.Address
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -129,7 +129,7 @@ val GetProfileUseCase.security
  * P2P Links preferences
  */
 val GetProfileUseCase.p2pLinks
-    get() = invoke().map { it.appPreferences.p2pLinks }.distinctUntilChanged()
+    get() = invoke().map { it.appPreferences.p2pLinks }
 
 /**
  * Default deposit guarantee


### PR DESCRIPTION
## Description
[Android | 1.0.0 #9 | P2P - Linked Connector - Issue post-restore of backup](https://radixdlt.atlassian.net/browse/ABW-2299)

### The problem
When the user deletes the profile, we call the `peerdroidClient.terminate()`  in the `onDeleteWalletConfirm()` of the `BackupViewModel`. Then:
1. the app navigates to the onboarding screen
2. user clicks on restore profile and when restore is done the app navigates to the wallet screen
3. `observeP2PLinksflow` won't work there, and we need to restart the app in order to make it work.

The cause was the `distinctUntilChanged` at `GetProfileUseCase.p2pLinks`. This property would prevent the subsequent repetitions of the same value every time the profile gets updated and thus would prevent the call of the `establishLinkConnection` in the `MainViewModel`. 

### The fix
I removed the `distinctUntilChanged` and now I rely only on the `PeerdroidConnector` to not establish a link connection with the same p2p link. Check the `connectToConnectorExtension`

## Testing
Read the steps in the ticket.
You can complicate the flow by adding more link connections before restoring.

