### PR TITLE
[ABW-2549] If request can't be handled due to failure, remove it from queue

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
@@ -183,6 +183,7 @@ class MainViewModel @Inject constructor(
                             when (dappRequestFailure) {
                                 RadixWalletException.DappRequestException.InvalidPersona,
                                 RadixWalletException.DappRequestException.InvalidRequest -> {
+                                    incomingRequestRepository.requestHandled(request.id)
                                     _state.update { state ->
                                         state.copy(dappRequestFailure = dappRequestFailure)
                                     }


### PR DESCRIPTION
## Description
Before we added error dialogs for those scenarios, request handling reached Dapp login flow screen, where request was marked as handled in the queue. Since now failure is handled in main view model, is should also be marked as handled there,

## How to test

See detailed steps in Jira ticket.

## PR submission checklist
- [x] I have tested that sending multiple requests using just hidden persona are received by wallet.
