### PR TITLE
[Abw-2454] Verify user written seed phrase

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/SeedPhraseInputDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/SeedPhraseInputDelegate.kt
@@ -21,7 +21,7 @@ class SeedPhraseInputDelegate(
     private var debounceJob: Job? = null
 
     fun initInConfirmMode(seedSize: Int, blankWords: Int = 4) {
-        val seedPhraseWords = (0 until seedSize).map { index ->
+        val seedPhraseWords = List(seedSize) { index ->
             SeedPhraseWord(
                 index,
                 lastWord = index == seedSize - 1,
@@ -29,7 +29,8 @@ class SeedPhraseInputDelegate(
                 state = SeedPhraseWord.State.ValidDisabled
             )
         }.toPersistentList()
-        val wordsToFillIndexes = mutableSetOf<Int>()
+        // always ask for last word
+        val wordsToFillIndexes = mutableSetOf<Int>().apply { add(seedSize - 1) }
         do {
             wordsToFillIndexes.add(Random.nextInt(seedSize))
         } while (wordsToFillIndexes.size < blankWords)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/SeedPhraseInputDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/SeedPhraseInputDelegate.kt
@@ -12,12 +12,35 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.core.mapWhen
+import kotlin.random.Random
 
 class SeedPhraseInputDelegate(
     private val scope: CoroutineScope
 ) : Stateful<SeedPhraseInputDelegate.State>() {
 
     private var debounceJob: Job? = null
+
+    fun initInConfirmMode(seedSize: Int, blankWords: Int = 4) {
+        val seedPhraseWords = (0 until seedSize).map { index ->
+            SeedPhraseWord(
+                index,
+                lastWord = index == seedSize - 1,
+                value = WORDLIST_ENGLISH[Random.nextInt(WORDLIST_ENGLISH.size)],
+                state = SeedPhraseWord.State.ValidDisabled
+            )
+        }.toPersistentList()
+        val wordsToFillIndexes = mutableSetOf<Int>()
+        do {
+            wordsToFillIndexes.add(Random.nextInt(seedSize))
+        } while (wordsToFillIndexes.size < blankWords)
+        _state.update { state ->
+            state.copy(
+                seedPhraseWords = seedPhraseWords.mapWhen(predicate = { wordsToFillIndexes.contains(it.index) }, mutation = { word ->
+                    word.copy(state = SeedPhraseWord.State.Empty, value = "")
+                }).toPersistentList(),
+            )
+        }
+    }
 
     fun setSeedPhraseSize(size: Int) {
         _state.update { state ->
@@ -39,7 +62,6 @@ class SeedPhraseInputDelegate(
             }).toPersistentList()
             state.copy(
                 seedPhraseWords = updatedWords,
-                seedPhraseValid = updatedWords.all { it.state == SeedPhraseWord.State.Valid },
                 wordAutocompleteCandidates = persistentListOf()
             )
         }
@@ -65,7 +87,12 @@ class SeedPhraseInputDelegate(
                     _state.update { state ->
                         state.copy(
                             seedPhraseWords = state.seedPhraseWords.mapIndexed { index, word ->
-                                word.copy(value = pastedMnemonic[index], state = SeedPhraseWord.State.Valid)
+                                val wordState = if (word.state == SeedPhraseWord.State.ValidDisabled) {
+                                    SeedPhraseWord.State.ValidDisabled
+                                } else {
+                                    SeedPhraseWord.State.Valid
+                                }
+                                word.copy(value = pastedMnemonic[index], state = wordState)
                             }.toPersistentList()
                         )
                     }
@@ -96,7 +123,6 @@ class SeedPhraseInputDelegate(
                 }).toPersistentList()
                 state.copy(
                     seedPhraseWords = updatedWords,
-                    seedPhraseValid = updatedWords.all { it.state == SeedPhraseWord.State.Valid },
                     wordAutocompleteCandidates = wordCandidates.toPersistentList()
                 )
             }
@@ -115,17 +141,10 @@ class SeedPhraseInputDelegate(
         _state.update { state ->
             state.copy(bip39Passphrase = value)
         }
-        validateMnemonic()
     }
 
     fun reset() {
         _state.update { State() }
-    }
-
-    private fun validateMnemonic() {
-        _state.update { state ->
-            state.copy(seedPhraseValid = _state.value.seedPhraseWords.all { it.state == SeedPhraseWord.State.Valid })
-        }
     }
 
     data class SeedPhraseWord(
@@ -134,20 +153,33 @@ class SeedPhraseInputDelegate(
         val state: State = State.Empty,
         val lastWord: Boolean = false
     ) {
+
+        val valid: Boolean
+            get() = state == State.Valid || state == State.ValidDisabled
+
+        val inputDisabled: Boolean
+            get() = state == State.ValidDisabled
+
         enum class State {
-            Valid, Invalid, Empty, HasValue
+            Valid, Invalid, Empty, HasValue, ValidDisabled
         }
     }
 
     data class State(
-        val seedPhraseValid: Boolean = false,
         val bip39Passphrase: String = "",
         val seedPhraseWords: ImmutableList<SeedPhraseWord> = persistentListOf(),
-        val wordAutocompleteCandidates: ImmutableList<String> = persistentListOf()
+        val wordAutocompleteCandidates: ImmutableList<String> = persistentListOf(),
+        val blankIndices: Set<Int> = emptySet()
     ) : UiState {
+
+        val seedPhraseValid: Boolean
+            get() = seedPhraseWords.all { it.valid }
 
         val wordsPhrase: String
             get() = seedPhraseWords.joinToString(separator = " ") { it.value }
+
+        val wordsToConfirm: Map<Int, String>
+            get() = blankIndices.associateWith { seedPhraseWords[it].value }
     }
 
     override fun initialState(): State {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -37,6 +37,8 @@ import com.babylon.wallet.android.presentation.onboarding.restore.backup.restore
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.RestoreMnemonicsArgs
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.restoreMnemonics
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.restoreMnemonicsScreen
+import com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.confirm.confirmSeedPhrase
+import com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.reveal.ROUTE_REVEAL_SEED_PHRASE
 import com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.seedPhrases
 import com.babylon.wallet.android.presentation.settings.personas.createpersona.createPersonaConfirmationScreen
 import com.babylon.wallet.android.presentation.settings.personas.createpersona.createPersonaScreen
@@ -116,6 +118,11 @@ fun NavigationHost(
                 }
             }
         )
+        confirmSeedPhrase(onMnemonicBackedUp = {
+            navController.popBackStack(ROUTE_REVEAL_SEED_PHRASE, inclusive = true)
+        }, onDismiss = {
+            navController.popBackStack()
+        })
         main(
             mainUiState = mainUiState,
             onMenuClick = {
@@ -254,9 +261,11 @@ fun NavigationHost(
                     AccountSettingItem.ThirdPartyDeposits -> {
                         navController.accountThirdPartyDeposits(accountAddress)
                     }
+
                     AccountSettingItem.DevSettings -> {
                         navController.devSettings(accountAddress)
                     }
+
                     else -> {}
                 }
             },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityNav.kt
@@ -12,6 +12,7 @@ import com.babylon.wallet.android.presentation.settings.SettingsItem
 import com.babylon.wallet.android.presentation.settings.accountsecurity.depositguarantees.depositGuaranteesScreen
 import com.babylon.wallet.android.presentation.settings.accountsecurity.importlegacywallet.importLegacyWalletScreen
 import com.babylon.wallet.android.presentation.settings.accountsecurity.ledgerhardwarewallets.ledgerHardwareWalletsScreen
+import com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.confirm.confirmSeedPhrase
 import com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.reveal.revealSeedPhrase
 import com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.seedPhrases
 import com.google.accompanist.navigation.animation.composable
@@ -58,6 +59,9 @@ fun NavGraphBuilder.accountSecurityNavGraph(
         revealSeedPhrase(
             onBackClick = {
                 navController.navigateUp()
+            },
+            onConfirmSeedPhraseClick = { factorSourceId, mnemonicSize ->
+                navController.confirmSeedPhrase(factorSourceId, mnemonicSize)
             }
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicNav.kt
@@ -1,0 +1,67 @@
+package com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.confirm
+
+import androidx.compose.animation.AnimatedContentScope
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
+import com.babylon.wallet.android.presentation.navigation.markAsHighPriority
+import com.google.accompanist.navigation.animation.composable
+
+private const val ARGS_FACTOR_SOURCE_ID = "factorSourceId"
+private const val ARGS_MNEMONIC_SIZE = "mnemonicSize"
+private const val ROUTE = "confirm_mnemonic?$ARGS_FACTOR_SOURCE_ID={$ARGS_FACTOR_SOURCE_ID}&$ARGS_MNEMONIC_SIZE={$ARGS_MNEMONIC_SIZE}"
+
+fun NavController.confirmSeedPhrase(
+    factorSourceId: String,
+    mnemonicSize: Int
+) {
+    navigate(route = "confirm_mnemonic?$ARGS_FACTOR_SOURCE_ID=$factorSourceId&$ARGS_MNEMONIC_SIZE=$mnemonicSize")
+}
+
+internal class ConfirmSeedPhraseArgs(val factorSourceId: String, val mnemonicSize: Int) {
+    constructor(savedStateHandle: SavedStateHandle) : this(
+        checkNotNull(savedStateHandle.get<String>(ARGS_FACTOR_SOURCE_ID)),
+        checkNotNull(savedStateHandle.get<Int>(ARGS_MNEMONIC_SIZE)),
+    )
+}
+
+@OptIn(ExperimentalAnimationApi::class)
+fun NavGraphBuilder.confirmSeedPhrase(
+    onMnemonicBackedUp: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    markAsHighPriority(ROUTE)
+    composable(
+        route = ROUTE,
+        arguments = listOf(
+            navArgument(
+                name = ARGS_FACTOR_SOURCE_ID,
+            ) {
+                nullable = false
+                type = NavType.StringType
+            },
+            navArgument(
+                name = ARGS_MNEMONIC_SIZE,
+            ) {
+                nullable = false
+                type = NavType.IntType
+            }
+        ),
+        enterTransition = {
+            slideIntoContainer(AnimatedContentScope.SlideDirection.Up)
+        },
+        exitTransition = {
+            slideOutOfContainer(AnimatedContentScope.SlideDirection.Down)
+        }
+    ) {
+        ConfirmMnemonicScreen(
+            viewModel = hiltViewModel(),
+            onMnemonicBackedUp = onMnemonicBackedUp,
+            onDismiss = onDismiss
+        )
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicScreen.kt
@@ -206,7 +206,8 @@ private fun SeedPhraseView(
             onWordChanged = onWordChanged,
             onPassphraseChanged = onPassphraseChanged,
             onFocusedWordIndexChanged = onFocusedWordIndexChanged,
-            showAdvancedMode = false
+            showAdvancedMode = false,
+            highlightFields = true
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicScreen.kt
@@ -1,0 +1,240 @@
+package com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.confirm
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.babylon.wallet.android.R
+import com.babylon.wallet.android.designsystem.composable.RadixPrimaryButton
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
+import com.babylon.wallet.android.domain.SampleDataProvider
+import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
+import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
+import com.babylon.wallet.android.presentation.ui.composables.SecureScreen
+import com.babylon.wallet.android.presentation.ui.composables.SeedPhraseInputForm
+import com.babylon.wallet.android.presentation.ui.composables.SeedPhraseSuggestions
+import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
+import com.babylon.wallet.android.utils.biometricAuthenticate
+
+@Composable
+fun ConfirmMnemonicScreen(
+    viewModel: ConfirmMnemonicViewModel,
+    onMnemonicBackedUp: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+
+    ConfirmMnemonicContent(
+        state = state,
+        onBackClick = onDismiss,
+        onSubmitClick = {
+            context.biometricAuthenticate { authenticated ->
+                if (authenticated) viewModel.onSubmit()
+            }
+        },
+        onWordTyped = viewModel::onWordChanged,
+        onPassphraseChanged = viewModel::onPassphraseChanged,
+        onMessageShown = viewModel::onMessageShown,
+        onWordSelected = viewModel::onWordSelected
+    )
+
+    val focusManager = LocalFocusManager.current
+    LaunchedEffect(Unit) {
+        viewModel.oneOffEvent.collect {
+            when (it) {
+                ConfirmMnemonicViewModel.Event.MoveToNextWord -> focusManager.moveFocus(FocusDirection.Next)
+                ConfirmMnemonicViewModel.Event.MnemonicBackedUp -> onMnemonicBackedUp()
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConfirmMnemonicContent(
+    modifier: Modifier = Modifier,
+    state: ConfirmMnemonicViewModel.State,
+    onBackClick: () -> Unit,
+    onSubmitClick: () -> Unit,
+    onWordTyped: (Int, String) -> Unit,
+    onWordSelected: (Int, String) -> Unit,
+    onPassphraseChanged: (String) -> Unit,
+    onMessageShown: () -> Unit
+) {
+    BackHandler(onBack = onBackClick)
+
+    val snackBarHostState = remember { SnackbarHostState() }
+
+    SnackbarUIMessage(
+        message = state.uiMessage,
+        snackbarHostState = snackBarHostState,
+        onMessageShown = onMessageShown
+    )
+
+    var focusedWordIndex by remember {
+        mutableStateOf<Int?>(null)
+    }
+
+    Scaffold(
+        modifier = modifier.navigationBarsPadding(),
+        topBar = {
+            RadixCenteredTopAppBar(
+                title = "",
+                onBackClick = onBackClick,
+                windowInsets = WindowInsets.statusBars
+            )
+        },
+        bottomBar = {
+            if (isSuggestionsVisible(state = state)) {
+                SeedPhraseSuggestions(
+                    wordAutocompleteCandidates = state.seedPhraseState.wordAutocompleteCandidates,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .imePadding()
+                        .height(56.dp)
+                        .padding(RadixTheme.dimensions.paddingSmall),
+                    onCandidateClick = { candidate ->
+                        focusedWordIndex?.let {
+                            onWordSelected(it, candidate)
+                            focusedWordIndex = null
+                        }
+                    }
+                )
+            } else {
+                RadixPrimaryButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .imePadding()
+                        .padding(RadixTheme.dimensions.paddingDefault),
+                    text = stringResource(
+                        id = R.string.common_continue
+                    ),
+                    enabled = state.seedPhraseState.seedPhraseValid,
+                    onClick = onSubmitClick
+                )
+            }
+        },
+        snackbarHost = {
+            RadixSnackbarHost(
+                hostState = snackBarHostState,
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault)
+            )
+        },
+        containerColor = RadixTheme.colors.defaultBackground
+    ) { padding ->
+
+        SeedPhraseView(
+            modifier = Modifier.padding(padding),
+            state = state,
+            onWordChanged = onWordTyped,
+            onPassphraseChanged = onPassphraseChanged,
+            onFocusedWordIndexChanged = { focusedWordIndex = it }
+        )
+    }
+}
+
+@Composable
+private fun SeedPhraseView(
+    modifier: Modifier = Modifier,
+    state: ConfirmMnemonicViewModel.State,
+    onWordChanged: (Int, String) -> Unit,
+    onPassphraseChanged: (String) -> Unit,
+    onFocusedWordIndexChanged: (Int) -> Unit,
+) {
+    SecureScreen()
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+    ) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = RadixTheme.dimensions.paddingLarge),
+            text = "Confirm Your Seed Phrase", // TODO crowding
+            textAlign = TextAlign.Center,
+            style = RadixTheme.typography.title
+        )
+        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+            text = "Confirm you have written down the seed phrase by entering the missing words below.", // TODO crowdin
+            textAlign = TextAlign.Center,
+            style = RadixTheme.typography.body1Header
+        )
+        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+        SeedPhraseInputForm(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+            seedPhraseWords = state.seedPhraseState.seedPhraseWords,
+            bip39Passphrase = state.seedPhraseState.bip39Passphrase,
+            onWordChanged = onWordChanged,
+            onPassphraseChanged = onPassphraseChanged,
+            onFocusedWordIndexChanged = onFocusedWordIndexChanged,
+            showAdvancedMode = false
+        )
+    }
+}
+
+@Composable
+private fun isSuggestionsVisible(state: ConfirmMnemonicViewModel.State): Boolean {
+    val density = LocalDensity.current
+    val imeInsets = WindowInsets.ime
+    val keyboardVisible by remember {
+        derivedStateOf { imeInsets.getBottom(density) > 0 }
+    }
+    return state.seedPhraseState.wordAutocompleteCandidates.isNotEmpty() && keyboardVisible
+}
+
+@Preview
+@Composable
+fun ConfirmMnemonicContentPreview() {
+    RadixWalletTheme {
+        ConfirmMnemonicContent(
+            state = ConfirmMnemonicViewModel.State(
+                factorSource = SampleDataProvider().babylonDeviceFactorSource()
+            ),
+            onBackClick = {},
+            onSubmitClick = {},
+            onWordTyped = { _, _ -> },
+            onPassphraseChanged = {},
+            onMessageShown = {},
+            onWordSelected = { _, _ -> }
+        )
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicViewModel.kt
@@ -20,7 +20,6 @@ import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.factorSourceByIdValue
 import javax.inject.Inject
 
-@Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class ConfirmMnemonicViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicViewModel.kt
@@ -1,0 +1,101 @@
+package com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.confirm
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.babylon.wallet.android.presentation.common.OneOffEvent
+import com.babylon.wallet.android.presentation.common.OneOffEventHandler
+import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
+import com.babylon.wallet.android.presentation.common.SeedPhraseInputDelegate
+import com.babylon.wallet.android.presentation.common.StateViewModel
+import com.babylon.wallet.android.presentation.common.UiMessage
+import com.babylon.wallet.android.presentation.common.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import rdx.works.core.preferences.PreferencesManager
+import rdx.works.profile.data.model.factorsources.DeviceFactorSource
+import rdx.works.profile.data.model.factorsources.FactorSource
+import rdx.works.profile.data.repository.MnemonicRepository
+import rdx.works.profile.domain.GetProfileUseCase
+import rdx.works.profile.domain.factorSourceByIdValue
+import javax.inject.Inject
+
+@Suppress("TooManyFunctions", "LongParameterList")
+@HiltViewModel
+class ConfirmMnemonicViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getProfileUseCase: GetProfileUseCase,
+    private val mnemonicRepository: MnemonicRepository,
+    private val preferencesManager: PreferencesManager
+) : StateViewModel<ConfirmMnemonicViewModel.State>(),
+    OneOffEventHandler<ConfirmMnemonicViewModel.Event> by OneOffEventHandlerImpl() {
+
+    private val args = ConfirmSeedPhraseArgs(savedStateHandle)
+    private val seedPhraseInputDelegate = SeedPhraseInputDelegate(viewModelScope)
+
+    override fun initialState(): State = State()
+
+    init {
+        viewModelScope.launch {
+            val factorSource = requireNotNull(getProfileUseCase.factorSourceByIdValue(args.factorSourceId) as? DeviceFactorSource)
+            val mnemonicExist = mnemonicRepository.mnemonicExist(factorSource.id)
+            if (mnemonicExist) {
+                seedPhraseInputDelegate.initInConfirmMode(args.mnemonicSize)
+            }
+        }
+        viewModelScope.launch {
+            seedPhraseInputDelegate.state.collect { delegateState ->
+                _state.update { it.copy(seedPhraseState = delegateState) }
+            }
+        }
+    }
+
+    fun onMessageShown() {
+        _state.update { it.copy(uiMessage = null) }
+    }
+
+    fun onWordChanged(index: Int, value: String) {
+        seedPhraseInputDelegate.onWordChanged(index, value) {
+            sendEvent(Event.MoveToNextWord)
+        }
+    }
+
+    fun onWordSelected(index: Int, value: String) {
+        seedPhraseInputDelegate.onWordSelected(index, value)
+        viewModelScope.launch {
+            sendEvent(Event.MoveToNextWord)
+        }
+    }
+
+    fun onPassphraseChanged(value: String) {
+        seedPhraseInputDelegate.onPassphraseChanged(value)
+    }
+
+    fun onSubmit() {
+        viewModelScope.launch {
+            val factorSource = requireNotNull(getProfileUseCase.factorSourceByIdValue(args.factorSourceId) as? DeviceFactorSource)
+            mnemonicRepository.readMnemonic(factorSource.id).onSuccess { mnemonicWithPassphrase ->
+                val mnemonicWords = mnemonicWithPassphrase.words
+                val inputMatchesMnemonic =
+                    _state.value.seedPhraseState.wordsToConfirm.all { entry -> mnemonicWords[entry.key] == entry.value }
+                if (inputMatchesMnemonic) {
+                    preferencesManager.markFactorSourceBackedUp(args.factorSourceId)
+                    sendEvent(Event.MnemonicBackedUp)
+                } else {
+                    _state.update { it.copy(uiMessage = UiMessage.InfoMessage.InvalidMnemonic) }
+                }
+            }
+        }
+    }
+
+    data class State(
+        private val factorSource: FactorSource? = null,
+        val uiMessage: UiMessage? = null,
+        val seedPhraseState: SeedPhraseInputDelegate.State = SeedPhraseInputDelegate.State()
+    ) : UiState
+
+    sealed interface Event : OneOffEvent {
+        data object MoveToNextWord : Event
+        data object MnemonicBackedUp : Event
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/reveal/RevealSeedPhraseNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/reveal/RevealSeedPhraseNav.kt
@@ -30,7 +30,8 @@ fun NavController.revealSeedPhrase(factorSourceId: String) {
 
 @OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.revealSeedPhrase(
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onConfirmSeedPhraseClick: (String, Int) -> Unit
 ) {
     composable(
         route = ROUTE_REVEAL_SEED_PHRASE,
@@ -55,6 +56,7 @@ fun NavGraphBuilder.revealSeedPhrase(
         RevealSeedPhraseScreen(
             viewModel = hiltViewModel(),
             onBackClick = onBackClick,
+            onConfirmSeedPhraseClick = onConfirmSeedPhraseClick
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SeedPhraseInputForm.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SeedPhraseInputForm.kt
@@ -53,6 +53,7 @@ fun SeedPhraseInputForm(
     bip39Passphrase: String,
     onFocusedWordIndexChanged: (Int) -> Unit,
     showAdvancedMode: Boolean = true,
+    highlightFields: Boolean = false
 ) {
     val focusManager = LocalFocusManager.current
     Column(
@@ -80,7 +81,8 @@ fun SeedPhraseInputForm(
                                 onFocusedWordIndexChanged(word.index)
                             }
                         },
-                        enabled = word.inputDisabled.not()
+                        enabled = word.inputDisabled.not(),
+                        highlightField = highlightFields
                     )
                 }
             }
@@ -145,7 +147,8 @@ private fun SeedPhraseWordInput(
     focusManager: FocusManager,
     modifier: Modifier = Modifier,
     onFocusChanged: ((FocusState) -> Unit)?,
-    enabled: Boolean
+    enabled: Boolean,
+    highlightField: Boolean
 ) {
     MnemonicWordTextField(
         modifier = modifier,
@@ -208,7 +211,8 @@ private fun SeedPhraseWordInput(
         onFocusChanged = onFocusChanged,
         errorFixedSize = true,
         singleLine = true,
-        enabled = enabled
+        enabled = enabled,
+        highlightField = highlightField
     )
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SeedPhraseInputForm.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SeedPhraseInputForm.kt
@@ -51,7 +51,8 @@ fun SeedPhraseInputForm(
     onWordChanged: (Int, String) -> Unit,
     onPassphraseChanged: (String) -> Unit,
     bip39Passphrase: String,
-    onFocusedWordIndexChanged: (Int) -> Unit
+    onFocusedWordIndexChanged: (Int) -> Unit,
+    showAdvancedMode: Boolean = true,
 ) {
     val focusManager = LocalFocusManager.current
     Column(
@@ -78,7 +79,8 @@ fun SeedPhraseInputForm(
                             if (it.hasFocus) {
                                 onFocusedWordIndexChanged(word.index)
                             }
-                        }
+                        },
+                        enabled = word.inputDisabled.not()
                     )
                 }
             }
@@ -97,19 +99,21 @@ fun SeedPhraseInputForm(
         }
 
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
-        RadixTextButton(
-            modifier = Modifier.fillMaxWidth(),
-            text = stringResource(
-                id = if (advancedMode) {
-                    R.string.importMnemonic_regularModeButton
-                } else {
-                    R.string.importMnemonic_advancedModeButton
+        if (showAdvancedMode) {
+            RadixTextButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(
+                    id = if (advancedMode) {
+                        R.string.importMnemonic_regularModeButton
+                    } else {
+                        R.string.importMnemonic_advancedModeButton
+                    }
+                ),
+                onClick = {
+                    advancedMode = !advancedMode
                 }
-            ),
-            onClick = {
-                advancedMode = !advancedMode
-            }
-        )
+            )
+        }
     }
 }
 
@@ -140,7 +144,8 @@ private fun SeedPhraseWordInput(
     word: SeedPhraseWord,
     focusManager: FocusManager,
     modifier: Modifier = Modifier,
-    onFocusChanged: ((FocusState) -> Unit)?
+    onFocusChanged: ((FocusState) -> Unit)?,
+    enabled: Boolean
 ) {
     MnemonicWordTextField(
         modifier = modifier,
@@ -150,7 +155,8 @@ private fun SeedPhraseWordInput(
         value = word.value,
         label = stringResource(id = R.string.importMnemonic_wordHeading, word.index + 1),
         trailingIcon = when (word.state) {
-            SeedPhraseWord.State.Valid -> {
+            SeedPhraseWord.State.Valid,
+            SeedPhraseWord.State.ValidDisabled -> {
                 {
                     Icon(
                         modifier = Modifier.size(20.dp),
@@ -186,17 +192,23 @@ private fun SeedPhraseWordInput(
         },
         keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Next) }),
         keyboardOptions = KeyboardOptions(
-            imeAction =
-            if (word.lastWord) {
-                ImeAction.Done
-            } else {
-                ImeAction.Next
+            imeAction = when {
+                word.lastWord -> {
+                    ImeAction.Done
+                }
+                word.inputDisabled -> {
+                    ImeAction.None
+                }
+                else -> {
+                    ImeAction.Next
+                }
             }
         ),
         error = if (word.state == SeedPhraseWord.State.Invalid) stringResource(id = R.string.common_invalid) else null,
         onFocusChanged = onFocusChanged,
         errorFixedSize = true,
-        singleLine = true
+        singleLine = true,
+        enabled = enabled
     )
 }
 

--- a/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/MnemonicWordTextField.kt
+++ b/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/MnemonicWordTextField.kt
@@ -57,7 +57,8 @@ fun MnemonicWordTextField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     textStyle: TextStyle = RadixTheme.typography.body1Regular,
     errorFixedSize: Boolean = false,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    highlightField: Boolean = false
 ) {
     var focused by remember { mutableStateOf(false) }
     Column(
@@ -79,6 +80,7 @@ fun MnemonicWordTextField(
             else -> RadixTheme.colors.gray1
         }
         val borderColor = when {
+            enabled && highlightField -> RadixTheme.colors.green1
             error != null -> RadixTheme.colors.red1
             focused -> RadixTheme.colors.gray1
             else -> RadixTheme.colors.gray4

--- a/profile/src/main/java/rdx/works/profile/data/model/MnemonicWithPassphrase.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/MnemonicWithPassphrase.kt
@@ -24,6 +24,9 @@ data class MnemonicWithPassphrase(
     val wordCount: Int
         get() = mnemonic.split(mnemonicWordsDelimiter).size
 
+    val words: List<String>
+        get() = mnemonic.split(mnemonicWordsDelimiter)
+
     companion object {
         const val mnemonicWordsDelimiter = " "
     }

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -68,6 +68,12 @@ suspend fun GetProfileUseCase.factorSourceById(
     factorSource.id == id
 }
 
+suspend fun GetProfileUseCase.factorSourceByIdValue(
+    value: String
+) = factorSources.first().firstOrNull { factorSource ->
+    factorSource.identifier == value
+}
+
 suspend fun GetProfileUseCase.accountsOnCurrentNetwork() = accountsOnCurrentNetwork.first()
 
 suspend fun GetProfileUseCase.accountOnCurrentNetwork(


### PR DESCRIPTION
## Description
This PR adds verification step after user confirm he/she backed up her seed phrase on Reveal Seed phrase screen. User is asked to fill in random 4 words of mnemonic, and those words are compared with corresponding words from mnemonic stored on device.


## How to test

1. Create account and transfer some XRD into it, for a seed phrase that was not yet backed up.
2. Tap prompt to back up mnemonic on account card or account details and reveal seed phrase.
3. When closing, confirm you written down the phrase.
4. Pass additional verification.

## Video

https://github.com/radixdlt/babylon-wallet-android/assets/118203440/9b73871b-cf98-4901-b1fe-f633eebd7b8d



## PR submission checklist
- [x] I have tested seed phrase verification and seed phrase input in backup restoration
