### PR TITLE
[ABW-2577] Fix backup recovery for profile with no babylon software accounts

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -22,7 +22,6 @@ import rdx.works.profile.data.model.extensions.changeGateway
 import rdx.works.profile.data.model.extensions.factorSourceId
 import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.pernetwork.Network
-import rdx.works.profile.data.model.pernetwork.SecurityState
 import rdx.works.profile.data.repository.MnemonicRepository
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.backup.BackupType
@@ -163,15 +162,12 @@ class RestoreMnemonicsViewModel @Inject constructor(
     }
 
     private suspend fun restoreMnemonic() {
-        val storedSecurityState = state.value
-            .recoverableFactorSource
-            ?.associatedAccounts
-            ?.firstOrNull()
-            ?.securityState as? SecurityState.Unsecured ?: return
+        val factorSourceToRecover = state.value
+            .recoverableFactorSource?.factorSource ?: return
 
         _state.update { it.copy(isRestoring = true) }
         restoreMnemonicUseCase(
-            factorInstance = storedSecurityState.unsecuredEntityControl.transactionSigning,
+            factorSource = factorSourceToRecover,
             mnemonicWithPassphrase = MnemonicWithPassphrase(
                 mnemonic = _state.value.seedPhraseState.wordsPhrase,
                 bip39Passphrase = _state.value.seedPhraseState.bip39Passphrase

--- a/profile/src/main/java/rdx/works/profile/data/model/factorsources/FactorSource.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/factorsources/FactorSource.kt
@@ -141,5 +141,3 @@ sealed class FactorSource : Identified {
         }
     }
 }
-
-class WasNotDeviceFactorSource : RuntimeException()

--- a/profile/src/main/java/rdx/works/profile/data/model/pernetwork/FactorInstance.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/pernetwork/FactorInstance.kt
@@ -1,13 +1,10 @@
 package rdx.works.profile.data.model.pernetwork
 
-import com.radixdlt.extensions.removeLeadingZero
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import rdx.works.core.toHexString
 import rdx.works.profile.data.model.MnemonicWithPassphrase
-import rdx.works.profile.data.model.compressedPublicKey
+import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.factorsources.FactorSource
-import rdx.works.profile.data.model.factorsources.FactorSourceKind
 import rdx.works.profile.data.model.factorsources.Slip10Curve
 import rdx.works.profile.data.model.factorsources.Slip10Curve.CURVE_25519
 import rdx.works.profile.data.model.factorsources.Slip10Curve.SECP_256K1
@@ -77,23 +74,8 @@ data class FactorInstance(
     }
 }
 
-fun FactorInstance.validateAgainst(mnemonicWithPassphrase: MnemonicWithPassphrase): Boolean {
-    if (factorSourceId.kind != FactorSourceKind.DEVICE) return false
-    val hashFactorSourceId = factorSourceId as? FactorSource.FactorSourceID.FromHash
-    val hdSource = badge as? FactorInstance.Badge.VirtualSource.HierarchicalDeterministic
-
-    return if (hashFactorSourceId != null && hdSource != null) {
-        val idMatches = FactorSource.factorSourceId(
-            mnemonicWithPassphrase = mnemonicWithPassphrase
-        ) == hashFactorSourceId.body.value
-
-        val pubKeyMatches = mnemonicWithPassphrase.compressedPublicKey(
-            derivationPath = hdSource.derivationPath,
-            curve = hdSource.publicKey.curve
-        ).removeLeadingZero().toHexString() == hdSource.publicKey.compressedData
-
-        idMatches && pubKeyMatches
-    } else {
-        false
-    }
+fun DeviceFactorSource.validateAgainst(mnemonicWithPassphrase: MnemonicWithPassphrase): Boolean {
+    return id.body.value == FactorSource.factorSourceId(
+        mnemonicWithPassphrase = mnemonicWithPassphrase
+    )
 }

--- a/profile/src/main/java/rdx/works/profile/domain/backup/RestoreMnemonicUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/RestoreMnemonicUseCase.kt
@@ -2,8 +2,7 @@ package rdx.works.profile.domain.backup
 
 import rdx.works.core.preferences.PreferencesManager
 import rdx.works.profile.data.model.MnemonicWithPassphrase
-import rdx.works.profile.data.model.factorsources.FactorSource
-import rdx.works.profile.data.model.pernetwork.FactorInstance
+import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.pernetwork.validateAgainst
 import rdx.works.profile.data.repository.MnemonicRepository
 import javax.inject.Inject
@@ -13,16 +12,13 @@ class RestoreMnemonicUseCase @Inject constructor(
     private val preferencesManager: PreferencesManager
 ) {
     suspend operator fun invoke(
-        factorInstance: FactorInstance,
+        factorSource: DeviceFactorSource,
         mnemonicWithPassphrase: MnemonicWithPassphrase
     ): Result<Unit> {
-        val isValid = factorInstance.validateAgainst(mnemonicWithPassphrase)
-
-        val factorSourceId = factorInstance.factorSourceId as? FactorSource.FactorSourceID.FromHash
-
-        return if (isValid && factorSourceId != null) {
-            mnemonicRepository.saveMnemonic(factorSourceId, mnemonicWithPassphrase)
-            preferencesManager.markFactorSourceBackedUp(factorSourceId.body.value)
+        val isValid = factorSource.validateAgainst(mnemonicWithPassphrase)
+        return if (isValid) {
+            mnemonicRepository.saveMnemonic(factorSource.id, mnemonicWithPassphrase)
+            preferencesManager.markFactorSourceBackedUp(factorSource.id.body.value)
             Result.success(Unit)
         } else {
             Result.failure(Exception("Invalid mnemonic with passphrase"))

--- a/profile/src/main/java/rdx/works/profile/olympiaimport/OlympiaWalletDataParser.kt
+++ b/profile/src/main/java/rdx/works/profile/olympiaimport/OlympiaWalletDataParser.kt
@@ -178,5 +178,3 @@ enum class OlympiaAccountType {
         }
     }
 }
-
-var olympiaTestSeedPhrase = "bridge easily outer film record undo turtle method knife quarter promote arch"

--- a/profile/src/test/java/rdx/works/profile/domain/account/MigrateOlympiaAccountsUseCaseTest.kt
+++ b/profile/src/test/java/rdx/works/profile/domain/account/MigrateOlympiaAccountsUseCaseTest.kt
@@ -14,7 +14,6 @@ import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -50,9 +49,7 @@ import rdx.works.profile.derivation.model.KeyType
 import rdx.works.profile.domain.TestData
 import rdx.works.profile.olympiaimport.OlympiaAccountDetails
 import rdx.works.profile.olympiaimport.OlympiaAccountType
-import rdx.works.profile.olympiaimport.olympiaTestSeedPhrase
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class MigrateOlympiaAccountsUseCaseTest {
 
     private val profileRepository = mockk<ProfileRepository>()
@@ -142,7 +139,7 @@ internal class MigrateOlympiaAccountsUseCaseTest {
     }
 
     private fun getOlympiaTestAccounts(): List<OlympiaAccountDetails> {
-        val words = MnemonicWords(olympiaTestSeedPhrase)
+        val words = MnemonicWords("bridge easily outer film record undo turtle method knife quarter promote arch")
         val seed = words.toSeed(passphrase = "")
         val accounts = (0..10).map { index ->
             val derivationPath = DerivationPath.forLegacyOlympia(accountIndex = index)

--- a/profile/src/test/java/rdx/works/profile/snapshot/SnapshotEncodingTests.kt
+++ b/profile/src/test/java/rdx/works/profile/snapshot/SnapshotEncodingTests.kt
@@ -96,13 +96,13 @@ class SnapshotEncodingTests(private val versionUnderTest: Int) {
 
                     if (instance.factorSourceId.kind != FactorSourceKind.DEVICE) return
 
-                    factorSources.find { it.id == instance.factorSourceId }
+                    val factorSource = factorSources.find { it.id == instance.factorSourceId } as? DeviceFactorSource
                         ?: error("Factor source not found ${instance.factorSourceId}")
                     val mnemonic = mnemonics.find { it.factorSourceID == instance.factorSourceId }
                         ?: error("Mnemonic not found ${instance.factorSourceId}")
 
                     assertTrue(
-                        instance.validateAgainst(mnemonic.mnemonicWithPassphrase.toDomain()),
+                        factorSource.validateAgainst(mnemonic.mnemonicWithPassphrase.toDomain()),
                         "FactorInstance: ${instance.factorSourceId} cannot be derived from mnemonic"
                     )
                 }


### PR DESCRIPTION
## Description
Condition we used to check if user entered correct mnemonic when restoring profile from backup was only executed when user had at least 1 software account. Tying it with accounts is not necessary.
I also simplified mnemonic input validation.

## How to test

1. Create new profile, 1st account with ledger, no software accounts.
2. Back up the profile and write down seed phrase.
3. Delete wallet and try to restore from backup by entering seed phrase - it's not posible to go past menmonic input and trigger mnemonic validation check

## PR submission checklist
- [x] I have tested that restoring profile works with or without babylon software accounts
- [x] I have tested that seed phrase input form correctly validates mnemonic words
