### PR TITLE
ABW-2460 - None button replaced with Done.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesScreen.kt
@@ -145,7 +145,7 @@ fun DepositGuaranteesContent(
                             singleLine = true,
                             textStyle = RadixTheme.typography.body1Regular.copy(textAlign = TextAlign.Center),
                             keyboardOptions = KeyboardOptions(
-                                imeAction = ImeAction.None,
+                                imeAction = ImeAction.Done,
                                 keyboardType = KeyboardType.Number
                             )
                         )


### PR DESCRIPTION
## Description
https://radixdlt.atlassian.net/browse/ABW-2460

### Screenshots (optional)
<img src="image_url" width="300">

### Notes (optional)
Ime action was replaced with Done, because previously we were adding new line character on click event which was breaking the functionality.
