### PR TITLE
ABW-2473 - Fee and the payer are being determined while being on Tx Review screen

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -260,6 +260,7 @@ private fun TransactionPreviewContent(
                                 fees = state.transactionFees,
                                 noFeePayerSelected = state.noFeePayerSelected,
                                 insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
+                                isNetworkFeeLoading = state.isNetworkFeeLoading,
                                 onCustomizeClick = onCustomizeClick
                             )
                             SlideToSignButton(
@@ -317,6 +318,7 @@ private fun TransactionPreviewContent(
                                 fees = state.transactionFees,
                                 noFeePayerSelected = state.noFeePayerSelected,
                                 insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
+                                isNetworkFeeLoading = state.isNetworkFeeLoading,
                                 onCustomizeClick = onCustomizeClick
                             )
                             SlideToSignButton(
@@ -462,6 +464,7 @@ fun TransactionPreviewContentPreview() {
                     requestMetadata = MessageFromDataChannel.IncomingRequest.RequestMetadata.internal(Radix.Gateway.default.network.id)
                 ),
                 isLoading = false,
+                isNetworkFeeLoading = false,
                 previewType = PreviewType.NonConforming
             ),
             onApproveTransaction = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -81,6 +81,7 @@ class TransactionReviewViewModel @Inject constructor(
 
     override fun initialState(): State = State(
         isLoading = true,
+        isNetworkFeeLoading = true,
         previewType = PreviewType.None
     )
 
@@ -260,6 +261,7 @@ class TransactionReviewViewModel @Inject constructor(
     data class State(
         val request: MessageFromDataChannel.IncomingRequest.TransactionRequest? = null,
         val isLoading: Boolean,
+        val isNetworkFeeLoading: Boolean,
         val isSubmitting: Boolean = false,
         val isRawManifestVisible: Boolean = false,
         val previewType: PreviewType,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -89,6 +89,15 @@ class TransactionAnalysisDelegate(
             signersCount = notaryAndSigners.signers.count()
         )
 
+        state.update {
+            it.copy(
+                isRawManifestVisible = previewType == PreviewType.NonConforming,
+                isLoading = false,
+                previewType = previewType,
+                defaultSignersCount = notaryAndSigners.signers.count()
+            )
+        }
+
         if (transactionFees.defaultTransactionFee > BigDecimal.ZERO) {
             // There will be a lock fee so update lock fee cost
             transactionFees = transactionFees.copy(
@@ -102,12 +111,9 @@ class TransactionAnalysisDelegate(
         ).onSuccess { feePayerResult ->
             state.update {
                 it.copy(
-                    isRawManifestVisible = previewType == PreviewType.NonConforming,
+                    isNetworkFeeLoading = false,
                     transactionFees = transactionFees,
-                    isLoading = false,
-                    previewType = previewType,
-                    feePayerSearchResult = feePayerResult,
-                    defaultSignersCount = notaryAndSigners.signers.count()
+                    feePayerSearchResult = feePayerResult
                 )
             }
         }
@@ -149,6 +155,7 @@ class TransactionAnalysisDelegate(
         state.update {
             it.copy(
                 isLoading = false,
+                isNetworkFeeLoading = false,
                 previewType = PreviewType.None,
                 error = UiMessage.ErrorMessage.from(error)
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/NetworkFeeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/NetworkFeeContent.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.presentation.transaction.composables
 
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,8 +15,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixTextButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.designsystem.theme.White
 import com.babylon.wallet.android.presentation.transaction.fees.TransactionFees
 import com.babylon.wallet.android.presentation.ui.composables.InfoLink
+import com.google.accompanist.placeholder.PlaceholderHighlight
+import com.google.accompanist.placeholder.placeholder
+import com.google.accompanist.placeholder.shimmer
 import rdx.works.core.displayableQuantity
 
 @Composable
@@ -23,6 +28,7 @@ fun NetworkFeeContent(
     fees: TransactionFees,
     noFeePayerSelected: Boolean,
     insufficientBalanceToPayTheFee: Boolean,
+    isNetworkFeeLoading: Boolean,
     modifier: Modifier = Modifier,
     onCustomizeClick: () -> Unit
 ) {
@@ -48,6 +54,17 @@ fun NetworkFeeContent(
 //            )
             Spacer(modifier = Modifier.weight(1f))
             Text(
+                modifier = Modifier
+                    .placeholder(
+                        visible = isNetworkFeeLoading,
+                        color = RadixTheme.colors.defaultText.copy(alpha = 0.2f),
+                        shape = RadixTheme.shapes.roundedRectSmall,
+                        highlight = PlaceholderHighlight.shimmer(
+                            highlightColor = White
+                        ),
+                        placeholderFadeTransitionSpec = { tween() },
+                        contentFadeTransitionSpec = { tween() }
+                    ),
                 text = "${fees.transactionFeeToLock.displayableQuantity()} XRD",
                 style = RadixTheme.typography.body1Link,
                 color = RadixTheme.colors.gray1
@@ -68,17 +85,19 @@ fun NetworkFeeContent(
         }
 
         if (noFeePayerSelected) {
-            InfoLink(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        horizontal = RadixTheme.dimensions.paddingDefault,
-                        vertical = RadixTheme.dimensions.paddingSmall
-                    ),
-                text = stringResource(id = R.string.transactionReview_customizeNetworkFeeSheet_selectFeePayer_warning),
-                contentColor = RadixTheme.colors.orange1,
-                iconRes = com.babylon.wallet.android.designsystem.R.drawable.ic_warning_error
-            )
+            if (!isNetworkFeeLoading) {
+                InfoLink(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = RadixTheme.dimensions.paddingDefault,
+                            vertical = RadixTheme.dimensions.paddingSmall
+                        ),
+                    text = stringResource(id = R.string.transactionReview_customizeNetworkFeeSheet_selectFeePayer_warning),
+                    contentColor = RadixTheme.colors.orange1,
+                    iconRes = com.babylon.wallet.android.designsystem.R.drawable.ic_warning_error
+                )
+            }
         } else if (insufficientBalanceToPayTheFee) {
             InfoLink(
                 modifier = Modifier
@@ -95,7 +114,8 @@ fun NetworkFeeContent(
 
         RadixTextButton(
             text = stringResource(id = R.string.transactionReview_networkFee_customizeButtonTitle),
-            onClick = onCustomizeClick
+            onClick = onCustomizeClick,
+            enabled = !isNetworkFeeLoading
         )
     }
 }
@@ -107,6 +127,7 @@ fun NetworkFeeContentPreview() {
         fees = TransactionFees(),
         noFeePayerSelected = false,
         insufficientBalanceToPayTheFee = false,
+        isNetworkFeeLoading = false,
         onCustomizeClick = {}
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
@@ -141,6 +141,7 @@ fun TransactionPreviewHeaderPreview() {
                     requestMetadata = MessageFromDataChannel.IncomingRequest.RequestMetadata.internal(Radix.Gateway.default.network.id)
                 ),
                 isLoading = false,
+                isNetworkFeeLoading = false,
                 previewType = PreviewType.None
             ),
             onRawManifestClick = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewTypeContent.kt
@@ -86,6 +86,7 @@ fun TransactionPreviewTypePreview() {
             state = TransactionReviewViewModel.State(
                 request = SampleDataProvider().transactionRequest,
                 isLoading = false,
+                isNetworkFeeLoading = false,
                 previewType = PreviewType.NonConforming
             ),
             preview = PreviewType.Transfer(


### PR DESCRIPTION
…view screen to speed up loading process.

## Description
https://radixdlt.atlassian.net/browse/ABW-2473

### Screenshots (optional)
https://github.com/radixdlt/babylon-wallet-android/assets/108684750/588934c2-a659-4df0-af9f-519b1afa1387

### Notes (optional)
I added shimmer instead of loading as mentioned in the ticket as I think its nicer and will be consistent with behaviour we have in the AssetRow.