### PR TITLE
ABW-2605 - Biometric auth only asked when we need it and when BDFS is  created.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -61,6 +61,7 @@ import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.formattedSpans
+import rdx.works.profile.domain.backup.BackupType
 
 @Composable
 fun RestoreMnemonicsScreen(
@@ -429,6 +430,7 @@ fun RestoreMnemonicsIntroContent() {
                         factorSource = SampleDataProvider().babylonDeviceFactorSource()
                     )
                 ),
+                restoreMnemonicsArgs = RestoreMnemonicsArgs.RestoreProfile(backupType = BackupType.Cloud),
                 screenType = RestoreMnemonicsViewModel.State.ScreenType.Entities
             ),
             onBackClick = {},
@@ -461,6 +463,7 @@ fun RestoreMnemonicsSeedPhraseContent() {
                         factorSource = SampleDataProvider().babylonDeviceFactorSource()
                     )
                 ),
+                restoreMnemonicsArgs = RestoreMnemonicsArgs.RestoreProfile(backupType = BackupType.Cloud),
                 screenType = RestoreMnemonicsViewModel.State.ScreenType.Entities
             ),
             onBackClick = {},
@@ -493,6 +496,7 @@ fun RestoreMnemonicsNoMainSeedPhraseContent() {
                         factorSource = SampleDataProvider().babylonDeviceFactorSource()
                     )
                 ),
+                restoreMnemonicsArgs = RestoreMnemonicsArgs.RestoreProfile(backupType = BackupType.Cloud),
                 screenType = RestoreMnemonicsViewModel.State.ScreenType.NoMainSeedPhrase
             ),
             onBackClick = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -59,6 +59,7 @@ import com.babylon.wallet.android.presentation.ui.composables.SeedPhraseSuggesti
 import com.babylon.wallet.android.presentation.ui.composables.SimpleAccountCard
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.utils.biometricAuthenticate
+import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.formattedSpans
 
 @Composable
@@ -74,28 +75,16 @@ fun RestoreMnemonicsScreen(
         state = state,
         onBackClick = viewModel::onBackClick,
         onSkipSeedPhraseClick = {
-            if (state.isLastRecoverableFactorSource) {
-                context.biometricAuthenticate { authenticated ->
-                    if (authenticated) {
-                        viewModel.onSkipSeedPhraseClick()
-                    }
-                }
-            } else {
-                viewModel.onSkipSeedPhraseClick()
+            viewModel.onSkipSeedPhraseClick {
+                context.biometricAuthenticateSuspend()
             }
         },
         onSkipMainSeedPhraseClick = viewModel::onSkipMainSeedPhraseClick,
         onSubmitClick = {
             when (state.screenType) {
                 RestoreMnemonicsViewModel.State.ScreenType.NoMainSeedPhrase -> {
-                    if (state.isLastRecoverableFactorSource) {
-                        context.biometricAuthenticate { authenticated ->
-                            if (authenticated) {
-                                viewModel.skipMainSeedPhraseAndCreateNew()
-                            }
-                        }
-                    } else {
-                        viewModel.skipMainSeedPhraseAndCreateNew()
+                    viewModel.skipMainSeedPhraseAndCreateNew {
+                        context.biometricAuthenticateSuspend()
                     }
                 }
                 RestoreMnemonicsViewModel.State.ScreenType.SeedPhrase -> {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -61,7 +61,6 @@ import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.formattedSpans
-import rdx.works.profile.domain.backup.BackupType
 
 @Composable
 fun RestoreMnemonicsScreen(
@@ -430,7 +429,6 @@ fun RestoreMnemonicsIntroContent() {
                         factorSource = SampleDataProvider().babylonDeviceFactorSource()
                     )
                 ),
-                restoreMnemonicsArgs = RestoreMnemonicsArgs.RestoreProfile(backupType = BackupType.Cloud),
                 screenType = RestoreMnemonicsViewModel.State.ScreenType.Entities
             ),
             onBackClick = {},
@@ -463,7 +461,6 @@ fun RestoreMnemonicsSeedPhraseContent() {
                         factorSource = SampleDataProvider().babylonDeviceFactorSource()
                     )
                 ),
-                restoreMnemonicsArgs = RestoreMnemonicsArgs.RestoreProfile(backupType = BackupType.Cloud),
                 screenType = RestoreMnemonicsViewModel.State.ScreenType.Entities
             ),
             onBackClick = {},
@@ -496,7 +493,6 @@ fun RestoreMnemonicsNoMainSeedPhraseContent() {
                         factorSource = SampleDataProvider().babylonDeviceFactorSource()
                     )
                 ),
-                restoreMnemonicsArgs = RestoreMnemonicsArgs.RestoreProfile(backupType = BackupType.Cloud),
                 screenType = RestoreMnemonicsViewModel.State.ScreenType.NoMainSeedPhrase
             ),
             onBackClick = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -78,7 +78,7 @@ class RestoreMnemonicsViewModel @Inject constructor(
                     _state.update {
                         it.copy(
                             recoverableFactorSources = factorSources,
-                            mainBabylonFactorSourceId = profile?.mainBabylonFactorSourceId()
+                            mainBabylonFactorSourceId = profile.mainBabylonFactorSourceId()
                         )
                     }
                 }
@@ -223,6 +223,7 @@ class RestoreMnemonicsViewModel @Inject constructor(
         }
     }
 
+    @Suppress("NestedBlockDepth")
     private suspend fun showNextRecoverableFactorSourceOrFinish(biometricAuthProvider: suspend () -> Boolean = { true }) {
         val nextRecoverableFactorSource = state.value.nextRecoverableFactorSource
         if (nextRecoverableFactorSource != null) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -113,7 +113,7 @@ class RestoreMnemonicsViewModel @Inject constructor(
             .orEmpty()
     }
 
-    fun Profile.mainBabylonFactorSourceId(): FactorSource.FactorSourceID.FromHash? {
+    private fun Profile.mainBabylonFactorSourceId(): FactorSource.FactorSourceID.FromHash? {
         val deviceFactorSources = factorSources.filterIsInstance<DeviceFactorSource>()
         val babylonFactorSources = deviceFactorSources.filter { it.isBabylon }
         return if (babylonFactorSources.size == 1) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -51,7 +51,7 @@ class RestoreMnemonicsViewModel @Inject constructor(
     private val args = RestoreMnemonicsArgs.from(savedStateHandle)
     private val seedPhraseInputDelegate = SeedPhraseInputDelegate(viewModelScope)
 
-    override fun initialState(): State = State()
+    override fun initialState(): State = State(restoreMnemonicsArgs = args)
 
     init {
         viewModelScope.launch {
@@ -229,6 +229,7 @@ class RestoreMnemonicsViewModel @Inject constructor(
 
     data class State(
         private val recoverableFactorSources: List<RecoverableFactorSource> = emptyList(),
+        private val restoreMnemonicsArgs: RestoreMnemonicsArgs,
         private val selectedIndex: Int = -1,
         val screenType: ScreenType = ScreenType.Entities,
         val isMovingForward: Boolean = false,
@@ -251,7 +252,15 @@ class RestoreMnemonicsViewModel @Inject constructor(
             get() = if (selectedIndex == -1) null else recoverableFactorSources.getOrNull(selectedIndex)
 
         val isMainBabylonSeedPhrase: Boolean
-            get() = recoverableFactorSource?.factorSource?.isMainBabylon == true
+            get() = if (recoverableFactorSources.any { it.factorSource.isMainBabylon }) {
+                recoverableFactorSource?.factorSource?.isMainBabylon == true
+            } else {
+                when (restoreMnemonicsArgs) {
+                    is RestoreMnemonicsArgs.RestoreProfile -> true
+                    is RestoreMnemonicsArgs.RestoreSpecificMnemonic -> false
+                }
+            }
+
 
         fun proceedToNextRecoverable() = copy(
             selectedIndex = selectedIndex + 1,

--- a/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
@@ -53,7 +53,7 @@ data class Profile(
             )
         )
     )
-    
+
     /**
      * Temporarily the only factor source that the user can use to create accounts/personas.
      * When new UI is added that allows the user to import other factor sources


### PR DESCRIPTION
## Description
This PR fixes a problem when we show biometric (and create BDFS when we shouldn't i.e. when clicking Seed phrase required on the card and start restoration process)
See video.

## How to test

1. Finish restoration some BDFS accounts with skipping seed phrases for them.
2. Once you have them click on **Seed phrase required - begin entry** button and make sure that no biometric is shown as no BDFS should be created.

## Video
https://github.com/radixdlt/babylon-wallet-android/assets/108684750/f143a158-51a9-410c-88a4-ea210eadea75

## PR submission checklist
- [x] I have gone through restoration flow started from **Seed phrase required - begin entry** card button click and verified that no biometric is shown and no BDFS is created.
