### PR TITLE
[ABW-2562] Update ledger errors to properly show  modals

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
@@ -61,7 +61,7 @@ class LedgerMessengerImpl @Inject constructor(
     override suspend fun sendDeviceInfoRequest(interactionId: String): Result<MessageFromDataChannel.LedgerResponse.GetDeviceInfoResponse> {
         val ledgerRequest: LedgerInteractionRequest = LedgerInteractionRequest.GetDeviceInfo(interactionId)
         return makeLedgerRequest(request = ledgerRequest, onError = {
-            RadixWalletException.LedgerCommunicationFailure.FailedToGetDeviceId
+            RadixWalletException.LedgerCommunicationException.FailedToGetDeviceId
         })
     }
 
@@ -76,7 +76,7 @@ class LedgerMessengerImpl @Inject constructor(
             ledgerDevice = ledgerDevice
         )
         return makeLedgerRequest(request = ledgerRequest, onError = {
-            RadixWalletException.LedgerCommunicationFailure.FailedToDerivePublicKeys
+            RadixWalletException.LedgerCommunicationException.FailedToDerivePublicKeys
         })
     }
 
@@ -101,7 +101,7 @@ class LedgerMessengerImpl @Inject constructor(
             mode = LedgerInteractionRequest.SignTransaction.Mode.Summary
         )
         return makeLedgerRequest(request = ledgerRequest, onError = {
-            RadixWalletException.LedgerCommunicationFailure.FailedToSignTransaction(it.code)
+            RadixWalletException.LedgerCommunicationException.FailedToSignTransaction(it.code)
         })
     }
 
@@ -127,7 +127,7 @@ class LedgerMessengerImpl @Inject constructor(
             dAppDefinitionAddress = dAppDefinitionAddress
         )
         return makeLedgerRequest(request = ledgerRequest, onError = {
-            RadixWalletException.LedgerCommunicationFailure.FailedToDerivePublicKeys
+            RadixWalletException.LedgerCommunicationException.FailedToDerivePublicKeys
         })
     }
 
@@ -142,13 +142,15 @@ class LedgerMessengerImpl @Inject constructor(
             ledgerDevice = ledgerDevice
         )
         return makeLedgerRequest(request = ledgerRequest, onError = {
-            RadixWalletException.LedgerCommunicationFailure.FailedToDeriveAndDisplayAddress
+            RadixWalletException.LedgerCommunicationException.FailedToDeriveAndDisplayAddress
         })
     }
 
     private suspend inline fun <reified R : MessageFromDataChannel.LedgerResponse> makeLedgerRequest(
         request: LedgerInteractionRequest,
-        crossinline onError: (MessageFromDataChannel.LedgerResponse.LedgerErrorResponse) -> RadixWalletException.LedgerCommunicationFailure
+        crossinline onError: (
+            MessageFromDataChannel.LedgerResponse.LedgerErrorResponse
+        ) -> RadixWalletException.LedgerCommunicationException
     ): Result<R> = flow<Result<R>> {
         peerdroidClient.sendMessage(peerdroidRequestJson.encodeToString(request))
             .onSuccess {

--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/InteractionState.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/InteractionState.kt
@@ -48,7 +48,7 @@ sealed class InteractionState(val factorSource: FactorSource) {
         data class Error(
             private val ledgerFactorSource: LedgerHardwareWalletFactorSource,
             override val signingPurpose: SigningPurpose?,
-            val failure: RadixWalletException.DappRequestException
+            val failure: RadixWalletException.LedgerCommunicationException
         ) : Ledger(ledgerFactorSource)
 
         override val label: String

--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/TransactionClient.kt
@@ -105,8 +105,12 @@ class TransactionClient @Inject constructor(
                     hashedDataToSign = transactionIntentHash.bytes().toByteArray()
                 ),
                 deviceBiometricAuthenticationProvider = deviceBiometricAuthenticationProvider
-            ).getOrElse {
-                return Result.failure(RadixWalletException.PrepareTransactionException.SignCompiledTransactionIntent(it))
+            ).getOrElse { throwable ->
+                return if (throwable is RadixWalletException) {
+                    Result.failure(throwable)
+                } else {
+                    Result.failure(RadixWalletException.PrepareTransactionException.SignCompiledTransactionIntent(throwable))
+                }
             }
 
             val signedTransactionIntent = runCatching {

--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -141,11 +141,11 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
             }
     }
 
-    sealed class LedgerCommunicationFailure : RadixWalletException(), ConnectorExtensionThrowable {
-        data object FailedToGetDeviceId : LedgerCommunicationFailure()
-        data object FailedToDerivePublicKeys : LedgerCommunicationFailure()
-        data object FailedToDeriveAndDisplayAddress : LedgerCommunicationFailure()
-        data class FailedToSignTransaction(val reason: LedgerErrorCode) : LedgerCommunicationFailure()
+    sealed class LedgerCommunicationException : RadixWalletException(), ConnectorExtensionThrowable {
+        data object FailedToGetDeviceId : LedgerCommunicationException()
+        data object FailedToDerivePublicKeys : LedgerCommunicationException()
+        data object FailedToDeriveAndDisplayAddress : LedgerCommunicationException()
+        data class FailedToSignTransaction(val reason: LedgerErrorCode) : LedgerCommunicationException()
 
         override val ceError: ConnectorExtensionError
             get() = when (this) {
@@ -163,22 +163,22 @@ interface ConnectorExtensionThrowable {
     val ceError: ConnectorExtensionError
 }
 
-fun RadixWalletException.LedgerCommunicationFailure.toUserFriendlyMessage(context: Context): String {
+fun RadixWalletException.LedgerCommunicationException.toUserFriendlyMessage(context: Context): String {
     return context.getString(
         when (this) {
-            RadixWalletException.LedgerCommunicationFailure.FailedToDerivePublicKeys -> {
+            RadixWalletException.LedgerCommunicationException.FailedToDerivePublicKeys -> {
                 R.string.common_somethingWentWrong
             } // TODO consider different copy
-            RadixWalletException.LedgerCommunicationFailure.FailedToGetDeviceId -> {
+            RadixWalletException.LedgerCommunicationException.FailedToGetDeviceId -> {
                 R.string.common_somethingWentWrong
             } // TODO consider different copy
-            is RadixWalletException.LedgerCommunicationFailure.FailedToSignTransaction -> when (this.reason) {
+            is RadixWalletException.LedgerCommunicationException.FailedToSignTransaction -> when (this.reason) {
                 LedgerErrorCode.Generic -> R.string.common_somethingWentWrong
                 LedgerErrorCode.BlindSigningNotEnabledButRequired -> R.string.error_transactionFailure_blindSigningNotEnabledButRequired
                 LedgerErrorCode.UserRejectedSigningOfTransaction -> R.string.error_transactionFailure_rejected
             }
 
-            is RadixWalletException.LedgerCommunicationFailure.FailedToDeriveAndDisplayAddress -> R.string.common_somethingWentWrong
+            is RadixWalletException.LedgerCommunicationException.FailedToDeriveAndDisplayAddress -> R.string.common_somethingWentWrong
         }
     )
 }
@@ -306,7 +306,7 @@ fun RadixWalletException.toUserFriendlyMessage(context: Context): String {
         ) // TODO consider different copy
         is RadixWalletException.DappRequestException -> toUserFriendlyMessage(context)
         is RadixWalletException.DappVerificationException -> toUserFriendlyMessage(context)
-        is RadixWalletException.LedgerCommunicationFailure -> toUserFriendlyMessage(context)
+        is RadixWalletException.LedgerCommunicationException -> toUserFriendlyMessage(context)
         is RadixWalletException.PrepareTransactionException -> toUserFriendlyMessage(context)
         is RadixWalletException.TransactionSubmitException -> toUserFriendlyMessage(context)
     }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
@@ -87,7 +87,7 @@ class CollectSignersSignaturesUseCase @Inject constructor(
                         signaturesWithPublicKeys.addAll(signatures)
                     }.onFailure { error ->
                         _interactionState.update {
-                            if (error is RadixWalletException.DappRequestException) {
+                            if (error is RadixWalletException.LedgerCommunicationException) {
                                 InteractionState.Ledger.Error(factorSource, signingPurpose, error)
                             } else {
                                 null

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/GenerateAuthSigningFactorInstanceUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/GenerateAuthSigningFactorInstanceUseCase.kt
@@ -112,7 +112,7 @@ class GenerateAuthSigningFactorInstanceUseCase @Inject constructor(
             )
         } else {
             _interactionState.update { null }
-            Result.failure(RadixWalletException.LedgerCommunicationFailure.FailedToDerivePublicKeys)
+            Result.failure(RadixWalletException.LedgerCommunicationException.FailedToDerivePublicKeys)
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaInfoScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaInfoScreen.kt
@@ -1,6 +1,5 @@
 package com.babylon.wallet.android.presentation.settings.personas.createpersona
 
-import android.graphics.drawable.ColorDrawable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -19,8 +18,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -29,8 +28,8 @@ import coil.compose.AsyncImage
 import com.babylon.wallet.android.designsystem.composable.RadixPrimaryButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
+import com.babylon.wallet.android.presentation.ui.composables.DSR
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
-import com.google.accompanist.drawablepainter.rememberDrawablePainter
 
 @Composable
 fun CreatePersonaInfoScreen(
@@ -88,14 +87,14 @@ private fun CreatePersonaInfoContent(
         ) {
             AsyncImage(
                 model = "",
-                placeholder = rememberDrawablePainter(drawable = ColorDrawable(RadixTheme.colors.gray3.toArgb())),
-                fallback = rememberDrawablePainter(drawable = ColorDrawable(RadixTheme.colors.gray3.toArgb())),
-                error = rememberDrawablePainter(drawable = ColorDrawable(RadixTheme.colors.gray3.toArgb())),
+                placeholder = painterResource(id = DSR.ic_persona),
+                fallback = painterResource(id = DSR.ic_persona),
+                error = painterResource(id = DSR.ic_persona),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
                     .size(200.dp)
-                    .clip(RadixTheme.shapes.roundedRectSmall)
+                    .clip(RadixTheme.shapes.circle)
             )
             Spacer(modifier = Modifier.height(48.dp))
             Text(


### PR DESCRIPTION
## Description
- updated how we pass Ledger error to signing state - it should be LedgerCommunicationException, not DappRequest anymore.
- updated persona placeholder - see this [discussion](https://rdxworks.slack.com/archives/C031A0V1A1W/p1697143834636869) 

## How to test

Steps are provided in Jira ticket
## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/118203440/a43ed6f2-1597-4546-8efa-3a6fc1db2c77" width="30%">

## PR submission checklist
- [x] I have tested leder blind signing, rejection and cancel (closing tab in browser) errors and verified those are displayed
