### PR TITLE
[ABW-2555] Fix showing duplicate dev section

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
@@ -47,6 +47,10 @@ class AccountSettingsViewModel @Inject constructor(
         viewModelScope.launch {
             getFreeXrdUseCase.getFaucetState(args.address).collect { faucetState ->
                 if (shouldShowDeveloperSettings(faucetState)) {
+                    val developerSectionExist = state.value.settingsSections.any {
+                        it is AccountSettingsSection.DevelopmentSection
+                    }
+                    if (developerSectionExist) return@collect
                     _state.update {
                         it.copy(
                             settingsSections = (
@@ -55,7 +59,7 @@ class AccountSettingsViewModel @Inject constructor(
                                         AccountSettingItem.DevSettings
                                     )
                                 )
-                                ).distinct().toPersistentList()
+                                ).toPersistentList()
                         )
                     }
                 }


### PR DESCRIPTION
## Description
Settings section are not data classes, so `distinct()` did not work and we need to explicitly check if dev section exist before adding it


## How to test

1. Edit account label and see dev section duplicated

## PR submission checklist
- [x] I have verified that developer section shows only once in settings list

