### PR TITLE
[ABW-2561] Pass same instance of TransactionClient in delegates of TransactionReviewViewModel

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -82,7 +82,7 @@ class TransactionReviewViewModel @Inject constructor(
                 }
             }
             viewModelScope.launch {
-                analysis.analyse()
+                analysis.analyse(transactionClient = transactionClient)
             }
         }
     }
@@ -92,7 +92,10 @@ class TransactionReviewViewModel @Inject constructor(
             _state.update { it.copy(sheetState = State.Sheet.None) }
         } else {
             viewModelScope.launch {
-                submit.onDismiss(RadixWalletException.DappRequestException.RejectedByUser)
+                submit.onDismiss(
+                    transactionClient = transactionClient,
+                    exception = RadixWalletException.DappRequestException.RejectedByUser
+                )
             }
         }
     }
@@ -106,7 +109,10 @@ class TransactionReviewViewModel @Inject constructor(
     }
 
     fun approveTransaction(deviceBiometricAuthenticationProvider: suspend () -> Boolean) {
-        submit.onSubmit(deviceBiometricAuthenticationProvider)
+        submit.onSubmit(
+            transactionClient = transactionClient,
+            deviceBiometricAuthenticationProvider
+        )
     }
 
     fun promptForGuaranteesClick() = guarantees.onEdit()

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
@@ -243,15 +243,13 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
                 getResourcesMetadataUseCase = getResourcesMetadataUseCase,
                 getResourcesUseCase = getResourcesUseCase,
                 getTransactionBadgesUseCase = getTransactionBadgesUseCase,
-                resolveDAppsUseCase = resolveDAppsUseCase,
-                transactionClient = transactionClient,
+                resolveDAppsUseCase = resolveDAppsUseCase
             ),
             guarantees = TransactionGuaranteesDelegate(),
             fees = TransactionFeesDelegate(
                 getProfileUseCase = getProfileUseCase,
             ),
             submit = TransactionSubmitDelegate(
-                transactionClient = transactionClient,
                 dAppMessenger = dAppMessenger,
                 getCurrentGatewayUseCase = getCurrentGatewayUseCase,
                 incomingRequestRepository = incomingRequestRepository,


### PR DESCRIPTION
## Description
After the [update of the delegates in viewmodel](https://github.com/radixdlt/babylon-wallet-android/pull/599) the delegates of the `TransactionReviewViewModel` get a different instance of the `TransactionClient` which breaks the logic of the viewmodel (requires same instance of client in delegates) and as a result the signing bottom sheet dialog is not shown.

This is definitely not the best solution but with the refactor of signing process most probably the `TransactionClient` won't exist at all or not in the form it is now. So imo this should be a fine solution at the moment.

I also checked the other constructor parameters of the delegates and didn't see any consequences. Most of them are usecases which take the same Singleton repository.

## How to test

1. Make any transaction 
2. Verify that you see the signing bottom sheet dialog

## Video

https://github.com/radixdlt/babylon-wallet-android/assets/118305718/43582a02-1c2f-4c4e-a805-d98f8ce8f7be

## PR submission checklist
- [x] I have tested two separate transaction flows (see video) and have confirmed that it works
- [ ] I have written unit tests
