### PR TITLE
ABW-2547 / ABW-2583 - Account history button added. NFT dashboard link url encoded.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
@@ -1,6 +1,7 @@
 package com.babylon.wallet.android.presentation.model
 
 import com.babylon.wallet.android.domain.model.resources.Resource
+import com.babylon.wallet.android.utils.encodeUtf8
 import com.babylon.wallet.android.utils.truncatedHash
 import rdx.works.profile.data.model.apppreferences.Radix.dashboardUrl
 import rdx.works.profile.derivation.model.NetworkId
@@ -24,12 +25,13 @@ data class ActionableAddress(
     }
 
     fun toDashboardUrl(networkId: NetworkId): String {
+        val addressUrlEncoded = address.encodeUtf8()
         val suffix = when {
-            isNft -> "nft/$address"
-            type == Type.TRANSACTION -> "transaction/$address"
-            type == Type.VALIDATOR -> "component/$address"
-            type != null -> "${type.prefix}/$address"
-            else -> address
+            isNft -> "nft/$addressUrlEncoded"
+            type == Type.TRANSACTION -> "transaction/$addressUrlEncoded"
+            type == Type.VALIDATOR -> "component/$addressUrlEncoded"
+            type != null -> "${type.prefix}/$addressUrlEncoded"
+            else -> addressUrlEncoded
         }
 
         val url = networkId.dashboardUrl()


### PR DESCRIPTION
## Description
Account history button added that redirect to the webpage.
When viewing NFT address on Radix Dashboard, link is url encoded.

## How to test

1. Go to account details view.
2. Click on History button and verify that it goes to the correct web page

1. Make sure you have some nfts
2. Open individual nft item on the Radix Dashboard and verify that it links to the correct page

## Video
https://github.com/radixdlt/babylon-wallet-android/assets/108684750/79b3ca45-416b-4319-9054-bb716c2d3da1

## PR submission checklist
- [x] I have tested dashboard links and verified that they link to correct web page.
