### PR TITLE
ABW-2614 - Skip button moved to the bottom of the page. Refactored RestoreMnemonicsArgs to contain only RestoreProfile case.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
+++ b/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
@@ -93,8 +93,7 @@ fun WalletApp(
     LaunchedEffect(Unit) {
         mainViewModel.babylonMnemonicNeedsRecoveryEvent.collect {
             navController.restoreMnemonics(
-                args = RestoreMnemonicsArgs.RestoreSpecificMnemonic(
-                    factorSourceId = it.factorSourceID.body,
+                args = RestoreMnemonicsArgs.RestoreProfile(
                     isMandatory = true
                 )
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
@@ -83,7 +83,7 @@ fun AccountScreen(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit,
     onNavigateToMnemonicBackup: (FactorSource.FactorSourceID.FromHash) -> Unit,
-    onNavigateToMnemonicRestore: (FactorSource.FactorSourceID.FromHash) -> Unit,
+    onNavigateToMnemonicRestore: () -> Unit,
     onFungibleResourceClick: (Resource.FungibleResource, Network.Account) -> Unit,
     onNonFungibleResourceClick: (Resource.NonFungibleResource, Resource.NonFungibleResource.Item) -> Unit,
     onPoolUnitClick: (PoolUnit, Network.Account) -> Unit,
@@ -95,7 +95,7 @@ fun AccountScreen(
         viewModel.oneOffEvent.collect {
             when (it) {
                 is AccountEvent.NavigateToMnemonicBackup -> onNavigateToMnemonicBackup(it.factorSourceId)
-                is AccountEvent.NavigateToMnemonicRestore -> onNavigateToMnemonicRestore(it.factorSourceId)
+                is AccountEvent.NavigateToMnemonicRestore -> onNavigateToMnemonicRestore()
                 is AccountEvent.OnFungibleClick -> onFungibleResourceClick(it.resource, it.account)
                 is AccountEvent.OnNonFungibleClick -> onNonFungibleResourceClick(it.resource, it.item)
                 is AccountEvent.OnPoolUnitClick -> onPoolUnitClick(it.poolUnit, it.account)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainScreen.kt
@@ -19,7 +19,7 @@ fun MainScreen(
     onMenuClick: () -> Unit,
     onAccountClick: (Network.Account) -> Unit = { },
     onNavigateToMnemonicBackup: (FactorSourceID.FromHash) -> Unit,
-    onNavigateToMnemonicRestore: (FactorSourceID.FromHash) -> Unit,
+    onNavigateToMnemonicRestore: () -> Unit,
     onAccountCreationClick: () -> Unit,
     onNavigateToOnBoarding: () -> Unit,
     onNavigateToIncompatibleProfile: () -> Unit

--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainScreenNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainScreenNav.kt
@@ -16,7 +16,7 @@ fun NavGraphBuilder.main(
     onMenuClick: () -> Unit,
     onAccountClick: (Network.Account) -> Unit,
     onNavigateToMnemonicBackup: (FactorSourceID.FromHash) -> Unit,
-    onNavigateToMnemonicRestore: (FactorSourceID.FromHash) -> Unit,
+    onNavigateToMnemonicRestore: () -> Unit,
     onAccountCreationClick: () -> Unit,
     onNavigateToOnBoarding: () -> Unit,
     onNavigateToIncompatibleProfile: () -> Unit

--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -152,7 +152,7 @@ fun NavigationHost(
             },
             onNavigateToMnemonicRestore = {
                 navController.restoreMnemonics(
-                    args = RestoreMnemonicsArgs.RestoreSpecificMnemonic(factorSourceId = it.body)
+                    args = RestoreMnemonicsArgs.RestoreProfile()
                 )
             },
         )
@@ -173,9 +173,9 @@ fun NavigationHost(
                 onNavigateToMnemonicBackup = {
                     navController.seedPhrases()
                 },
-                onNavigateToMnemonicRestore = { factorSourceId ->
+                onNavigateToMnemonicRestore = {
                     navController.restoreMnemonics(
-                        args = RestoreMnemonicsArgs.RestoreSpecificMnemonic(factorSourceId = factorSourceId.body)
+                        args = RestoreMnemonicsArgs.RestoreProfile()
                     )
                 },
                 onFungibleResourceClick = { resource, account ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsNav.kt
@@ -13,7 +13,6 @@ import com.google.accompanist.navigation.animation.composable
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import rdx.works.core.HexCoded32Bytes
 import rdx.works.profile.domain.backup.BackupType
 
 private const val ARGS_RESTORE_MNEMONICS = "restoreMnemonicsArgs"

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsNav.kt
@@ -28,11 +28,8 @@ fun NavController.restoreMnemonics(
 @Serializable
 sealed interface RestoreMnemonicsArgs {
     @Serializable
-    data class RestoreProfile(val backupType: BackupType) : RestoreMnemonicsArgs
-
-    @Serializable
-    data class RestoreSpecificMnemonic(
-        val factorSourceId: HexCoded32Bytes,
+    data class RestoreProfile(
+        val backupType: BackupType? = null,
         val isMandatory: Boolean = false
     ) : RestoreMnemonicsArgs
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -287,16 +288,6 @@ private fun EntitiesView(
         )
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
 
-        if (!state.isMainBabylonSeedPhrase) {
-            RadixTextButton(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = RadixTheme.dimensions.paddingLarge),
-                text = stringResource(id = R.string.recoverSeedPhrase_skipButton),
-                onClick = onSkipClicked
-            )
-        }
-
         state.recoverableFactorSource?.let { recoverable ->
             LazyColumn(
                 verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall),
@@ -308,17 +299,27 @@ private fun EntitiesView(
                         account = account
                     )
                 }
+            }
 
-                if (state.isMainBabylonSeedPhrase && state.isMandatory.not()) {
-                    item {
-                        RadixTextButton(
-                            modifier = Modifier
-                                .fillMaxWidth(),
-                            text = stringResource(id = R.string.recoverSeedPhrase_noMainSeedPhraseButton),
-                            onClick = onSkipMainSeedPhraseClicked
-                        )
-                    }
-                }
+            if (!state.isMainBabylonSeedPhrase) {
+                Spacer(modifier = Modifier.weight(1f))
+                RadixTextButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingLarge),
+                    text = stringResource(id = R.string.recoverSeedPhrase_skipButton),
+                    onClick = onSkipClicked
+                )
+            }
+
+            if (state.isMainBabylonSeedPhrase && state.isMandatory.not()) {
+                Spacer(modifier = Modifier.weight(1f))
+                RadixTextButton(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    text = stringResource(id = R.string.recoverSeedPhrase_noMainSeedPhraseButton),
+                    onClick = onSkipMainSeedPhraseClicked
+                )
             }
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityNav.kt
@@ -37,7 +37,7 @@ fun NavGraphBuilder.accountSecurityNavGraph(
         seedPhrases(
             onBackClick = { navController.popBackStack() },
             onNavigateToRecoverMnemonic = {
-                navController.restoreMnemonics(args = RestoreMnemonicsArgs.RestoreSpecificMnemonic(it.body))
+                navController.restoreMnemonics(args = RestoreMnemonicsArgs.RestoreProfile())
             },
             onNavigateToSeedPhrase = { navController.revealSeedPhrase(it.body.value) }
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/SeedPhrasesNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/SeedPhrasesNav.kt
@@ -20,7 +20,7 @@ fun NavController.seedPhrases() {
 @OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.seedPhrases(
     onBackClick: () -> Unit,
-    onNavigateToRecoverMnemonic: (FactorSource.FactorSourceID.FromHash) -> Unit,
+    onNavigateToRecoverMnemonic: () -> Unit,
     onNavigateToSeedPhrase: (FactorSource.FactorSourceID.FromHash) -> Unit
 ) {
     composable(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/SeedPhrasesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/SeedPhrasesScreen.kt
@@ -48,7 +48,7 @@ fun SeedPhrasesScreen(
     modifier: Modifier = Modifier,
     viewModel: SeedPhrasesViewModel,
     onBackClick: () -> Unit,
-    onNavigateToRecoverMnemonic: (FactorSource.FactorSourceID.FromHash) -> Unit,
+    onNavigateToRecoverMnemonic: () -> Unit,
     onNavigateToSeedPhrase: (FactorSource.FactorSourceID.FromHash) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -72,7 +72,7 @@ fun SeedPhrasesScreen(
                 }
 
                 is SeedPhrasesViewModel.Effect.OnRequestToRecoverMnemonic -> {
-                    onNavigateToRecoverMnemonic(it.factorSourceID)
+                    onNavigateToRecoverMnemonic()
                 }
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -59,7 +59,7 @@ fun WalletScreen(
     onMenuClick: () -> Unit,
     onAccountClick: (Network.Account) -> Unit = { },
     onNavigateToMnemonicBackup: (FactorSourceID.FromHash) -> Unit,
-    onNavigateToMnemonicRestore: (FactorSourceID.FromHash) -> Unit,
+    onNavigateToMnemonicRestore: () -> Unit,
     onAccountCreationClick: () -> Unit
 ) {
     val context = LocalContext.current
@@ -86,7 +86,7 @@ fun WalletScreen(
         viewModel.oneOffEvent.collect {
             when (it) {
                 is WalletEvent.NavigateToMnemonicBackup -> onNavigateToMnemonicBackup(it.factorSourceId)
-                is WalletEvent.NavigateToMnemonicRestore -> onNavigateToMnemonicRestore(it.factorSourceId)
+                is WalletEvent.NavigateToMnemonicRestore -> onNavigateToMnemonicRestore()
             }
         }
     }


### PR DESCRIPTION
## Description
This PR refactores RestoreMnemonicsArgs to contain only RestoreProfile and remove RestoreMnemonic:
Also moved Skip button at the bottom of the page during Seed Phrase Restoration, see the ticket or here -> https://rdxworks.slack.com/archives/C03QFAWBRNX/p1700727176253209?thread_ts=1700663158.113269&cid=C03QFAWBRNX

## How to test

1. Go through seedphrase restoration and verify behaviour have not changed except:
Skip button appears at the bottom of the page. See screenshots.

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/44e5a79a-c690-44d5-97a6-f2baf1f188df" width="300">

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/02d2551e-9214-443c-a493-2c73ad327c71" width="300">

## PR submission checklist
- [x] I have tested restoration flow and verified it works as expected
