### PR TITLE
ABW-2551 - Behaviours section hidden for XRD resource.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/resources/Resource.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/resources/Resource.kt
@@ -37,7 +37,7 @@ sealed class Resource {
         private val descriptionMetadataItem: DescriptionMetadataItem? = null,
         private val iconUrlMetadataItem: IconUrlMetadataItem? = null,
         private val tagsMetadataItem: TagsMetadataItem? = null,
-        val behaviours: AssetBehaviours = emptySet(),
+        private val behaviours: AssetBehaviours = emptySet(),
         val currentSupply: BigDecimal? = null,
         private val validatorMetadataItem: ValidatorMetadataItem? = null,
         private val poolMetadataItem: PoolMetadataItem? = null,
@@ -70,6 +70,13 @@ sealed class Resource {
                 tagsMetadataItem?.tags?.map { Tag.Dynamic(name = it) }?.plus(Tag.Official).orEmpty()
             } else {
                 tagsMetadataItem?.tags?.map { Tag.Dynamic(name = it) }.orEmpty()
+            }
+
+        val resourceBehaviours: AssetBehaviours
+            get() = if (isXrd) {
+                emptySet()
+            } else {
+                behaviours
             }
 
         val currentSupplyToDisplay: String?

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FungibleTokenBottomSheetDetails.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FungibleTokenBottomSheetDetails.kt
@@ -117,7 +117,7 @@ fun FungibleTokenBottomSheetDetails(
                 )
             }
 
-            if (fungible.behaviours.isNotEmpty()) {
+            if (fungible.resourceBehaviours.isNotEmpty()) {
                 Column {
                     Text(
                         modifier = Modifier
@@ -130,7 +130,7 @@ fun FungibleTokenBottomSheetDetails(
                         style = RadixTheme.typography.body1Regular,
                         color = RadixTheme.colors.gray2
                     )
-                    fungible.behaviours.forEach { behaviour ->
+                    fungible.resourceBehaviours.forEach { behaviour ->
                         Behaviour(
                             icon = behaviour.icon(),
                             name = behaviour.name(fungible.isXrd)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/LSUBottomSheetDetails.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/LSUBottomSheetDetails.kt
@@ -161,7 +161,7 @@ fun LSUBottomSheetDetails(
                 label = stringResource(id = R.string.assetDetails_validator)
             )
 
-            if (lsuUnit.fungibleResource.behaviours.isNotEmpty()) {
+            if (lsuUnit.fungibleResource.resourceBehaviours.isNotEmpty()) {
                 Column {
                     Text(
                         modifier = Modifier
@@ -174,7 +174,7 @@ fun LSUBottomSheetDetails(
                         style = RadixTheme.typography.body1Regular,
                         color = RadixTheme.colors.gray2
                     )
-                    lsuUnit.fungibleResource.behaviours.forEach { behaviour ->
+                    lsuUnit.fungibleResource.resourceBehaviours.forEach { behaviour ->
                         Behaviour(
                             icon = behaviour.icon(),
                             name = behaviour.name()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/PoolUnitBottomSheetDetails.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/PoolUnitBottomSheetDetails.kt
@@ -148,7 +148,7 @@ fun PoolUnitBottomSheetDetails(
                 )
             }
 
-            if (poolUnit.poolUnitResource.behaviours.isNotEmpty()) {
+            if (poolUnit.poolUnitResource.resourceBehaviours.isNotEmpty()) {
                 Column {
                     Text(
                         modifier = Modifier
@@ -161,7 +161,7 @@ fun PoolUnitBottomSheetDetails(
                         style = RadixTheme.typography.body1Regular,
                         color = RadixTheme.colors.gray2
                     )
-                    poolUnit.poolUnitResource.behaviours.forEach { behaviour ->
+                    poolUnit.poolUnitResource.resourceBehaviours.forEach { behaviour ->
                         Behaviour(
                             icon = behaviour.icon(),
                             name = behaviour.name()

--- a/app/src/test/java/com/babylon/wallet/android/domain/model/ResourceTests.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/model/ResourceTests.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.domain.model
 
+import com.babylon.wallet.android.domain.model.assets.AssetBehaviour
 import com.babylon.wallet.android.domain.model.resources.Resource.NonFungibleResource.Item
 import com.babylon.wallet.android.domain.model.resources.metadata.NameMetadataItem
 import com.babylon.wallet.android.domain.model.resources.metadata.SymbolMetadataItem
@@ -171,6 +172,31 @@ class ResourceTests {
         Item.ID.from("{7b003d8e0b2c9e3a-516cf99882de64a1-f1cd6742ce3299e0-357f54f0333d25d0}").toRetId()
     }
 
+    @Test
+    fun `verify that xrd resource do not show behaviours `() {
+        val resource = fungibleResource(
+            address = "resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc",
+            name = "Radix fungible token",
+            symbol = "XRD"
+        )
+
+        Assert.assertTrue(resource.resourceBehaviours.isEmpty())
+    }
+
+    @Test
+    fun `verify that all resources except xrd show behaviours `() {
+        val resource = fungibleResource(
+            address = "resource_rdx_abcd",
+            name = "Some fungible",
+            symbol = "BUM"
+        )
+
+        Assert.assertEquals(resource.resourceBehaviours, setOf(
+            AssetBehaviour.SIMPLE_ASSET,
+            AssetBehaviour.INFORMATION_CHANGEABLE
+        ))
+    }
+
     private fun fungibleResource(
         address: String = "resource_rdx_abcd",
         name: String?,
@@ -179,7 +205,11 @@ class ResourceTests {
         resourceAddress = address,
         ownedAmount = BigDecimal(1234.5678),
         nameMetadataItem = name?.let { NameMetadataItem(it) },
-        symbolMetadataItem = symbol?.let { SymbolMetadataItem(it) }
+        symbolMetadataItem = symbol?.let { SymbolMetadataItem(it) },
+        behaviours = setOf(
+            AssetBehaviour.SIMPLE_ASSET,
+            AssetBehaviour.INFORMATION_CHANGEABLE
+        )
     )
 
     private fun nonFungibleCollection(


### PR DESCRIPTION
## Description
This PR hides behaviours section for XRD resource. For any other resources there is no difference, functionality stays the same.

## How to test

1. Go to XRD and verify that there is no behaviours section.

## Video
https://github.com/radixdlt/babylon-wallet-android/assets/108684750/d12a3867-bafb-4b37-9fd3-726a1cf47f9b

## PR submission checklist
- [] I have checked XRD resource details page to see if behaviours section is gone
- [] I have written unit tests
