### PR TITLE
ABW-2534 - Dashboard url determined based on networkId.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
@@ -23,7 +23,7 @@ data class ActionableAddress(
         if (shouldTruncateAddressForDisplay) address.truncatedHash() else address
     }
 
-    fun toDashboardUrl(networkId: NetworkId?): String {
+    fun toDashboardUrl(networkId: NetworkId): String {
         val suffix = when {
             isNft -> "nft/$address"
             type == Type.TRANSACTION -> "transaction/$address"
@@ -32,7 +32,7 @@ data class ActionableAddress(
             else -> address
         }
 
-        val url = networkId?.dashboardUrl()
+        val url = networkId.dashboardUrl()
 
         return "$url/$suffix"
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
@@ -2,7 +2,6 @@ package com.babylon.wallet.android.presentation.model
 
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.utils.truncatedHash
-import rdx.works.core.AddressValidator
 import rdx.works.profile.data.model.apppreferences.Radix.dashboardUrl
 import rdx.works.profile.derivation.model.NetworkId
 
@@ -24,7 +23,7 @@ data class ActionableAddress(
         if (shouldTruncateAddressForDisplay) address.truncatedHash() else address
     }
 
-    fun toDashboardUrl(): String {
+    fun toDashboardUrl(networkId: NetworkId?): String {
         val suffix = when {
             isNft -> "nft/$address"
             type == Type.TRANSACTION -> "transaction/$address"
@@ -33,14 +32,8 @@ data class ActionableAddress(
             else -> address
         }
 
-        val url = if (type == Type.TRANSACTION) {
-            NetworkId.Mainnet.dashboardUrl()
-        } else {
-            val globalAddress = address.split(NFT_DELIMITER)[0]
-            AddressValidator.getValidNetworkId(globalAddress)?.let {
-                NetworkId.from(it)
-            }?.dashboardUrl() ?: NetworkId.Mainnet.dashboardUrl()
-        }
+        val url = networkId?.dashboardUrl()
+
         return "$url/$suffix"
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
@@ -226,7 +226,8 @@ private fun SuccessContent(
         Text(
             text = "Transaction Success", // stringResource(id = R.string.transaction_status_success_title),
             style = RadixTheme.typography.title,
-            color = RadixTheme.colors.gray1
+            color = RadixTheme.colors.gray1,
+            textAlign = TextAlign.Center
         )
 
         Text(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ActionableAddressView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ActionableAddressView.kt
@@ -53,12 +53,13 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import rdx.works.profile.derivation.model.NetworkId
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.accountOnCurrentNetwork
-import rdx.works.profile.domain.gateway.GetCurrentGatewayUseCase
+import rdx.works.profile.domain.gateways
 import timber.log.Timber
 
 @Suppress("CyclomaticComplexMethod")
@@ -86,7 +87,7 @@ fun ActionableAddressView(
 
     LaunchedEffect(actionableAddress) {
         scope.launch {
-            val networkId = useCaseProvider.currentGatewayUseCase().invoke().network.networkId()
+            val networkId = useCaseProvider.profileUseCase().gateways.first().current().network.networkId()
 
             val copyAction = PopupActionItem(
                 name = context.getString(
@@ -338,7 +339,7 @@ private sealed interface OnAction {
 
         data class OpenExternalWebView(
             private val actionableAddress: ActionableAddress,
-            private val networkId: NetworkId?
+            private val networkId: NetworkId
         ) : CallbackBasedAction {
 
             @Suppress("SwallowedException")
@@ -381,8 +382,6 @@ private sealed interface OnAction {
 @InstallIn(SingletonComponent::class)
 private interface ActionableAddressViewEntryPoint {
     fun profileUseCase(): GetProfileUseCase
-
-    fun currentGatewayUseCase(): GetCurrentGatewayUseCase
 
     fun verifyAddressOnLedgerUseCase(): VerifyAddressOnLedgerUseCase
 

--- a/app/src/test/java/com/babylon/wallet/android/presentation/model/AddressDashboardUrlTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/model/AddressDashboardUrlTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import rdx.works.profile.derivation.model.NetworkId
 
 @RunWith(Parameterized::class)
 internal class AddressDashboardUrlTest(
@@ -13,7 +14,7 @@ internal class AddressDashboardUrlTest(
 
     @Test
     fun `convert of address to dashboard url`() {
-        assertEquals(url, ActionableAddress(address).toDashboardUrl())
+        assertEquals(url, ActionableAddress(address).toDashboardUrl(networkId = NetworkId.Mainnet))
     }
 
 
@@ -22,10 +23,10 @@ internal class AddressDashboardUrlTest(
         @Parameterized.Parameters(name = "\"{0}\" => {1}")
         fun data() : Collection<Array<Any>> {
             return listOf(
-                arrayOf(RESOURCE_ADDRESS, "$BASE_NETWORK_URL/resource/$RESOURCE_ADDRESS"),
-                arrayOf(RESOURCE_NFT_ADDRESS, "$BASE_NETWORK_URL/nft/$RESOURCE_NFT_ADDRESS"),
-                arrayOf(ACCOUNT_ADDRESS, "$BASE_NETWORK_URL/account/$ACCOUNT_ADDRESS"),
-                arrayOf(PACKAGE_ADDRESS, "$BASE_NETWORK_URL/package/$PACKAGE_ADDRESS"),
+                arrayOf(RESOURCE_ADDRESS, "$BASE_MAIN_URL/resource/$RESOURCE_ADDRESS"),
+                arrayOf(RESOURCE_NFT_ADDRESS, "$BASE_MAIN_URL/nft/$RESOURCE_NFT_ADDRESS"),
+                arrayOf(ACCOUNT_ADDRESS, "$BASE_MAIN_URL/account/$ACCOUNT_ADDRESS"),
+                arrayOf(PACKAGE_ADDRESS, "$BASE_MAIN_URL/package/$PACKAGE_ADDRESS"),
                 arrayOf(
                     "txid_tdx_e_106vpmdem94zr2x4yt2rf4l935d26pzrnlmz6wzwrwgz8s6jpyhmsa5ze2x",
                     "$BASE_MAIN_URL/transaction/txid_tdx_e_106vpmdem94zr2x4yt2rf4l935d26pzrnlmz6wzwrwgz8s6jpyhmsa5ze2x"
@@ -34,12 +35,11 @@ internal class AddressDashboardUrlTest(
                     "txid_tdx_22_1t0sdhcc6usx8sun36cd95jn6xlwzt4mw3gctz5r5yp94fjss9u3syuqcxg",
                     "$BASE_MAIN_URL/transaction/txid_tdx_22_1t0sdhcc6usx8sun36cd95jn6xlwzt4mw3gctz5r5yp94fjss9u3syuqcxg"
                 ),
-                arrayOf(COMPONENT_ADDRESS, "$BASE_NETWORK_URL/component/$COMPONENT_ADDRESS"),
+                arrayOf(COMPONENT_ADDRESS, "$BASE_MAIN_URL/component/$COMPONENT_ADDRESS"),
                 arrayOf(UNKNOWN_ADDRESS, "$BASE_MAIN_URL/$UNKNOWN_ADDRESS")
             )
         }
 
-        private const val BASE_NETWORK_URL = "https://rcnet-v3-dashboard.radixdlt.com"
         private const val BASE_MAIN_URL = "https://dashboard.radixdlt.com"
         private const val RESOURCE_ADDRESS = "resource_tdx_e_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxx8rpsmc"
         private const val RESOURCE_NFT_ADDRESS = "resource_tdx_e_1t45e0q75zln8jk5z3vyxp88hrugj5p7alr8spspv2r79lv0px6rpdg:#1#"

--- a/core/src/main/java/rdx/works/core/AddressValidator.kt
+++ b/core/src/main/java/rdx/works/core/AddressValidator.kt
@@ -21,8 +21,4 @@ object AddressValidator {
     fun isValidNft(address: String): Boolean = runCatching {
         NonFungibleGlobalId(address)
     }.getOrNull() != null
-
-    fun getValidNetworkId(address: String) = runCatching {
-        Address(address)
-    }.getOrNull()?.networkId()?.toInt()
 }

--- a/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Radix.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Radix.kt
@@ -148,7 +148,7 @@ object Radix {
         }
     }
 
-    fun NetworkId.dashboardUrl() =
+    fun NetworkId?.dashboardUrl() =
         when (this) {
             NetworkId.Mainnet -> {
                 DASHBOARD_MAINNET_URL


### PR DESCRIPTION
## Description
This PR fixes a problem when user is navigated to Mainnet dashboard after successfully tx, even when being on different network.

## How to test

Given tx is successful, when View on Radix dashboard clicked, verify that user is navigated to correct dashboard associated with current networkID, not always to main net dashboard

## Screenshot

## PR submission checklist
- [x] I have tested navigating to Radix Dashboard after successful tx
- [x] I have added unit tests
