### PR TITLE
[ABW-2528] Improve viewmodel delegates

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/ViewModelDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/ViewModelDelegate.kt
@@ -1,0 +1,19 @@
+package com.babylon.wallet.android.presentation.common
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+
+@Suppress("VariableNaming")
+open class ViewModelDelegate<T : UiState> {
+
+    lateinit var viewModelScope: CoroutineScope
+    lateinit var _state: MutableStateFlow<T>
+
+    operator fun invoke(
+        scope: CoroutineScope,
+        state: MutableStateFlow<T>
+    ) {
+        this.viewModelScope = scope
+        _state = state
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -139,13 +139,9 @@ fun TransactionReviewScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        viewModel.oneOffEvent.collect { event ->
-            when (event) {
-                TransactionReviewViewModel.Event.Dismiss -> {
-                    onDismiss()
-                }
-            }
+    LaunchedEffect(state.isTransactionDismissed) {
+        if (state.isTransactionDismissed) {
+            onDismiss()
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -92,7 +92,7 @@ class TransactionAnalysisDelegate @Inject constructor(
             signersCount = notaryAndSigners.signers.count()
         )
 
-        state.update {
+        _state.update {
             it.copy(
                 isRawManifestVisible = previewType == PreviewType.NonConforming,
                 isLoading = false,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFeesDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFeesDelegate.kt
@@ -1,37 +1,37 @@
 package com.babylon.wallet.android.presentation.transaction.fees
 
-import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel.State
-import kotlinx.coroutines.flow.MutableStateFlow
+import com.babylon.wallet.android.presentation.common.ViewModelDelegate
+import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel
 import kotlinx.coroutines.flow.update
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.accountOnCurrentNetwork
 import java.math.BigDecimal
+import javax.inject.Inject
 
-class TransactionFeesDelegate(
-    private val state: MutableStateFlow<State>,
+class TransactionFeesDelegate @Inject constructor(
     private val getProfileUseCase: GetProfileUseCase
-) {
+) : ViewModelDelegate<TransactionReviewViewModel.State>() {
 
     @Suppress("NestedBlockDepth")
     suspend fun onCustomizeClick() {
-        if (state.value.transactionFees.defaultTransactionFee == BigDecimal.ZERO) {
+        if (_state.value.transactionFees.defaultTransactionFee == BigDecimal.ZERO) {
             // None required
-            state.update { state ->
+            _state.update { state ->
                 state.noneRequiredState()
             }
         } else {
-            state.value.feePayerSearchResult?.let { feePayerResult ->
+            _state.value.feePayerSearchResult?.let { feePayerResult ->
                 if (feePayerResult.feePayerAddress != null) {
                     // Candidate selected
                     getProfileUseCase.accountOnCurrentNetwork(withAddress = feePayerResult.feePayerAddress)
                         ?.let { feePayerCandidate ->
-                            state.update { state ->
+                            _state.update { state ->
                                 state.candidateSelectedState(feePayerCandidate)
                             }
                         }
                 } else {
                     // No candidate selected
-                    state.update { state ->
+                    _state.update { state ->
                         state.noCandidateSelectedState()
                     }
                 }
@@ -48,8 +48,8 @@ class TransactionFeesDelegate(
     }
 
     fun onFeePaddingAmountChanged(feePaddingAmount: String) {
-        val transactionFees = state.value.transactionFees
-        state.update { state ->
+        val transactionFees = _state.value.transactionFees
+        _state.update { state ->
             state.copy(
                 transactionFees = transactionFees.copy(
                     feePaddingAmount = feePaddingAmount
@@ -60,9 +60,9 @@ class TransactionFeesDelegate(
 
     @Suppress("MagicNumber")
     fun onTipPercentageChanged(tipPercentage: String) {
-        val transactionFees = state.value.transactionFees
+        val transactionFees = _state.value.transactionFees
 
-        state.update { state ->
+        _state.update { state ->
             state.copy(
                 transactionFees = transactionFees.copy(
                     tipPercentage = tipPercentage.filter { it.isDigit() }
@@ -72,19 +72,19 @@ class TransactionFeesDelegate(
     }
 
     fun onViewDefaultModeClick() {
-        state.update { state ->
+        _state.update { state ->
             state.defaultModeState()
         }
     }
 
     fun onViewAdvancedModeClick() {
-        state.update { state ->
+        _state.update { state ->
             state.advancedModeState()
         }
     }
 
     private fun switchToFeePayerSelection() {
-        state.update { state ->
+        _state.update { state ->
             state.feePayerSelectionState()
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/guarantees/TransactionGuaranteesDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/guarantees/TransactionGuaranteesDelegate.kt
@@ -3,20 +3,20 @@ package com.babylon.wallet.android.presentation.transaction.guarantees
 import com.babylon.wallet.android.domain.model.GuaranteeType
 import com.babylon.wallet.android.domain.model.Transferable
 import com.babylon.wallet.android.domain.model.TransferableResource
+import com.babylon.wallet.android.presentation.common.ViewModelDelegate
 import com.babylon.wallet.android.presentation.transaction.AccountWithPredictedGuarantee
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
 import com.babylon.wallet.android.presentation.transaction.PreviewType
-import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel.State
-import kotlinx.coroutines.flow.MutableStateFlow
+import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel
+import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel.State.Sheet
 import kotlinx.coroutines.flow.update
 import rdx.works.core.mapWhen
+import javax.inject.Inject
 
-class TransactionGuaranteesDelegate(
-    private val state: MutableStateFlow<State>
-) {
+class TransactionGuaranteesDelegate @Inject constructor() : ViewModelDelegate<TransactionReviewViewModel.State>() {
 
     fun onEdit() {
-        val transaction = (state.value.previewType as? PreviewType.Transfer) ?: return
+        val transaction = (_state.value.previewType as? PreviewType.Transfer) ?: return
 
         val accountsWithPredictedGuarantee = mutableListOf<AccountWithPredictedGuarantee>()
         transaction.to.forEach { depositing ->
@@ -40,6 +40,7 @@ class TransactionGuaranteesDelegate(
                         )
                     }
                 }
+
                 is AccountWithTransferableResources.Owned -> {
                     predictedAmounts.forEach { amount ->
                         accountsWithPredictedGuarantee.add(
@@ -55,9 +56,9 @@ class TransactionGuaranteesDelegate(
             }
         }
 
-        state.update {
+        _state.update {
             it.copy(
-                sheetState = State.Sheet.CustomizeGuarantees(
+                sheetState = Sheet.CustomizeGuarantees(
                     accountsWithPredictedGuarantees = accountsWithPredictedGuarantee
                 )
             )
@@ -65,9 +66,9 @@ class TransactionGuaranteesDelegate(
     }
 
     fun onValueChange(account: AccountWithPredictedGuarantee, value: String) {
-        val sheet = (state.value.sheetState as? State.Sheet.CustomizeGuarantees) ?: return
+        val sheet = (_state.value.sheetState as? Sheet.CustomizeGuarantees) ?: return
 
-        state.update { state ->
+        _state.update { state ->
             state.copy(
                 sheetState = sheet.copy(
                     accountsWithPredictedGuarantees = sheet.accountsWithPredictedGuarantees.mapWhen(
@@ -80,9 +81,9 @@ class TransactionGuaranteesDelegate(
     }
 
     fun onValueIncreased(account: AccountWithPredictedGuarantee) {
-        val sheet = (state.value.sheetState as? State.Sheet.CustomizeGuarantees) ?: return
+        val sheet = (_state.value.sheetState as? Sheet.CustomizeGuarantees) ?: return
 
-        state.update { state ->
+        _state.update { state ->
             state.copy(
                 sheetState = sheet.copy(
                     accountsWithPredictedGuarantees = sheet.accountsWithPredictedGuarantees.mapWhen(
@@ -95,9 +96,9 @@ class TransactionGuaranteesDelegate(
     }
 
     fun onValueDecreased(account: AccountWithPredictedGuarantee) {
-        val sheet = (state.value.sheetState as? State.Sheet.CustomizeGuarantees) ?: return
+        val sheet = (_state.value.sheetState as? Sheet.CustomizeGuarantees) ?: return
 
-        state.update { state ->
+        _state.update { state ->
             state.copy(
                 sheetState = sheet.copy(
                     accountsWithPredictedGuarantees = sheet.accountsWithPredictedGuarantees.mapWhen(
@@ -110,14 +111,14 @@ class TransactionGuaranteesDelegate(
     }
 
     fun onClose() {
-        state.update { it.copy(sheetState = State.Sheet.None) }
+        _state.update { it.copy(sheetState = Sheet.None) }
     }
 
     fun onApply() {
-        val sheet = (state.value.sheetState as? State.Sheet.CustomizeGuarantees) ?: return
-        val preview = (state.value.previewType as? PreviewType.Transfer) ?: return
+        val sheet = (_state.value.sheetState as? Sheet.CustomizeGuarantees) ?: return
+        val preview = (_state.value.previewType as? PreviewType.Transfer) ?: return
 
-        state.update {
+        _state.update {
             it.copy(
                 previewType = preview.copy(
                     to = preview.to.mapWhen(
@@ -129,7 +130,7 @@ class TransactionGuaranteesDelegate(
                         }
                     )
                 ),
-                sheetState = State.Sheet.None
+                sheetState = Sheet.None
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
@@ -215,8 +215,7 @@ class TransactionSubmitDelegate @Inject constructor(
                     }
 
                     else -> {
-                        val walletErrorType =
-                            (dappRequestException.failure as? DappRequestFailure)?.toWalletErrorType()
+                        val walletErrorType = (dappRequestException.failure as? DappRequestFailure)?.toWalletErrorType()
                         reportFailure(error)
                         appEventBus.sendEvent(
                             AppEvent.Status.Transaction.Fail(
@@ -225,7 +224,7 @@ class TransactionSubmitDelegate @Inject constructor(
                                 isInternal = transactionRequest.isInternal,
                                 errorMessage = UiMessage.ErrorMessage.from((error as? DappRequestException)?.failure),
                                 blockUntilComplete = transactionRequest.blockUntilComplete,
-                                txProcessingTime = state.value.txProcessingTime,
+                                txProcessingTime = _state.value.txProcessingTime,
                                 walletErrorType = walletErrorType
                             )
                         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
@@ -5,18 +5,18 @@ import com.babylon.wallet.android.domain.common.onValue
 import com.babylon.wallet.android.domain.model.assets.Assets
 import com.babylon.wallet.android.domain.usecases.GetAccountsWithAssetsUseCase
 import com.babylon.wallet.android.presentation.common.UiMessage
+import com.babylon.wallet.android.presentation.common.ViewModelDelegate
 import com.babylon.wallet.android.presentation.transfer.SpendingAsset
 import com.babylon.wallet.android.presentation.transfer.TargetAccount
 import com.babylon.wallet.android.presentation.transfer.TransferViewModel
 import com.babylon.wallet.android.presentation.transfer.TransferViewModel.State.Sheet
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import rdx.works.profile.data.model.pernetwork.Network
+import javax.inject.Inject
 
-class AssetsChooserDelegate(
-    private val state: MutableStateFlow<TransferViewModel.State>,
+class AssetsChooserDelegate @Inject constructor(
     private val getAccountsWithAssetsUseCase: GetAccountsWithAssetsUseCase
-) {
+) : ViewModelDelegate<TransferViewModel.State>() {
 
     /**
      * Starts the assets chooser flow
@@ -28,7 +28,7 @@ class AssetsChooserDelegate(
         fromAccount: Network.Account,
         targetAccount: TargetAccount
     ) {
-        state.update {
+        _state.update {
             it.copy(sheet = Sheet.ChooseAssets.init(forTargetAccount = targetAccount))
         }
 
@@ -66,7 +66,7 @@ class AssetsChooserDelegate(
     }
 
     fun onChooseAssetsSubmitted() {
-        state.update { state ->
+        _state.update { state ->
             val chooseAssetState = (state.sheet as? Sheet.ChooseAssets) ?: return@update state
 
             state
@@ -78,7 +78,7 @@ class AssetsChooserDelegate(
     private fun updateSheetState(
         onUpdate: (Sheet.ChooseAssets) -> Sheet.ChooseAssets
     ) {
-        state.update { state ->
+        _state.update { state ->
             if (state.sheet is Sheet.ChooseAssets) {
                 state.copy(sheet = onUpdate(state.sheet))
             } else {

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
@@ -257,6 +257,7 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
                 incomingRequestRepository = incomingRequestRepository,
                 appEventBus = appEventBus,
                 transactionStatusClient = transactionStatusClient,
+                submitTransactionUseCase = submitTransactionUseCase,
                 applicationScope = TestScope(),
             ),
             incomingRequestRepository = incomingRequestRepository,

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
@@ -31,6 +31,10 @@ import com.babylon.wallet.android.domain.usecases.transaction.SubmitTransactionU
 import com.babylon.wallet.android.mockdata.account
 import com.babylon.wallet.android.mockdata.profile
 import com.babylon.wallet.android.presentation.StateViewModelTest
+import com.babylon.wallet.android.presentation.transaction.analysis.TransactionAnalysisDelegate
+import com.babylon.wallet.android.presentation.transaction.fees.TransactionFeesDelegate
+import com.babylon.wallet.android.presentation.transaction.guarantees.TransactionGuaranteesDelegate
+import com.babylon.wallet.android.presentation.transaction.submit.TransactionSubmitDelegate
 import com.babylon.wallet.android.utils.AppEventBus
 import com.babylon.wallet.android.utils.DeviceSecurityHelper
 import com.radixdlt.ret.Decimal
@@ -55,6 +59,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -232,20 +237,30 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
     override fun initVM(): TransactionReviewViewModel {
         return TransactionReviewViewModel(
             transactionClient = transactionClient,
-            getAccountsWithAssetsUseCase = getAccountsWithAssetsUseCase,
-            getResourcesMetadataUseCase = getResourcesMetadataUseCase,
-            getProfileUseCase = getProfileUseCase,
-            getTransactionBadgesUseCase = getTransactionBadgesUseCase,
-            resolveDAppsUseCase = resolveDAppsUseCase,
-            getCurrentGatewayUseCase = getCurrentGatewayUseCase,
-            dAppMessenger = dAppMessenger,
-            appEventBus = appEventBus,
+            analysis = TransactionAnalysisDelegate(
+                getProfileUseCase = getProfileUseCase,
+                getAccountsWithAssetsUseCase = getAccountsWithAssetsUseCase,
+                getResourcesMetadataUseCase = getResourcesMetadataUseCase,
+                getResourcesUseCase = getResourcesUseCase,
+                getTransactionBadgesUseCase = getTransactionBadgesUseCase,
+                resolveDAppsUseCase = resolveDAppsUseCase,
+                transactionClient = transactionClient,
+            ),
+            guarantees = TransactionGuaranteesDelegate(),
+            fees = TransactionFeesDelegate(
+                getProfileUseCase = getProfileUseCase,
+            ),
+            submit = TransactionSubmitDelegate(
+                transactionClient = transactionClient,
+                dAppMessenger = dAppMessenger,
+                getCurrentGatewayUseCase = getCurrentGatewayUseCase,
+                incomingRequestRepository = incomingRequestRepository,
+                appEventBus = appEventBus,
+                transactionStatusClient = transactionStatusClient,
+                applicationScope = TestScope(),
+            ),
             incomingRequestRepository = incomingRequestRepository,
-            appScope = TestScope(),
             savedStateHandle = savedStateHandle,
-            transactionStatusClient = transactionStatusClient,
-            getResourcesUseCase = getResourcesUseCase,
-            submitTransactionUseCase = submitTransactionUseCase
         )
     }
 
@@ -281,7 +296,7 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
             )
         }
         assertEquals(WalletErrorType.WrongNetwork, errorSlot.captured)
-        assertEquals(TransactionReviewViewModel.Event.Dismiss, vm.oneOffEvent.first())
+        assertTrue(vm.state.value.isTransactionDismissed)
     }
 
     @Test

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transfer/TransferViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transfer/TransferViewModelTest.kt
@@ -8,6 +8,9 @@ import com.babylon.wallet.android.domain.usecases.GetAccountsWithAssetsUseCase
 import com.babylon.wallet.android.mockdata.account
 import com.babylon.wallet.android.mockdata.profile
 import com.babylon.wallet.android.presentation.StateViewModelTest
+import com.babylon.wallet.android.presentation.transfer.accounts.AccountsChooserDelegate
+import com.babylon.wallet.android.presentation.transfer.assets.AssetsChooserDelegate
+import com.babylon.wallet.android.presentation.transfer.prepare.PrepareManifestDelegate
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.collections.immutable.persistentListOf
@@ -56,9 +59,16 @@ class TransferViewModelTest : StateViewModelTest<TransferViewModel>() {
     override fun initVM(): TransferViewModel {
         return TransferViewModel(
             getProfileUseCase = getProfileUseCase,
-            getAccountsWithAssetsUseCase = getAccountsWithAssetsUseCase,
-            incomingRequestRepository = incomingRequestRepository,
-            mnemonicRepository = mnemonicRepository,
+            accountsChooserDelegate = AccountsChooserDelegate(
+                getProfileUseCase = getProfileUseCase
+            ),
+            assetsChooserDelegate = AssetsChooserDelegate(
+                getAccountsWithAssetsUseCase = getAccountsWithAssetsUseCase
+            ),
+            prepareManifestDelegate = PrepareManifestDelegate(
+                incomingRequestRepository = incomingRequestRepository,
+                mnemonicRepository = mnemonicRepository
+            ),
             savedStateHandle = savedStateHandle
         )
     }


### PR DESCRIPTION
## Description
This PR is a showcase for how we can (slightly) improve the way we create delegates in the viewmodel.

The goal is: 
- to reduce the amount of the constructor parameters in the viewmodels
- to inject the required parameters in the delagates

If we want to go further, we can make an interface with the attributes and functions that we want to delegate, and then the viewmodel can implement that interface by delegating the implementation.