### PR TITLE
[ABW-2535] handle requests that need signature and were already granted

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
@@ -42,6 +42,9 @@ class AuthorizeSpecifiedPersonaUseCase @Inject constructor(
             RadixWalletException.DappRequestException.NotPossibleToAuthenticateAutomatically
         )
         (incomingRequest as? AuthorizedRequest)?.let { request ->
+            if (incomingRequest.needSignatures()) {
+                return@let
+            }
             (request.authRequest as? AuthorizedRequest.AuthRequest.UsePersonaRequest)?.let {
                 val authorizedDapp = dAppConnectionRepository.getAuthorizedDapp(
                     dAppDefinitionAddress = request.metadata.dAppDefinitionAddress

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/InitialAuthorizedLoginRoute.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/InitialAuthorizedLoginRoute.kt
@@ -3,6 +3,7 @@ package com.babylon.wallet.android.presentation.dapp
 import com.babylon.wallet.android.domain.model.RequiredPersonaFields
 
 sealed interface InitialAuthorizedLoginRoute {
+    data object CompleteRequest : InitialAuthorizedLoginRoute
     data class SelectPersona(val dappDefinitionAddress: String) : InitialAuthorizedLoginRoute
     data class Permission(
         val numberOfAccounts: Int,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/DappLoginAuthorizedNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/DappLoginAuthorizedNavGraph.kt
@@ -41,10 +41,14 @@ fun NavGraphBuilder.dappLoginAuthorizedNavGraph(navController: NavController) {
             },
             navigateToSelectPersona = { dappDefinitionAddress ->
                 navController.selectPersona(dappDefinitionAddress)
+            },
+            onLoginFlowComplete = {
+                navController.popBackStack(ROUTE_DAPP_LOGIN_AUTHORIZED_GRAPH, true)
+            },
+            navigateToOngoingPersonaData = { personaAddress, requiredFields ->
+                navController.personaDataOngoing(personaAddress, requiredFields)
             }
-        ) { personaAddress, requiredFields ->
-            navController.personaDataOngoing(personaAddress, requiredFields)
-        }
+        )
         selectPersona(
             navController = navController,
             onBackClick = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginNav.kt
@@ -36,6 +36,7 @@ fun NavGraphBuilder.dAppLoginAuthorized(
     navigateToOneTimePersonaData: (RequiredPersonaFields) -> Unit,
     navigateToSelectPersona: (String) -> Unit,
     navigateToOngoingPersonaData: (String, RequiredPersonaFields) -> Unit,
+    onLoginFlowComplete: () -> Unit,
 ) {
     composable(
         route = ROUTE_DAPP_LOGIN_AUTHORIZED_SCREEN,
@@ -56,8 +57,8 @@ fun NavGraphBuilder.dAppLoginAuthorized(
             navigateToPermissions = navigateToPermissions,
             navigateToOneTimePersonaData = navigateToOneTimePersonaData,
             navigateToSelectPersona = navigateToSelectPersona,
-            navigateToOngoingPersonaData = navigateToOngoingPersonaData
-
+            navigateToOngoingPersonaData = navigateToOngoingPersonaData,
+            onLoginFlowComplete = onLoginFlowComplete
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
@@ -1,19 +1,24 @@
 package com.babylon.wallet.android.presentation.dapp.authorized.login
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.R
@@ -22,8 +27,12 @@ import com.babylon.wallet.android.domain.model.RequiredPersonaFields
 import com.babylon.wallet.android.domain.userFriendlyMessage
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
 import com.babylon.wallet.android.presentation.dapp.InitialAuthorizedLoginRoute
+import com.babylon.wallet.android.presentation.status.signing.SigningStatusBottomDialog
+import com.babylon.wallet.android.presentation.ui.composables.BackIconType
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
+import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUiMessageHandler
+import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import kotlinx.coroutines.flow.filterIsInstance
 
 @Composable
@@ -37,10 +46,33 @@ fun DappAuthorizedLoginScreen(
     navigateToOngoingPersonaData: (String, RequiredPersonaFields) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.filterIsInstance<Event.CloseLoginFlow>().collect {
             onBackClick()
         }
+    }
+    val sharedState by viewModel.state.collectAsStateWithLifecycle()
+    val initialRoute = sharedState.initialAuthorizedLoginRoute
+    BackHandler {
+        viewModel.onAbortDappLogin()
+    }
+    LaunchedEffect(initialRoute) {
+        if (initialRoute == InitialAuthorizedLoginRoute.CompleteRequest) {
+            viewModel.completeRequestHandling(deviceBiometricAuthenticationProvider = {
+                context.biometricAuthenticateSuspend()
+            }, abortOnFailure = true)
+        }
+    }
+    if (sharedState.isNoMnemonicErrorVisible) {
+        BasicPromptAlertDialog(
+            finish = {
+                viewModel.dismissNoMnemonicError()
+            },
+            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            dismissText = null
+        )
     }
     val state by viewModel.state.collectAsStateWithLifecycle()
     when (val route = state.initialAuthorizedLoginRoute) {
@@ -50,35 +82,49 @@ fun DappAuthorizedLoginScreen(
             route.oneTime,
             route.showBack
         )
+
         is InitialAuthorizedLoginRoute.OneTimePersonaData -> navigateToOneTimePersonaData(route.requiredPersonaFields)
         is InitialAuthorizedLoginRoute.OngoingPersonaData -> navigateToOngoingPersonaData(
             route.personaAddress,
             route.requiredPersonaFields
         )
+
         is InitialAuthorizedLoginRoute.Permission -> navigateToPermissions(
             route.numberOfAccounts,
             route.isExactAccountsCount,
             route.oneTime,
             route.showBack
         )
+
         is InitialAuthorizedLoginRoute.SelectPersona -> navigateToSelectPersona(route.dappDefinitionAddress)
         else -> {}
     }
-    Box(
-        modifier = modifier
-            .systemBarsPadding()
-            .navigationBarsPadding()
-            .fillMaxSize()
-            .background(RadixTheme.colors.defaultBackground)
-    ) {
-        AnimatedVisibility(
-            visible = state.initialAuthorizedLoginRoute == null,
-            enter = fadeIn(),
-            exit = fadeOut(),
-            modifier = Modifier.fillMaxSize()
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            RadixCenteredTopAppBar(
+                title = stringResource(id = R.string.empty),
+                backIconType = BackIconType.Close,
+                onBackClick = viewModel::onAbortDappLogin,
+                windowInsets = WindowInsets.statusBars
+            )
+        },
+        containerColor = RadixTheme.colors.defaultBackground
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .background(RadixTheme.colors.defaultBackground)
         ) {
-            FullscreenCircularProgressContent()
-        }
+            AnimatedVisibility(
+                visible = state.initialAuthorizedLoginRoute == null,
+                enter = fadeIn(),
+                exit = fadeOut(),
+                modifier = Modifier.fillMaxSize()
+            ) {
+                FullscreenCircularProgressContent()
+            }
 
         when (val dialogState = state.failureDialog) {
             is DAppLoginUiState.FailureDialog.Closed -> {}
@@ -105,10 +151,18 @@ fun DappAuthorizedLoginScreen(
             }
         }
 
-        SnackbarUiMessageHandler(
-            message = state.uiMessage,
-            onMessageShown = viewModel::onMessageShown,
-            modifier = Modifier.imePadding()
-        )
+            SnackbarUiMessageHandler(
+                message = state.uiMessage,
+                onMessageShown = viewModel::onMessageShown,
+                modifier = Modifier.imePadding()
+            )
+            sharedState.interactionState?.let {
+                SigningStatusBottomDialog(
+                    modifier = Modifier.fillMaxHeight(0.8f),
+                    onDismissDialogClick = viewModel::onDismissSigningStatusDialog,
+                    interactionState = it
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
@@ -127,30 +127,30 @@ fun DappAuthorizedLoginScreen(
                 FullscreenCircularProgressContent()
             }
 
-        when (val dialogState = state.failureDialog) {
-            is DAppLoginUiState.FailureDialog.Closed -> {}
-            is DAppLoginUiState.FailureDialog.Open -> {
-                BasicPromptAlertDialog(
-                    finish = { viewModel.onAcknowledgeFailureDialog() },
-                    title = {
-                        Text(
-                            text = stringResource(id = R.string.error_dappRequest_invalidRequest),
-                            style = RadixTheme.typography.body1Header,
-                            color = RadixTheme.colors.gray1
-                        )
-                    },
-                    text = {
-                        Text(
-                            text = dialogState.dappRequestException.userFriendlyMessage(),
-                            style = RadixTheme.typography.body2Regular,
-                            color = RadixTheme.colors.gray1
-                        )
-                    },
-                    confirmText = stringResource(id = R.string.common_cancel),
-                    dismissText = null
-                )
+            when (val dialogState = state.failureDialog) {
+                is DAppLoginUiState.FailureDialog.Closed -> {}
+                is DAppLoginUiState.FailureDialog.Open -> {
+                    BasicPromptAlertDialog(
+                        finish = { viewModel.onAcknowledgeFailureDialog() },
+                        title = {
+                            Text(
+                                text = stringResource(id = R.string.error_dappRequest_invalidRequest),
+                                style = RadixTheme.typography.body1Header,
+                                color = RadixTheme.colors.gray1
+                            )
+                        },
+                        text = {
+                            Text(
+                                text = dialogState.dappRequestException.userFriendlyMessage(),
+                                style = RadixTheme.typography.body2Regular,
+                                color = RadixTheme.colors.gray1
+                            )
+                        },
+                        confirmText = stringResource(id = R.string.common_cancel),
+                        dismissText = null
+                    )
+                }
             }
-        }
 
             SnackbarUiMessageHandler(
                 message = state.uiMessage,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -670,7 +670,10 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
         sendEvent(Event.RequestCompletionBiometricPrompt(request.needSignatures()))
     }
 
-    fun completeRequestHandling(deviceBiometricAuthenticationProvider: suspend () -> Boolean = { true }, abortOnFailure: Boolean = false) {
+    fun completeRequestHandling(
+        deviceBiometricAuthenticationProvider: suspend () -> Boolean = { true },
+        abortOnFailure: Boolean = false
+    ) {
         viewModelScope.launch {
             val selectedPersona = state.value.selectedPersona?.persona
             requireNotNull(selectedPersona)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
@@ -40,6 +40,7 @@ import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.model.DAppWithMetadata
 import com.babylon.wallet.android.domain.model.resources.metadata.NameMetadataItem
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
+import com.babylon.wallet.android.presentation.dapp.InitialAuthorizedLoginRoute
 import com.babylon.wallet.android.presentation.dapp.authorized.login.DAppAuthorizedLoginViewModel
 import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
 import com.babylon.wallet.android.presentation.status.signing.SigningStatusBottomDialog
@@ -105,7 +106,13 @@ fun SelectPersonaScreen(
     }
     val state by viewModel.state.collectAsStateWithLifecycle()
     val sharedState by sharedViewModel.state.collectAsStateWithLifecycle()
-    BackHandler(enabled = true) {}
+    BackHandler {
+        if (sharedState.initialAuthorizedLoginRoute is InitialAuthorizedLoginRoute.SelectPersona) {
+            sharedViewModel.onAbortDappLogin()
+        } else {
+            onBackClick()
+        }
+    }
     SelectPersonaContent(
         onCancelClick = sharedViewModel::onAbortDappLogin,
         onContinueClick = sharedViewModel::personaSelectionConfirmed,


### PR DESCRIPTION
## Description
Before this change, if we granted access to accounts and (or) persona data, for example exactly 2 accounts, and fired same request again, but with proof of ownership, app would crash because we wanted to handle that request entirely in the background, without any UI, and we didn't prompt for biometrics.
After the fix in this scenario we trigger dapp login flow where we immediately prompt for biometrics, if granted we show signing sheet, and if signatures are successfull, we immediately complete request.
If mnemonic for account is missing, we display same dialog as in other places.


## How to test

1. Trigger ongoing request for accounts, complete the flow
2. Now trigger same request but check with proof in Sandbox dapp
3. Verify that handling is as described above.

## Video

https://github.com/radixdlt/babylon-wallet-android/assets/118203440/db79fa6b-b028-4f6c-b193-07fa42edace5

Black screen is when I authenticate

## PR submission checklist
- [x] I have tested dapp login flow and have confirmed that it works
