### PR TITLE
ABW-2498 - When max clicked, dialogs show to confirm which amount we want to insert.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -142,7 +142,9 @@ fun TransferContent(
         BasicPromptAlertDialog(
             finish = onMaxAmountApplied,
             title = "Sending All XRD", // TODO Crowdin
-            text = "Sending the full amount of XRD in this account will require you to pay the transaction fee from a different account. Or, the wallet can reduce the amount transferred so the fee can be paid from this account. Choose the amount to transfer:",
+            text = "Sending the full amount of XRD in this account will require you to pay the transaction " +
+                    "fee from a different account. Or, the wallet can reduce the amount transferred so the fee can be " +
+                    "paid from this account. Choose the amount to transfer:",
             confirmText = "${error.amountWithoutFees.displayableQuantity()} (send all XRD)",
             dismissText = "${error.maxAccountAmount.displayableQuantity()} (save 1 XRD for fee)"
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -51,10 +51,12 @@ import com.babylon.wallet.android.presentation.transfer.TransferViewModel.State
 import com.babylon.wallet.android.presentation.transfer.accounts.ChooseAccountSheet
 import com.babylon.wallet.android.presentation.transfer.assets.ChooseAssetsSheet
 import com.babylon.wallet.android.presentation.ui.composables.BackIconType
+import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.SimpleAccountCard
 import kotlinx.coroutines.launch
+import rdx.works.core.displayableQuantity
 import rdx.works.profile.data.model.pernetwork.Network
 
 @Composable
@@ -86,6 +88,7 @@ fun TransferScreen(
         onRemoveAssetClick = viewModel::onRemoveAsset,
         onAmountTyped = viewModel::onAmountTyped,
         onMaxAmountClicked = viewModel::onMaxAmount,
+        onMaxAmountApplied = viewModel::onMaxAmountApplied,
         onAssetSelectionChanged = viewModel::onAssetSelectionChanged,
         onUiMessageShown = viewModel::onUiMessageShown,
         onChooseAssetsSubmitted = viewModel::onChooseAssetsSubmitted,
@@ -116,6 +119,7 @@ fun TransferContent(
     onRemoveAssetClick: (TargetAccount, SpendingAsset) -> Unit,
     onAmountTyped: (TargetAccount, SpendingAsset, String) -> Unit,
     onMaxAmountClicked: (TargetAccount, SpendingAsset) -> Unit,
+    onMaxAmountApplied: (Boolean) -> Unit,
     onAssetSelectionChanged: (SpendingAsset, Boolean) -> Unit,
     onUiMessageShown: () -> Unit,
     onChooseAssetsSubmitted: () -> Unit,
@@ -133,6 +137,16 @@ fun TransferContent(
         isSheetVisible = state.isSheetVisible,
         onSheetClosed = onSheetClosed
     )
+
+    state.maxXrdError?.let { error ->
+        BasicPromptAlertDialog(
+            finish = onMaxAmountApplied,
+            title = "Sending All XRD", // TODO Crowdin
+            text = "Sending the full amount of XRD in this account will require you to pay the transaction fee from a different account. Or, the wallet can reduce the amount transferred so the fee can be paid from this account. Choose the amount to transfer:",
+            confirmText = "${error.emptyAccountAmount.displayableQuantity()} (send all XRD)",
+            dismissText = "${error.maxAccountAmount.displayableQuantity()} (save 1 XRD for fee)"
+        )
+    }
 
     DefaultModalSheetLayout(
         modifier = modifier,
@@ -400,6 +414,7 @@ fun TransferContentPreview() {
             onRemoveAssetClick = { _, _ -> },
             onAmountTyped = { _, _, _ -> },
             onMaxAmountClicked = { _, _ -> },
+            onMaxAmountApplied = {},
             onAssetSelectionChanged = { _, _ -> },
             onUiMessageShown = {},
             onChooseAssetsSubmitted = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -143,8 +143,8 @@ fun TransferContent(
             finish = onMaxAmountApplied,
             title = "Sending All XRD", // TODO Crowdin
             text = "Sending the full amount of XRD in this account will require you to pay the transaction " +
-                    "fee from a different account. Or, the wallet can reduce the amount transferred so the fee can be " +
-                    "paid from this account. Choose the amount to transfer:",
+                "fee from a different account. Or, the wallet can reduce the amount transferred so the fee can be " +
+                "paid from this account. Choose the amount to transfer:",
             confirmText = "${error.maxAccountAmount.displayableQuantity()} (send all XRD)",
             dismissText = "${error.amountWithoutFees.displayableQuantity()} (save 1 XRD for fee)"
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -143,7 +143,7 @@ fun TransferContent(
             finish = onMaxAmountApplied,
             title = "Sending All XRD", // TODO Crowdin
             text = "Sending the full amount of XRD in this account will require you to pay the transaction fee from a different account. Or, the wallet can reduce the amount transferred so the fee can be paid from this account. Choose the amount to transfer:",
-            confirmText = "${error.emptyAccountAmount.displayableQuantity()} (send all XRD)",
+            confirmText = "${error.amountWithoutFees.displayableQuantity()} (send all XRD)",
             dismissText = "${error.maxAccountAmount.displayableQuantity()} (save 1 XRD for fee)"
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -145,8 +145,8 @@ fun TransferContent(
             text = "Sending the full amount of XRD in this account will require you to pay the transaction " +
                     "fee from a different account. Or, the wallet can reduce the amount transferred so the fee can be " +
                     "paid from this account. Choose the amount to transfer:",
-            confirmText = "${error.amountWithoutFees.displayableQuantity()} (send all XRD)",
-            dismissText = "${error.maxAccountAmount.displayableQuantity()} (save 1 XRD for fee)"
+            confirmText = "${error.maxAccountAmount.displayableQuantity()} (send all XRD)",
+            dismissText = "${error.amountWithoutFees.displayableQuantity()} (save 1 XRD for fee)"
         )
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -111,7 +111,6 @@ class TransferViewModel @Inject constructor(
             _state.update {
                 it.copy(
                     maxXrdError = State.MaxAmountMessage(
-                        emptyAccountAmount = remainingAmount,
                         maxAccountAmount = maxAccountAmount,
                         account = account,
                         asset = asset
@@ -133,7 +132,7 @@ class TransferViewModel @Inject constructor(
         _state.value.maxXrdError?.let { maxXrdError ->
             val fungibleAsset = maxXrdError.asset as? SpendingAsset.Fungible ?: return
             val remainingAmountString = if (emptyAccount) {
-                maxXrdError.emptyAccountAmount
+                maxXrdError.amountWithoutFees
             } else {
                 maxXrdError.maxAccountAmount
             }
@@ -414,11 +413,13 @@ class TransferViewModel @Inject constructor(
         }
 
         data class MaxAmountMessage(
-            val emptyAccountAmount: BigDecimal,
             val maxAccountAmount: BigDecimal,
             val account: TargetAccount,
             val asset: SpendingAsset
-        )
+        ) {
+            val amountWithoutFees: BigDecimal
+                get() = maxAccountAmount - BigDecimal.ONE
+        }
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.core.UUIDGenerator
-import rdx.works.core.displayableQuantity
 import rdx.works.core.mapWhen
 import rdx.works.profile.data.model.extensions.factorSourceId
 import rdx.works.profile.data.model.extensions.isSignatureRequiredBasedOnDepositRules
@@ -105,13 +104,12 @@ class TransferViewModel @Inject constructor(
             .sumOf { it.amountSpent(fungibleAsset) }
         val remainingAmount = (maxAmount - spentAmount).coerceAtLeast(BigDecimal.ZERO)
         val remainingAmountString = remainingAmount.toPlainString()
-        val maxAccountAmount = remainingAmount.subtract(BigDecimal.ONE)
 
         if (fungibleAsset.resource.isXrd) {
             _state.update {
                 it.copy(
                     maxXrdError = State.MaxAmountMessage(
-                        maxAccountAmount = maxAccountAmount,
+                        maxAccountAmount = remainingAmount,
                         account = account,
                         asset = asset
                     )
@@ -132,9 +130,9 @@ class TransferViewModel @Inject constructor(
         _state.value.maxXrdError?.let { maxXrdError ->
             val fungibleAsset = maxXrdError.asset as? SpendingAsset.Fungible ?: return
             val remainingAmountString = if (emptyAccount) {
-                maxXrdError.amountWithoutFees
-            } else {
                 maxXrdError.maxAccountAmount
+            } else {
+                maxXrdError.amountWithoutFees
             }
             _state.update { state ->
                 state.updateAssetAmount(


### PR DESCRIPTION
## Description
This PR adds a dialog when clicking Max amount on Transfer page to determine if we want to leave 1 xrd for the fee or transfer the whole amount (empty account).
Only applies to XRD fungible.

## How to test

1. Initiate XRD transfer
2. In the field, hit Max button and chose one of the options.
3. If empty account chosen, verify that Insufficient balance error is displayed and another account has to be choose to pay for the fee in order to complete the transfer.

## Screenshot
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/3d976c10-2bf3-4821-b504-d867c55df8e7" width="300">

## PR submission checklist
- [ ] I have tested xrd transfer flow with Max option and have confirmed that it works
