### PR TITLE
ABW-1975 - Depositing accounts are ordered in the same way as in the wallet dashboard

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/GeneralTransferAnalysis.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/GeneralTransferAnalysis.kt
@@ -122,32 +122,57 @@ private fun TransactionType.GeneralTransaction.resolveFromAccounts(
     }
 }
 
+/**
+ * The account deposits order that comes from RET does not take into account the order we maintain in the app.
+ * This method sorts accounts in the same order they are appearing in the dashboard.
+ */
+fun Map<String, List<ResourceTracker>>.sort(allAccounts: List<Network.Account>): Map<String, List<ResourceTracker>> {
+    val allAccountsAddresses = allAccounts.map { it.address }
+
+    // Only account deposits that we own
+    val ownedAccountDeposits = this.toList().filter {
+        allAccountsAddresses.indexOf(it.first) != -1
+    }
+
+    // Sorted owned accounts deposits according to the all accounts order
+    val ownedAccountDepositsSorted = ownedAccountDeposits.sortedBy {
+        allAccountsAddresses.indexOf(it.first)
+    }.toMap()
+
+    // The rest of account deposits (ones we do not own)
+    val thirdPartyAccountDeposits = this.minus(ownedAccountDepositsSorted.keys)
+
+    return ownedAccountDepositsSorted.plus(thirdPartyAccountDeposits)
+}
+
 private fun TransactionType.GeneralTransaction.resolveToAccounts(
     allAssets: List<Assets>,
     allAccounts: List<Network.Account>,
     thirdPartyMetadata: Map<String, List<MetadataItem>> = emptyMap(),
     defaultDepositGuarantees: Double
-) = accountDeposits.map { depositEntry ->
-    val transferables = depositEntry.value.map {
-        it.toDepositingTransferableResource(
-            allAssets = allAssets,
-            newlyCreatedMetadata = metadataOfNewlyCreatedEntities,
-            newlyCreatedEntities = addressesOfNewlyCreatedEntities,
-            thirdPartyMetadata = thirdPartyMetadata,
-            defaultDepositGuarantees = defaultDepositGuarantees
-        )
-    }
+): List<AccountWithTransferableResources> {
+    return accountDeposits.sort(allAccounts).map { depositEntry ->
+        val transferables = depositEntry.value.map {
+            it.toDepositingTransferableResource(
+                allAssets = allAssets,
+                newlyCreatedMetadata = metadataOfNewlyCreatedEntities,
+                newlyCreatedEntities = addressesOfNewlyCreatedEntities,
+                thirdPartyMetadata = thirdPartyMetadata,
+                defaultDepositGuarantees = defaultDepositGuarantees
+            )
+        }
 
-    val ownedAccount = allAccounts.find { it.address == depositEntry.key }
-    if (ownedAccount != null) {
-        AccountWithTransferableResources.Owned(
-            account = ownedAccount,
-            resources = transferables
-        )
-    } else {
-        AccountWithTransferableResources.Other(
-            address = depositEntry.key,
-            resources = transferables
-        )
+        val ownedAccount = allAccounts.find { it.address == depositEntry.key }
+        if (ownedAccount != null) {
+            AccountWithTransferableResources.Owned(
+                account = ownedAccount,
+                resources = transferables
+            )
+        } else {
+            AccountWithTransferableResources.Other(
+                address = depositEntry.key,
+                resources = transferables
+            )
+        }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/GeneralTransferAnalysis.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/GeneralTransferAnalysis.kt
@@ -125,6 +125,7 @@ private fun TransactionType.GeneralTransaction.resolveFromAccounts(
 /**
  * The account deposits order that comes from RET does not take into account the order we maintain in the app.
  * This method sorts accounts in the same order they are appearing in the dashboard.
+ * TODO revisit if this can be done using Comparator.comparing { item -> allAccounts.map { it.address }.indexOf(item) }
  */
 fun Map<String, List<ResourceTracker>>.sort(allAccounts: List<Network.Account>): Map<String, List<ResourceTracker>> {
     val allAccountsAddresses = allAccounts.map { it.address }

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/GeneralTransactionAnalysisTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/GeneralTransactionAnalysisTest.kt
@@ -1,0 +1,91 @@
+package com.babylon.wallet.android.presentation.transaction
+
+import com.babylon.wallet.android.domain.SampleDataProvider
+import com.babylon.wallet.android.presentation.transaction.analysis.sort
+import com.radixdlt.ret.ResourceTracker
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class GeneralTransactionAnalysisTest {
+
+    @Test
+    fun `when deposit accounts are in the same order, order is retained`() = runTest {
+        val accountsDeposits = mapOf(
+            "rdx_t_1" to listOf<ResourceTracker>(),
+            "rdx_t_2" to listOf(),
+        )
+        val allAccounts = listOf(
+            SampleDataProvider().sampleAccount(
+                address = "rdx_t_1",
+                name = "One account"
+            ),
+            SampleDataProvider().sampleAccount(
+                address = "rdx_t_2",
+                name = "Two account"
+            ),
+            SampleDataProvider().sampleAccount(
+                address = "rdx_t_3",
+                name = "Three account"
+            )
+        )
+
+        val sortedAccountsDeposits = accountsDeposits.sort(allAccounts)
+        assert(sortedAccountsDeposits.keys.toList()[0] == allAccounts[0].address)
+        assert(sortedAccountsDeposits.keys.toList()[1] == allAccounts[1].address)
+    }
+
+    @Test
+    fun `when deposit accounts are not in the same order, order is taken after owned accounts`() = runTest {
+        val accountsDeposits = mapOf(
+            "rdx_t_2" to listOf<ResourceTracker>(),
+            "rdx_t_1" to listOf(),
+        )
+        val allAccounts = listOf(
+            SampleDataProvider().sampleAccount(
+                address = "rdx_t_1",
+                name = "One account"
+            ),
+            SampleDataProvider().sampleAccount(
+                address = "rdx_t_2",
+                name = "Two account"
+            ),
+            SampleDataProvider().sampleAccount(
+                address = "rdx_t_3",
+                name = "Three account"
+            )
+        )
+
+        val sortedAccountsDeposits = accountsDeposits.sort(allAccounts)
+        assert(sortedAccountsDeposits.keys.toList()[0] == allAccounts[0].address)
+        assert(sortedAccountsDeposits.keys.toList()[1] == allAccounts[1].address)
+    }
+
+    @Test
+    fun `when deposit accounts are not in the same order and have third party accounts, owned accounts shown first `() = runTest {
+        val accountsDeposits = mapOf(
+            "rdx_t_2" to listOf<ResourceTracker>(),
+            "rdx_t_1" to listOf(),
+            "rdx_t_third_party1" to listOf(),
+            "rdx_t_third_party2" to listOf()
+        )
+        val allAccounts = listOf(
+            SampleDataProvider().sampleAccount(
+                address = "rdx_t_1",
+                name = "One account"
+            ),
+            SampleDataProvider().sampleAccount(
+                address = "rdx_t_2",
+                name = "Two account"
+            ),
+            SampleDataProvider().sampleAccount(
+                address = "rdx_t_3",
+                name = "Three account"
+            )
+        )
+
+        val sortedAccountsDeposits = accountsDeposits.sort(allAccounts)
+        assert(sortedAccountsDeposits.keys.toList()[0] == allAccounts[0].address)
+        assert(sortedAccountsDeposits.keys.toList()[1] == allAccounts[1].address)
+        assert(sortedAccountsDeposits.keys.toList()[2] != allAccounts[2].address)
+    }
+}


### PR DESCRIPTION
Ticket -> https://radixdlt.atlassian.net/browse/ABW-1975

## Description
So far order of the depositing accounts was inherited from RET **accountDeposits**  which does not take into the account any order whatsoever.

This change is to keep the order of the Depositing accounts in the Tx Review in the same way as in the wallet dashboard.

## How to test

1. Go to https://radix-dapp-toolkit-dev.rdx-works-main.extratools.works/integration-tests
2. Run Gumball machine example 1
3. Verify that depositing accounts are show in the same order as in the dashboard.

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/eb00829d-2011-420f-8998-0eb737679b27" width=30%>

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/17e3fb18-57a7-4d51-bcbe-8c1e1a619699" width=30%>

## PR submission checklist
- [x] I have tested example 1 from Gumball to see if it works
- [x] I have written unit tests
