### PR TITLE
[ABW-2604] Fix formatting for amounts below 1

### DIFF
--- a/core/src/main/java/rdx/works/core/BigDecimalExtensions.kt
+++ b/core/src/main/java/rdx/works/core/BigDecimalExtensions.kt
@@ -66,7 +66,8 @@ fun BigDecimal.displayableQuantity(): String {
         if (roundTokenQuantity == BigDecimal.ZERO) {
             "0"
         } else {
-            roundTokenQuantity.toPlainString()
+            decimalFormat.maximumFractionDigits = MAX_TOKEN_DIGITS_LENGTH - 1
+            decimalFormat.format(roundTokenQuantity)
         }
     } else {
         decimalFormat.maximumFractionDigits = MAX_TOKEN_DIGITS_LENGTH - integralPartLength


### PR DESCRIPTION
## Description
For values below 1 we didn't use same decimal format as for any other amount.

## How to test

1. You need to own token with amount less then 1 to se wrong display.

## PR submission checklist
- [x] I have verified that amounts < 1 use same decimal format as other cases
