### PR TITLE
[ABW-2530] return proper exception when request can't be handled automatically

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
@@ -132,7 +132,9 @@ class AuthorizeSpecifiedPersonaUseCase @Inject constructor(
         hasOngoingPersonaDataRequest: Boolean,
         persona: Network.Persona
     ): Result<String?> {
-        var operationResult: Result<String?> = Result.failure(RadixWalletException.DappRequestException.InvalidRequest)
+        var operationResult: Result<String?> = Result.failure(
+            exception = RadixWalletException.DappRequestException.NotPossibleToAuthenticateAutomatically
+        )
         val selectedAccounts: List<Selectable<Network.Account>> = getAccountsWithGrantedAccess(
             request,
             authorizedDapp,


### PR DESCRIPTION
## Description
This side effect was introduced by exception refactor. When request can't be handled automatically, and we want to trigger dapp request handling flow, we should return specific exception to indicate that.

## How to test
Detailed step by step instruction how to reproduce can be found in linked ABW-2530 Jira ticket.

## PR submission checklist
- [x] I have verified that issue no longer happen after the fix
