### PR TITLE
ABW-2466 Throw no mnemonic exception and handle it on UI

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
+++ b/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
@@ -4,8 +4,6 @@ import android.content.Intent
 import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -20,7 +18,6 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
-import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.presentation.dapp.authorized.login.dAppLoginAuthorized
 import com.babylon.wallet.android.presentation.dapp.unauthorized.login.dAppLoginUnauthorized
@@ -43,7 +40,7 @@ import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import kotlinx.coroutines.flow.Flow
 
-@OptIn(ExperimentalAnimationApi::class, ExperimentalMaterialApi::class)
+@OptIn(ExperimentalAnimationApi::class)
 @Composable
 @Suppress("ModifierMissing")
 fun WalletApp(
@@ -138,20 +135,8 @@ fun WalletApp(
                     mainViewModel.clearOlympiaError()
                 }
             },
-            title = {
-                Text(
-                    text = stringResource(id = R.string.homePage_profileOlympiaError_title),
-                    style = RadixTheme.typography.body1Header,
-                    color = RadixTheme.colors.gray1
-                )
-            },
-            text = {
-                Text(
-                    text = stringResource(id = R.string.homePage_profileOlympiaError_subtitle),
-                    style = RadixTheme.typography.body2Regular,
-                    color = RadixTheme.colors.gray1
-                )
-            },
+            title = stringResource(id = R.string.homePage_profileOlympiaError_title),
+            text = stringResource(id = R.string.homePage_profileOlympiaError_subtitle),
             confirmText = confirmText,
             dismissText = null
         )
@@ -161,20 +146,8 @@ fun WalletApp(
             finish = {
                 mainViewModel.onInvalidRequestMessageShown()
             },
-            title = {
-                Text(
-                    text = stringResource(id = R.string.dAppRequest_validationOutcome_invalidRequestTitle),
-                    style = RadixTheme.typography.body1Header,
-                    color = RadixTheme.colors.gray1
-                )
-            },
-            text = {
-                Text(
-                    text = stringResource(id = it.toDescriptionRes()),
-                    style = RadixTheme.typography.body2Regular,
-                    color = RadixTheme.colors.gray1
-                )
-            },
+            title = stringResource(id = R.string.dAppRequest_validationOutcome_invalidRequestTitle),
+            text = stringResource(id = it.toDescriptionRes()),
             confirmText = stringResource(
                 id = R.string.common_ok
             ),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
@@ -45,6 +45,7 @@ import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
 import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.PersonaUiModel
 import com.babylon.wallet.android.presentation.status.signing.SigningStatusBottomDialog
 import com.babylon.wallet.android.presentation.ui.composables.BackIconType
+import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.BottomPrimaryButton
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
@@ -71,6 +72,16 @@ fun PersonaDataOnetimeScreen(
     val context = LocalContext.current
     val state by viewModel.state.collectAsStateWithLifecycle()
     val sharedState by sharedViewModel.state.collectAsStateWithLifecycle()
+    if (sharedState.isNoMnemonicErrorVisible) {
+        BasicPromptAlertDialog(
+            finish = {
+                sharedViewModel.dismissNoMnemonicError()
+            },
+            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            dismissText = null
+        )
+    }
     LaunchedEffect(Unit) {
         sharedViewModel.oneOffEvent.collect { event ->
             when (event) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
@@ -44,6 +44,7 @@ import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
 import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.PersonaUiModel
 import com.babylon.wallet.android.presentation.status.signing.SigningStatusBottomDialog
 import com.babylon.wallet.android.presentation.ui.composables.BackIconType
+import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.BottomPrimaryButton
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
@@ -66,6 +67,16 @@ fun PersonaDataOngoingScreen(
     val context = LocalContext.current
     val state by viewModel.state.collectAsStateWithLifecycle()
     val sharedState by sharedViewModel.state.collectAsStateWithLifecycle()
+    if (sharedState.isNoMnemonicErrorVisible) {
+        BasicPromptAlertDialog(
+            finish = {
+                sharedViewModel.dismissNoMnemonicError()
+            },
+            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            dismissText = null
+        )
+    }
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.collect { event ->
             when (event) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
@@ -23,6 +23,7 @@ import com.babylon.wallet.android.presentation.dapp.authorized.account.AccountIt
 import com.babylon.wallet.android.presentation.dapp.unauthorized.login.DAppUnauthorizedLoginViewModel
 import com.babylon.wallet.android.presentation.dapp.unauthorized.login.Event
 import com.babylon.wallet.android.presentation.status.signing.SigningStatusBottomDialog
+import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.ChooseAccountContent
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
@@ -40,6 +41,17 @@ fun OneTimeChooseAccountsScreen(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val sharedViewModelState by sharedViewModel.state.collectAsStateWithLifecycle()
+    if (sharedViewModelState.isNoMnemonicErrorVisible) {
+        BasicPromptAlertDialog(
+            finish = {
+                sharedViewModel.dismissNoMnemonicError()
+            },
+            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            dismissText = null
+        )
+    }
     LaunchedEffect(Unit) {
         sharedViewModel.oneOffEvent.collect { event ->
             when (event) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -81,7 +81,7 @@ fun TransactionReviewScreen(
     if (state.isNoMnemonicErrorVisible) {
         BasicPromptAlertDialog(
             finish = {
-                viewModel.dismissNoMnemonicError()
+                viewModel.dismissNoMnemonicErrorDialog()
             },
             title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
             text = stringResource(id = R.string.transactionReview_noMnemonicError_text),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -78,6 +78,16 @@ fun TransactionReviewScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    if (state.isNoMnemonicErrorVisible) {
+        BasicPromptAlertDialog(
+            finish = {
+                viewModel.dismissNoMnemonicError()
+            },
+            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            dismissText = null
+        )
+    }
     TransactionPreviewContent(
         onBackClick = viewModel::onBackClick,
         state = state,
@@ -120,6 +130,7 @@ fun TransactionReviewScreen(
                     dismissText = null
                 )
             }
+
             else -> SigningStatusBottomDialog(
                 modifier = Modifier.fillMaxHeight(0.8f),
                 onDismissDialogClick = viewModel::onBackClick,
@@ -288,6 +299,7 @@ private fun TransactionPreviewContent(
                                 is PreviewType.UnacceptableManifest -> {
                                     return@AnimatedVisibility
                                 }
+
                                 is PreviewType.NonConforming -> {}
                                 is PreviewType.Transfer -> {
                                     TransactionPreviewTypeContent(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -257,6 +257,10 @@ class TransactionReviewViewModel @Inject constructor(
         }
     }
 
+    fun dismissNoMnemonicError() {
+        _state.update { it.copy(isNoMnemonicErrorVisible = false) }
+    }
+
     data class State(
         val request: MessageFromDataChannel.IncomingRequest.TransactionRequest? = null,
         val isLoading: Boolean,
@@ -269,6 +273,7 @@ class TransactionReviewViewModel @Inject constructor(
         val sheetState: Sheet = Sheet.None,
         private val latestFeesMode: Sheet.CustomizeFees.FeesMode = Sheet.CustomizeFees.FeesMode.Default,
         val error: UiMessage? = null,
+        val isNoMnemonicErrorVisible: Boolean = false,
         val ephemeralNotaryPrivateKey: PrivateKey = PrivateKey.EddsaEd25519.newRandom(),
         val interactionState: InteractionState? = null
     ) : UiState {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -257,7 +257,7 @@ class TransactionReviewViewModel @Inject constructor(
         }
     }
 
-    fun dismissNoMnemonicError() {
+    fun dismissNoMnemonicErrorDialog() {
         _state.update { it.copy(isNoMnemonicErrorVisible = false) }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -10,13 +10,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.IconButton
-import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -136,6 +136,50 @@ fun BasicPromptAlertDialog(
         },
         title = title,
         text = text
+    )
+}
+
+@Composable
+fun BasicPromptAlertDialog(
+    modifier: Modifier = Modifier,
+    finish: (accepted: Boolean) -> Unit,
+    title: String? = null,
+    text: String? = null,
+    confirmText: String = stringResource(id = R.string.common_confirm),
+    dismissText: String? = stringResource(id = R.string.common_cancel),
+    confirmTextColor: Color = RadixTheme.colors.blue2
+) {
+    AlertDialog(
+        modifier = modifier
+            .background(RadixTheme.colors.defaultBackground, shape = RadixTheme.shapes.roundedRectSmall)
+            .clip(RadixTheme.shapes.roundedRectSmall),
+        onDismissRequest = { finish(false) },
+        confirmButton = {
+            RadixTextButton(text = confirmText, onClick = { finish(true) }, contentColor = confirmTextColor)
+        },
+        dismissButton = dismissText?.let {
+            {
+                RadixTextButton(text = it, onClick = { finish(false) })
+            }
+        },
+        title = title?.let {
+            {
+                Text(
+                    text = title,
+                    style = RadixTheme.typography.body1Header,
+                    color = RadixTheme.colors.gray1
+                )
+            }
+        },
+        text = text?.let {
+            {
+                Text(
+                    text = text,
+                    style = RadixTheme.typography.body2Regular,
+                    color = RadixTheme.colors.gray1
+                )
+            }
+        }
     )
 }
 


### PR DESCRIPTION
## Description
- trhow no menmonic exception whenever there is no mnemonic during signing
- handle it on the UI for dapp login and transaction review

### Notes (optional)
- strings added in crowdin, waiting for propagation
- to test: create wallet with at least 1 olympia software account, back it up. Then uninstall wallet, restore backup and don't recover olympia seed phrase. Now you can get this error either by doing a transaction which involves that Olympia account signature, or send dapp request with proof of accounts  and select that olympia account.
