### PR TITLE
ABW-2550 - Transaction processing time displayed properly for rejected transaction

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/TransactionStatusClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/TransactionStatusClient.kt
@@ -90,6 +90,5 @@ data class TransactionStatusData(
     val txId: String,
     val requestId: String,
     val result: Result<Unit>,
-    val transactionType: TransactionType = TransactionType.Generic,
-    val txProcessingTime: String
+    val transactionType: TransactionType = TransactionType.Generic
 )

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/TransactionStatusClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/TransactionStatusClient.kt
@@ -46,10 +46,10 @@ class TransactionStatusClient @Inject constructor(
         txID: String,
         requestId: String,
         transactionType: TransactionType = TransactionType.Generic,
-        txProcessingTime: String
+        endEpoch: ULong
     ) {
         appScope.launch {
-            val pollResult = pollTransactionStatusUseCase(txID, requestId, transactionType, txProcessingTime)
+            val pollResult = pollTransactionStatusUseCase(txID, requestId, transactionType, endEpoch)
             pollResult.result.onSuccess {
                 appEventBus.sendEvent(AppEvent.RefreshResourcesNeeded)
             }

--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
@@ -350,6 +350,6 @@ data class NotarizedTransactionResult(
     val notarizedTransactionIntentHex: String,
     val transactionHeader: TransactionHeader
 ) {
-    val txProcessingTime: String
-        get() = ((transactionHeader.endEpochExclusive - transactionHeader.startEpochInclusive) * 5u).toString()
+    val endEpoch: ULong
+        get() = transactionHeader.endEpochExclusive
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetFreeXrdUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetFreeXrdUseCase.kt
@@ -71,14 +71,14 @@ class GetFreeXrdUseCase @Inject constructor(
                         submitTransactionUseCase(
                             notarizedTransactionResult.txIdHash,
                             notarizedTransactionResult.notarizedTransactionIntentHex,
-                            txProcessingTime = notarizedTransactionResult.txProcessingTime
+                            endEpoch = notarizedTransactionResult.endEpoch
                         ).getOrThrow()
                     }
                     .onSuccess { submitTransactionResult ->
                         pollTransactionStatusUseCase(
                             txID = submitTransactionResult.txId,
                             requestId = "",
-                            txProcessingTime = submitTransactionResult.txProcessingTime
+                            endEpoch = submitTransactionResult.endEpoch
                         ).result.onSuccess {
                             preferencesManager.updateEpoch(address, epoch)
                         }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
@@ -16,10 +16,13 @@ class PollTransactionStatusUseCase @Inject constructor(
         txID: String,
         requestId: String,
         transactionType: TransactionType = TransactionType.Generic,
-        txProcessingTime: String
+        endEpoch: ULong
     ): TransactionStatusData {
         while (true) {
             transactionRepository.getTransactionStatus(txID).onSuccess { statusCheckResult ->
+                val currentEpoch = statusCheckResult.ledgerState.epoch.toULong()
+                val txProcessingTime = ((endEpoch - currentEpoch) * 5u).toString()
+
                 when (statusCheckResult.knownPayloads.firstOrNull()?.payloadStatus) {
                     TransactionPayloadStatus.unknown,
                     TransactionPayloadStatus.commitPendingOutcomeUnknown,

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
@@ -35,9 +35,8 @@ class PollTransactionStatusUseCase @Inject constructor(
                         return TransactionStatusData(
                             txId = txID,
                             requestId = requestId,
-                            result = kotlin.Result.success(Unit),
-                            transactionType = transactionType,
-                            txProcessingTime = txProcessingTime
+                            result = Result.success(Unit),
+                            transactionType = transactionType
                         )
                     }
 
@@ -46,13 +45,12 @@ class PollTransactionStatusUseCase @Inject constructor(
                         return TransactionStatusData(
                             txId = txID,
                             requestId = requestId,
-                            result = kotlin.Result.failure(
+                            result = Result.failure(
                                 RadixWalletException.TransactionSubmitException.TransactionCommitted.Failure(
                                     txID
                                 )
                             ),
-                            transactionType = transactionType,
-                            txProcessingTime = txProcessingTime
+                            transactionType = transactionType
                         )
                     }
 
@@ -61,13 +59,12 @@ class PollTransactionStatusUseCase @Inject constructor(
                         return TransactionStatusData(
                             txId = txID,
                             requestId = requestId,
-                            result = kotlin.Result.failure(
+                            result = Result.failure(
                                 RadixWalletException.TransactionSubmitException.TransactionRejected.Permanently(
                                     txID
                                 )
                             ),
-                            transactionType = transactionType,
-                            txProcessingTime = txProcessingTime
+                            transactionType = transactionType
                         )
                     }
 
@@ -76,14 +73,13 @@ class PollTransactionStatusUseCase @Inject constructor(
                         return TransactionStatusData(
                             txId = txID,
                             requestId = requestId,
-                            result = kotlin.Result.failure(
+                            result = Result.failure(
                                 RadixWalletException.TransactionSubmitException.TransactionRejected.Temporary(
                                     txID,
                                     txProcessingTime
                                 )
                             ),
-                            transactionType = transactionType,
-                            txProcessingTime = txProcessingTime
+                            transactionType = transactionType
                         )
                     }
 

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/SubmitTransactionUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/SubmitTransactionUseCase.kt
@@ -13,7 +13,7 @@ class SubmitTransactionUseCase @Inject constructor(
     suspend operator fun invoke(
         txIDHash: String,
         notarizedTransactionHex: String,
-        txProcessingTime: String
+        endEpoch: ULong
     ): Result<SubmitTransactionResult> {
         val submitResult = transactionRepository.submitTransaction(
             notarizedTransaction = notarizedTransactionHex
@@ -33,7 +33,7 @@ class SubmitTransactionUseCase @Inject constructor(
                 Result.success(
                     SubmitTransactionResult(
                         txId = txIDHash,
-                        txProcessingTime = txProcessingTime
+                        endEpoch = endEpoch
                     )
                 )
             }
@@ -44,6 +44,6 @@ class SubmitTransactionUseCase @Inject constructor(
 
     data class SubmitTransactionResult(
         val txId: String,
-        val txProcessingTime: String
+        val endEpoch: ULong
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -215,7 +215,7 @@ class TransactionReviewViewModel @Inject constructor(
 
     data class State(
         val request: MessageFromDataChannel.IncomingRequest.TransactionRequest? = null,
-        val txProcessingTime: String? = null,
+        val endEpoch: ULong? = null,
         val isLoading: Boolean,
         val isNetworkFeeLoading: Boolean,
         val isSubmitting: Boolean = false,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
@@ -155,13 +155,13 @@ class TransactionSubmitDelegate @Inject constructor(
             submitTransactionUseCase(
                 notarizedTransactionResult.txIdHash,
                 notarizedTransactionResult.notarizedTransactionIntentHex,
-                txProcessingTime = notarizedTransactionResult.txProcessingTime
+                endEpoch = notarizedTransactionResult.endEpoch
             ).getOrThrow()
         }.onSuccess { submitTransactionResult ->
             _state.update {
                 it.copy(
                     isSubmitting = false,
-                    txProcessingTime = submitTransactionResult.txProcessingTime
+                    endEpoch = submitTransactionResult.endEpoch
                 )
             }
             appEventBus.sendEvent(
@@ -176,7 +176,7 @@ class TransactionSubmitDelegate @Inject constructor(
                 txID = submitTransactionResult.txId,
                 requestId = transactionRequest.requestId,
                 transactionType = transactionRequest.transactionType,
-                txProcessingTime = submitTransactionResult.txProcessingTime
+                endEpoch = submitTransactionResult.endEpoch
             )
             // Send confirmation to the dApp that tx was submitted before status polling
             if (!transactionRequest.isInternal) {

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
@@ -143,7 +143,7 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
         every { savedStateHandle.get<String>(ARG_TRANSACTION_REQUEST_ID) } returns sampleRequestId
         coEvery { getCurrentGatewayUseCase() } returns Radix.Gateway.nebunet
         coEvery { submitTransactionUseCase(any(), any(), any()) } returns Result.success(
-            SubmitTransactionUseCase.SubmitTransactionResult(sampleTxId, "50")
+            SubmitTransactionUseCase.SubmitTransactionResult(sampleTxId, 50u)
         )
         coEvery { getTransactionBadgesUseCase.invoke(any()) } returns listOf(
             Badge(address = "", nameMetadataItem = null, iconMetadataItem = null)


### PR DESCRIPTION
## Description
With the previous implementation I have used current epoch directly from Tx submission GW call however we need one from Poll transaction status GW call.

## How to test

1. Simulate Transaction rejection (**temporarilyRejected**) and verify that tx processing time is passed along and displayed properly.

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/c788a165-670b-4e81-a049-e5b72e511539" width="30%">

## PR submission checklist
- [x] I have tested account to account transfer flow, simulated temporarilyRejected error status and verified tx processing time is displayed.
