### PR TITLE
[ABW-2609] Update detection of main babylon seed phrase recovery 

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -320,7 +320,7 @@ private fun EntitiesView(
                     )
                 }
 
-                if (state.isMainBabylonSeedPhrase) {
+                if (state.isMainBabylonSeedPhrase && state.isMandatory.not()) {
                     item {
                         RadixTextButton(
                             modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -50,7 +50,7 @@ class RestoreMnemonicsViewModel @Inject constructor(
     private val args = RestoreMnemonicsArgs.from(savedStateHandle)
     private val seedPhraseInputDelegate = SeedPhraseInputDelegate(viewModelScope)
 
-    override fun initialState(): State = State()
+    override fun initialState(): State = State(isMandatory = (args as? RestoreMnemonicsArgs.RestoreSpecificMnemonic)?.isMandatory == true)
 
     init {
         viewModelScope.launch {
@@ -240,7 +240,8 @@ class RestoreMnemonicsViewModel @Inject constructor(
         val uiMessage: UiMessage? = null,
         val isRestoring: Boolean = false,
         val hasSkippedMainSeedPhrase: Boolean = false,
-        val seedPhraseState: SeedPhraseInputDelegate.State = SeedPhraseInputDelegate.State()
+        val seedPhraseState: SeedPhraseInputDelegate.State = SeedPhraseInputDelegate.State(),
+        val isMandatory: Boolean = false
     ) : UiState {
 
         sealed interface ScreenType {

--- a/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
@@ -53,7 +53,7 @@ data class Profile(
             )
         )
     )
-    
+
     /**
      * Temporarily the only factor source that the user can use to create accounts/personas.
      * When new UI is added that allows the user to import other factor sources


### PR DESCRIPTION
## Description
Right now, if you skip babylon seed recovery, there is new BDFS that will be marked as main. If user will remove security settings of device and we lose encryption key to decrypt mnemonics, we delete them and expect recovery of main one (used for account/persona creation - otherwise app will crash if we try to create new entity). But the logic for detecting main one was not updated in BDFS skip changes, so we would restore wrong one (not used for entity creation)

## How to test

1. Restore app from backup, skip BDFS recovery
2. Remove device security screen and addd it again
3. Open app - you will see mandatory recovery that is now skippable - also a bug.
4a. Enter seed phrase, try to create account/persona - app crashes.
4b. Skip recovery - we have wallet without main BDFS mnemonic.

This PR aims to fix this 

## PR submission checklist
- [x] I have tested main BDFS recovery after device security removal
