### PR TITLE
Return the currently newly resolved validators with stakes

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/state/StateRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/state/StateRepository.kt
@@ -144,6 +144,7 @@ class StateRepositoryImpl @Inject constructor(
         }
     }
 
+    @Suppress("LongMethod")
     override suspend fun updateLSUsInfo(
         account: Network.Account,
         validatorsWithStakes: List<ValidatorWithStakes>

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.domain.model.assets.AccountWithAssets
 import com.babylon.wallet.android.domain.model.assets.LiquidStakeUnit
 import com.babylon.wallet.android.domain.model.assets.PoolUnit
+import com.babylon.wallet.android.domain.model.assets.ValidatorWithStakes
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.usecases.GetEntitiesWithSecurityPromptUseCase
 import com.babylon.wallet.android.domain.usecases.GetNetworkInfoUseCase
@@ -212,7 +213,7 @@ class AccountViewModel @Inject constructor(
             _state.update { state -> state.copy(pendingStakeUnits = true) }
             viewModelScope.launch {
                 updateLSUsInfo(account, stakes).onSuccess {
-                    _state.update { state -> state.copy(pendingStakeUnits = false) }
+                    _state.update { state -> state.onValidatorsReceived(it) }
                 }.onFailure { error ->
                     _state.update { state -> state.copy(pendingStakeUnits = false, uiMessage = UiMessage.ErrorMessage(error)) }
                 }
@@ -303,4 +304,13 @@ data class AccountUiState(
             uiMessage = UiMessage.ErrorMessage(error = error)
         )
     }
+
+    fun onValidatorsReceived(validatorsWithStakes: List<ValidatorWithStakes>): AccountUiState = copy(
+        accountWithAssets = accountWithAssets?.copy(
+            assets = accountWithAssets.assets?.copy(
+                validatorsWithStakes = validatorsWithStakes
+            )
+        ),
+        pendingStakeUnits = false
+    )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -3,8 +3,10 @@ package com.babylon.wallet.android.presentation.transfer
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.domain.model.assets.Assets
+import com.babylon.wallet.android.domain.model.assets.ValidatorWithStakes
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.model.resources.isXrd
+import com.babylon.wallet.android.presentation.account.AccountUiState
 import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.UiState
@@ -423,6 +425,11 @@ class TransferViewModel @Inject constructor(
                         uiMessage = UiMessage.ErrorMessage(error = error)
                     )
                 }
+
+                fun onValidatorsReceived(validatorsWithStakes: List<ValidatorWithStakes>): ChooseAssets = copy(
+                    assets = assets?.copy(validatorsWithStakes = validatorsWithStakes),
+                    pendingStakeUnits = false
+                )
 
                 enum class Tab {
                     Tokens,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -6,7 +6,6 @@ import com.babylon.wallet.android.domain.model.assets.Assets
 import com.babylon.wallet.android.domain.model.assets.ValidatorWithStakes
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.model.resources.isXrd
-import com.babylon.wallet.android.presentation.account.AccountUiState
 import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.UiState

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
@@ -110,7 +110,7 @@ class AssetsChooserDelegate @Inject constructor(
             updateSheetState { state -> state.copy(pendingStakeUnits = true) }
             viewModelScope.launch {
                 updateLSUsInfo(account, stakes).onSuccess {
-                    updateSheetState { state -> state.copy(pendingStakeUnits = false) }
+                    updateSheetState { state -> state.onValidatorsReceived(it) }
                 }.onFailure { error ->
                     updateSheetState { state -> state.copy(pendingStakeUnits = false, uiMessage = UiMessage.ErrorMessage(error)) }
                 }

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/SearchFeePayersUseCaseTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/SearchFeePayersUseCaseTest.kt
@@ -124,7 +124,10 @@ class SearchFeePayersUseCaseTest {
                 error("Not needed")
             }
 
-            override suspend fun updateLSUsInfo(account: Network.Account, validatorsWithStakes: List<ValidatorWithStakes>): Result<Unit> {
+            override suspend fun updateLSUsInfo(
+                account: Network.Account,
+                validatorsWithStakes: List<ValidatorWithStakes>
+            ): Result<List<ValidatorWithStakes>> {
                 error("Not needed")
             }
 


### PR DESCRIPTION
## Description
The account and choose assets screens are being updated when an account's resources change in db.
Lets say that `Account A` and `Account B` both have stakes to the same validator `Validator 1`. If the user navigates to the `Account A` and expands the `Validator 1` the details will shimmer and then fetched from the stream when db updates itself.

Now if we navigate to `Account B` which holds stake to the same validator, we have already cached the validator's details, but we need to find if there are specific NFT claims to this account <-> validator pair. If yes, we do update the db when expanding the stakes section, BUT the db will not fire an update because the basic QUERY that is firing is not taking into account owned NFTs.

The solution is to just return the result, instead of simply updating the database.


## How to test
Use the profile I have given to you in order to see `Stoke` and `Pool Unit` accounts interact with the same validator. If you navigate to `Stoke` and expand the stakes section you will see the stake. But when you navigate to `Pool Unit` account and expand the stakes section there you will see the claim shimmering although the database is updated.

## Screenshot
It looked like this
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/053f285a-b815-4d3b-8ec0-54704ec8ca0d" width="300">

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
