### PR TITLE
[ABW-2464] Correctly compare guarantee items

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -545,6 +545,9 @@ sealed interface AccountWithPredictedGuarantee {
         }
     }
 
+    fun isTheSameGuaranteeItem(with: AccountWithPredictedGuarantee): Boolean = address == with.address
+            && transferableAmount.resourceAddress == with.transferableAmount.resourceAddress
+
     data class Owned(
         val account: Network.Account,
         override val transferableAmount: TransferableResource.Amount,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -545,8 +545,8 @@ sealed interface AccountWithPredictedGuarantee {
         }
     }
 
-    fun isTheSameGuaranteeItem(with: AccountWithPredictedGuarantee): Boolean = address == with.address
-            && transferableAmount.resourceAddress == with.transferableAmount.resourceAddress
+    fun isTheSameGuaranteeItem(with: AccountWithPredictedGuarantee): Boolean = address == with.address &&
+        transferableAmount.resourceAddress == with.transferableAmount.resourceAddress
 
     data class Owned(
         val account: Network.Account,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/guarantees/TransactionGuaranteesDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/guarantees/TransactionGuaranteesDelegate.kt
@@ -71,7 +71,7 @@ class TransactionGuaranteesDelegate(
             state.copy(
                 sheetState = sheet.copy(
                     accountsWithPredictedGuarantees = sheet.accountsWithPredictedGuarantees.mapWhen(
-                        predicate = { it.address == account.address },
+                        predicate = { it.isTheSameGuaranteeItem(with = account) },
                         mutation = { it.change(value) }
                     )
                 )
@@ -86,7 +86,7 @@ class TransactionGuaranteesDelegate(
             state.copy(
                 sheetState = sheet.copy(
                     accountsWithPredictedGuarantees = sheet.accountsWithPredictedGuarantees.mapWhen(
-                        predicate = { it.address == account.address },
+                        predicate = { it.isTheSameGuaranteeItem(with = account) },
                         mutation = { it.increase() }
                     )
                 )
@@ -101,7 +101,7 @@ class TransactionGuaranteesDelegate(
             state.copy(
                 sheetState = sheet.copy(
                     accountsWithPredictedGuarantees = sheet.accountsWithPredictedGuarantees.mapWhen(
-                        predicate = { it.address == account.address },
+                        predicate = { it.isTheSameGuaranteeItem(with = account) },
                         mutation = { it.decrease() }
                     )
                 )


### PR DESCRIPTION
## Description
[Android - 1.0.6 (17) - Adjusting % increment on Customize Guarantees will adjust for multiple assets simultaneously ](https://radixdlt.atlassian.net/browse/ABW-2464)

### Notes
* Customising guarantees of the same amount needs to compare an item on each account and on each resource
