### PR TITLE
[ABW-2483] Fix how to check if a gateway is already in saved gateways

### DIFF
--- a/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Gateways.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Gateways.kt
@@ -3,6 +3,7 @@ package rdx.works.profile.data.model.apppreferences
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import rdx.works.profile.data.model.Profile
+import java.net.URI
 
 @Serializable
 data class Gateways(
@@ -17,7 +18,7 @@ data class Gateways(
     }
 
     fun changeCurrent(gateway: Radix.Gateway): Gateways {
-        require(saved.contains(gateway))
+        require(saved.containsGateway(gateway))
         return copy(currentGatewayUrl = gateway.url)
     }
 
@@ -59,4 +60,14 @@ fun Profile.deleteGateway(
 ): Profile {
     val updatedGateways = appPreferences.gateways.delete(gateway)
     return copy(appPreferences = appPreferences.copy(gateways = updatedGateways))
+}
+
+fun List<Radix.Gateway>.containsGateway(gateway: Radix.Gateway): Boolean {
+    return this.any {
+        // example: if the url is "https://mainnet.radixdlt.com" then the host is mainnet.radixdlt.com
+        // example: if the url is "https://mainnet.radixdlt.com/" then the host is mainnet.radixdlt.com
+        val existedGateway = URI.create(it.url).host
+        val gatewayHost = URI.create(gateway.url).host
+        it.network.id == gateway.network.id && existedGateway == gatewayHost
+    }
 }

--- a/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Gateways.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Gateways.kt
@@ -66,8 +66,8 @@ fun List<Radix.Gateway>.containsGateway(gateway: Radix.Gateway): Boolean {
     return this.any {
         // example: if the url is "https://mainnet.radixdlt.com" then the host is mainnet.radixdlt.com
         // example: if the url is "https://mainnet.radixdlt.com/" then the host is mainnet.radixdlt.com
-        val existedGateway = URI.create(it.url).host
+        val existingGateway = URI.create(it.url).host
         val gatewayHost = URI.create(gateway.url).host
-        it.network.id == gateway.network.id && existedGateway == gatewayHost
+        it.network.id == gateway.network.id && existingGateway == gatewayHost
     }
 }

--- a/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Gateways.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Gateways.kt
@@ -64,17 +64,9 @@ fun Profile.deleteGateway(
 
 fun List<Radix.Gateway>.containsGateway(gateway: Radix.Gateway): Boolean {
     return this.any {
-        val existingGatewayUri = URI.create(it.url)
-        val gatewayUri = URI.create(gateway.url)
+        val existingGatewayUri = URI.create(it.url.removeSuffix("/"))
+        val gatewayUri = URI.create(gateway.url.removeSuffix("/"))
 
-        // example: if the url is "https://mainnet.radixdlt.com" then the host is mainnet.radixdlt.com
-        // example: if the url is "https://mainnet.radixdlt.com/" then the host is mainnet.radixdlt.com
-        val existingGatewayHost = existingGatewayUri.host
-        val gatewayHost = gatewayUri.host
-
-        val existingGatewayPath = existingGatewayUri.path.removePrefix("/").removeSuffix("/")
-        val gatewayPath = gatewayUri.path.removePrefix("/").removeSuffix("/")
-
-        it.network.id == gateway.network.id && existingGatewayHost == gatewayHost && existingGatewayPath == gatewayPath
+        it.network.id == gateway.network.id && gatewayUri.equals(existingGatewayUri)
     }
 }

--- a/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Gateways.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Gateways.kt
@@ -64,10 +64,17 @@ fun Profile.deleteGateway(
 
 fun List<Radix.Gateway>.containsGateway(gateway: Radix.Gateway): Boolean {
     return this.any {
+        val existingGatewayUri = URI.create(it.url)
+        val gatewayUri = URI.create(gateway.url)
+
         // example: if the url is "https://mainnet.radixdlt.com" then the host is mainnet.radixdlt.com
         // example: if the url is "https://mainnet.radixdlt.com/" then the host is mainnet.radixdlt.com
-        val existingGateway = URI.create(it.url).host
-        val gatewayHost = URI.create(gateway.url).host
-        it.network.id == gateway.network.id && existingGateway == gatewayHost
+        val existingGatewayHost = existingGatewayUri.host
+        val gatewayHost = gatewayUri.host
+
+        val existingGatewayPath = existingGatewayUri.path.removePrefix("/").removeSuffix("/")
+        val gatewayPath = gatewayUri.path.removePrefix("/").removeSuffix("/")
+
+        it.network.id == gateway.network.id && existingGatewayHost == gatewayHost && existingGatewayPath == gatewayPath
     }
 }

--- a/profile/src/test/java/rdx/works/profile/gateways/ExtensionsTest.kt
+++ b/profile/src/test/java/rdx/works/profile/gateways/ExtensionsTest.kt
@@ -35,7 +35,7 @@ class ExtensionsTest {
     }
 
     @Test
-    fun `containsGateway extension with custom gateway`() {
+    fun `existing custom gateway with slash and new gateway with same id but without path then containsGateway returns true`() {
         val savedGateways = mutableListOf<Radix.Gateway>()
 
         val myGatewayWithoutPath = Radix.Gateway(
@@ -60,7 +60,7 @@ class ExtensionsTest {
     }
 
     @Test
-    fun `containsGateway extension with custom gateway that contains also path`() {
+    fun `existing gateway with path and new gateway with same id but without path then containsGateway returns false`() {
         val savedGateways = mutableListOf<Radix.Gateway>()
 
         val myGatewayWithPath = Radix.Gateway(
@@ -82,6 +82,21 @@ class ExtensionsTest {
             )
         )
         Assert.assertFalse(savedGateways.containsGateway(myGatewayWithoutPath))
+    }
+
+    @Test
+    fun `existing gateway with path and new gateway with same id and with slash then containsGateway returns true`() {
+        val savedGateways = mutableListOf<Radix.Gateway>()
+
+        val myGatewayWithPath = Radix.Gateway(
+            url = "https://my.gateway.com/path/morepath",
+            network = Radix.Network(
+                id = 11,
+                name = "mygateway",
+                displayDescription = "Gateway"
+            )
+        )
+        savedGateways.add(myGatewayWithPath)
 
         val myGatewayWithPathAndSlash = Radix.Gateway(
             url = "https://my.gateway.com/path/morepath/",
@@ -95,7 +110,7 @@ class ExtensionsTest {
     }
 
     @Test
-    fun `containsGateway extension with custom IP gateway`() {
+    fun `existing gateway with slash and new gateway with same id but without slash then containsGateway returns true`() {
         val savedGateways = mutableListOf<Radix.Gateway>()
 
         val mainnet = Radix.Gateway(
@@ -112,7 +127,7 @@ class ExtensionsTest {
             url = "https://1.1.1.1",
             network = Radix.Network(
                 id = 1,
-                name = "mainnet", // name fixed
+                name = "mainnet",
                 displayDescription = "Mainnet"
             )
         )
@@ -121,7 +136,7 @@ class ExtensionsTest {
     }
 
     @Test
-    fun `containsGateway extension with custom IP gateway and different id`() {
+    fun `existing gateway with slash and new gateway with different id and without slash then containsGateway returns false`() {
         val savedGateways = mutableListOf<Radix.Gateway>()
 
         val mainnet = Radix.Gateway(
@@ -138,7 +153,7 @@ class ExtensionsTest {
             url = "https://1.1.1.1",
             network = Radix.Network(
                 id = 1,
-                name = "mainnet", // name fixed
+                name = "mainnet",
                 displayDescription = "Mainnet"
             )
         )

--- a/profile/src/test/java/rdx/works/profile/gateways/ExtensionsTest.kt
+++ b/profile/src/test/java/rdx/works/profile/gateways/ExtensionsTest.kt
@@ -1,0 +1,35 @@
+package rdx.works.profile.gateways
+
+import org.junit.Assert
+import org.junit.Test
+import rdx.works.profile.data.model.apppreferences.Radix
+import rdx.works.profile.data.model.apppreferences.containsGateway
+
+class ExtensionsTest {
+
+    @Test
+    fun `containsGateway extension`() {
+        val savedGateways = mutableListOf<Radix.Gateway>()
+        val mainnet = Radix.Gateway(
+            url = "https://mainnet.radixdlt.com",
+            network = Radix.Network(
+                id = 1,
+                name = "Mainnet",
+                displayDescription = "Mainnet"
+            )
+        )
+        savedGateways.add(mainnet)
+
+        // a later app version fixed the properties of this object
+        val updatedMainnet = Radix.Gateway(
+            url = "https://mainnet.radixdlt.com/", // added a slash in the end
+            network = Radix.Network(
+                id = 1,
+                name = "mainnet", // name fixed
+                displayDescription = "Mainnet"
+            )
+        )
+
+        Assert.assertTrue(savedGateways.containsGateway(updatedMainnet))
+    }
+}

--- a/profile/src/test/java/rdx/works/profile/gateways/ExtensionsTest.kt
+++ b/profile/src/test/java/rdx/works/profile/gateways/ExtensionsTest.kt
@@ -8,8 +8,9 @@ import rdx.works.profile.data.model.apppreferences.containsGateway
 class ExtensionsTest {
 
     @Test
-    fun `containsGateway extension`() {
+    fun `containsGateway extension with Radix mainnet gateway`() {
         val savedGateways = mutableListOf<Radix.Gateway>()
+
         val mainnet = Radix.Gateway(
             url = "https://mainnet.radixdlt.com",
             network = Radix.Network(
@@ -31,5 +32,117 @@ class ExtensionsTest {
         )
 
         Assert.assertTrue(savedGateways.containsGateway(updatedMainnet))
+    }
+
+    @Test
+    fun `containsGateway extension with custom gateway`() {
+        val savedGateways = mutableListOf<Radix.Gateway>()
+
+        val myGatewayWithoutPath = Radix.Gateway(
+            url = "https://my.gateway.com/",
+            network = Radix.Network(
+                id = 11,
+                name = "mygateway",
+                displayDescription = "My gateway"
+            )
+        )
+        savedGateways.add(myGatewayWithoutPath)
+
+        val myGatewayWithoutSlash = Radix.Gateway(
+            url = "https://my.gateway.com",
+            network = Radix.Network(
+                id = 11,
+                name = "mygateway",
+                displayDescription = "My gateway"
+            )
+        )
+        Assert.assertTrue(savedGateways.containsGateway(myGatewayWithoutSlash))
+    }
+
+    @Test
+    fun `containsGateway extension with custom gateway that contains also path`() {
+        val savedGateways = mutableListOf<Radix.Gateway>()
+
+        val myGatewayWithPath = Radix.Gateway(
+            url = "https://my.gateway.com/path/morepath",
+            network = Radix.Network(
+                id = 11,
+                name = "mygateway",
+                displayDescription = "Gateway"
+            )
+        )
+        savedGateways.add(myGatewayWithPath)
+
+        val myGatewayWithoutPath = Radix.Gateway(
+            url = "https://my.gateway.com/",
+            network = Radix.Network(
+                id = 11,
+                name = "mygateway",
+                displayDescription = "My gateway"
+            )
+        )
+        Assert.assertFalse(savedGateways.containsGateway(myGatewayWithoutPath))
+
+        val myGatewayWithPathAndSlash = Radix.Gateway(
+            url = "https://my.gateway.com/path/morepath/",
+            network = Radix.Network(
+                id = 11,
+                name = "mygateway",
+                displayDescription = "Gateway"
+            )
+        )
+        Assert.assertTrue(savedGateways.containsGateway(myGatewayWithPathAndSlash))
+    }
+
+    @Test
+    fun `containsGateway extension with custom IP gateway`() {
+        val savedGateways = mutableListOf<Radix.Gateway>()
+
+        val mainnet = Radix.Gateway(
+            url = "https://1.1.1.1/",
+            network = Radix.Network(
+                id = 1,
+                name = "Mainnet",
+                displayDescription = "Mainnet"
+            )
+        )
+        savedGateways.add(mainnet)
+
+        val updatedMainnet = Radix.Gateway(
+            url = "https://1.1.1.1",
+            network = Radix.Network(
+                id = 1,
+                name = "mainnet", // name fixed
+                displayDescription = "Mainnet"
+            )
+        )
+
+        Assert.assertTrue(savedGateways.containsGateway(updatedMainnet))
+    }
+
+    @Test
+    fun `containsGateway extension with custom IP gateway and different id`() {
+        val savedGateways = mutableListOf<Radix.Gateway>()
+
+        val mainnet = Radix.Gateway(
+            url = "https://1.1.1.1/",
+            network = Radix.Network(
+                id = 2,
+                name = "Mainnet",
+                displayDescription = "Mainnet"
+            )
+        )
+        savedGateways.add(mainnet)
+
+        val updatedMainnet = Radix.Gateway(
+            url = "https://1.1.1.1",
+            network = Radix.Network(
+                id = 1,
+                name = "mainnet", // name fixed
+                displayDescription = "Mainnet"
+            )
+        )
+
+        Assert.assertFalse(savedGateways.containsGateway(updatedMainnet))
     }
 }


### PR DESCRIPTION
## Description
[Fix the way we verify the gateway change](https://radixdlt.atlassian.net/browse/ABW-2483)

The first versions (1.0.0 - 1.0.2) of the Android wallet contained the mainnet gateway with wrong name property. So users who export a profile from these versions and import to the latest versions cause a crash in the app. See more details in the ticket.
The unit test explains better the fix.

