### PR TITLE
[ABW-2615] Update ledger error handling, remove unused error property and dialog.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
@@ -127,7 +127,7 @@ class LedgerMessengerImpl @Inject constructor(
             dAppDefinitionAddress = dAppDefinitionAddress
         )
         return makeLedgerRequest(request = ledgerRequest, onError = {
-            RadixWalletException.LedgerCommunicationException.FailedToDerivePublicKeys
+            RadixWalletException.LedgerCommunicationException.FailedToSignAuthChallenge
         })
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -145,6 +145,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
         data object FailedToGetDeviceId : LedgerCommunicationException()
         data object FailedToDerivePublicKeys : LedgerCommunicationException()
         data object FailedToDeriveAndDisplayAddress : LedgerCommunicationException()
+        data object FailedToSignAuthChallenge : LedgerCommunicationException()
         data class FailedToSignTransaction(val reason: LedgerErrorCode) : LedgerCommunicationException()
 
         override val ceError: ConnectorExtensionError
@@ -153,6 +154,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
                 FailedToGetDeviceId -> WalletErrorType.InvalidRequest
                 is FailedToSignTransaction -> WalletErrorType.InvalidRequest
                 is FailedToDeriveAndDisplayAddress -> WalletErrorType.InvalidRequest
+                FailedToSignAuthChallenge -> WalletErrorType.InvalidRequest
             }
     }
 }
@@ -167,8 +169,9 @@ fun RadixWalletException.LedgerCommunicationException.toUserFriendlyMessage(cont
     return context.getString(
         when (this) {
             RadixWalletException.LedgerCommunicationException.FailedToDerivePublicKeys -> {
-                R.string.common_somethingWentWrong
-            } // TODO consider different copy
+                R.string.ledgerHardwareDevices_verification_requestFailed
+            }
+
             RadixWalletException.LedgerCommunicationException.FailedToGetDeviceId -> {
                 R.string.common_somethingWentWrong
             } // TODO consider different copy
@@ -179,6 +182,9 @@ fun RadixWalletException.LedgerCommunicationException.toUserFriendlyMessage(cont
             }
 
             is RadixWalletException.LedgerCommunicationException.FailedToDeriveAndDisplayAddress -> R.string.common_somethingWentWrong
+            RadixWalletException.LedgerCommunicationException.FailedToSignAuthChallenge -> {
+                R.string.ledgerHardwareDevices_verification_requestFailed
+            }
         }
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
@@ -86,13 +86,7 @@ class CollectSignersSignaturesUseCase @Inject constructor(
                         _interactionState.update { null }
                         signaturesWithPublicKeys.addAll(signatures)
                     }.onFailure { error ->
-                        _interactionState.update {
-                            if (error is RadixWalletException.LedgerCommunicationException) {
-                                InteractionState.Ledger.Error(factorSource, signingPurpose, error)
-                            } else {
-                                null
-                            }
-                        }
+                        _interactionState.update { null }
                         return Result.failure(error)
                     }
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DappInteractionFailureDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DappInteractionFailureDialog.kt
@@ -1,0 +1,45 @@
+package com.babylon.wallet.android.presentation.dapp
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.babylon.wallet.android.R
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.domain.userFriendlyMessage
+import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
+
+@Composable
+fun DappInteractionFailureDialog(
+    dialogState: FailureDialogState,
+    onAcknowledgeFailureDialog: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    when (dialogState) {
+        is FailureDialogState.Closed -> {}
+        is FailureDialogState.Open -> {
+            BasicPromptAlertDialog(
+                modifier = modifier,
+                finish = {
+                    onAcknowledgeFailureDialog()
+                },
+                title = {
+                    Text(
+                        text = stringResource(id = R.string.error_dappRequest_invalidRequest),
+                        style = RadixTheme.typography.body1Header,
+                        color = RadixTheme.colors.gray1
+                    )
+                },
+                text = {
+                    Text(
+                        text = dialogState.dappRequestException.userFriendlyMessage(),
+                        style = RadixTheme.typography.body2Regular,
+                        color = RadixTheme.colors.gray1
+                    )
+                },
+                confirmText = stringResource(id = R.string.common_cancel),
+                dismissText = null
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/FailureDialogState.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/FailureDialogState.kt
@@ -1,0 +1,8 @@
+package com.babylon.wallet.android.presentation.dapp
+
+import com.babylon.wallet.android.domain.RadixWalletException
+
+sealed interface FailureDialogState {
+    data object Closed : FailureDialogState
+    data class Open(val dappRequestException: RadixWalletException.DappRequestException) : FailureDialogState
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/DappLoginAuthorizedNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/DappLoginAuthorizedNavGraph.kt
@@ -99,9 +99,6 @@ fun NavGraphBuilder.dappLoginAuthorizedNavGraph(navController: NavController) {
             navController.popBackStack()
         }
         chooseAccounts(
-            dismissErrorDialog = {
-                navController.navigateUp()
-            },
             onAccountCreationClick = {
                 navController.createAccountScreen(CreateAccountRequestSource.ChooseAccount)
             },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsNav.kt
@@ -55,7 +55,6 @@ fun NavController.chooseAccounts(
 @Suppress("LongParameterList", "MagicNumber")
 @OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.chooseAccounts(
-    dismissErrorDialog: () -> Unit,
     onAccountCreationClick: () -> Unit,
     onChooseAccounts: (Event.ChooseAccounts) -> Unit,
     onLoginFlowComplete: () -> Unit,
@@ -88,7 +87,6 @@ fun NavGraphBuilder.chooseAccounts(
         ChooseAccountsScreen(
             viewModel = hiltViewModel(),
             sharedViewModel = sharedVM,
-            dismissErrorDialog = dismissErrorDialog,
             onAccountCreationClick = onAccountCreationClick,
             onChooseAccounts = onChooseAccounts,
             onLoginFlowComplete = onLoginFlowComplete,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
@@ -2,14 +2,10 @@ package com.babylon.wallet.android.presentation.dapp.authorized.account
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.material.AlertDialog
-import androidx.compose.material.TextButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,6 +14,7 @@ import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.model.DApp
 import com.babylon.wallet.android.domain.model.resources.metadata.NameMetadataItem
+import com.babylon.wallet.android.presentation.dapp.DappInteractionFailureDialog
 import com.babylon.wallet.android.presentation.dapp.authorized.login.DAppAuthorizedLoginViewModel
 import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
 import com.babylon.wallet.android.presentation.status.signing.SigningStatusBottomDialog
@@ -32,7 +29,6 @@ import kotlinx.coroutines.flow.Flow
 fun ChooseAccountsScreen(
     viewModel: ChooseAccountsViewModel,
     sharedViewModel: DAppAuthorizedLoginViewModel,
-    dismissErrorDialog: () -> Unit,
     onAccountCreationClick: () -> Unit,
     onChooseAccounts: (Event.ChooseAccounts) -> Unit,
     onLoginFlowComplete: () -> Unit,
@@ -93,13 +89,10 @@ fun ChooseAccountsScreen(
         modifier = modifier
     )
 
-    state.error?.let { error ->
-        ErrorAlertDialog(
-            title = stringResource(id = R.string.dAppRequest_chooseAccounts_verificationErrorTitle),
-            body = error,
-            dismissErrorDialog = dismissErrorDialog
-        )
-    }
+    DappInteractionFailureDialog(
+        dialogState = sharedState.failureDialog,
+        onAcknowledgeFailureDialog = sharedViewModel::onAcknowledgeFailureDialog
+    )
     sharedState.interactionState?.let {
         SigningStatusBottomDialog(
             modifier = Modifier.fillMaxHeight(0.8f),
@@ -145,28 +138,6 @@ private fun HandleOneOffEvents(
             }
         }
     }
-}
-
-@Composable
-private fun ErrorAlertDialog(
-    title: String,
-    body: String,
-    dismissErrorDialog: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    AlertDialog(
-        modifier = modifier,
-        onDismissRequest = {},
-        title = { Text(text = title, color = Color.Black) },
-        text = { Text(text = body, color = Color.Black) },
-        confirmButton = {
-            TextButton(
-                onClick = dismissErrorDialog
-            ) {
-                Text(stringResource(id = R.string.common_ok), color = Color.Black)
-            }
-        }
-    )
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsViewModel.kt
@@ -54,7 +54,6 @@ class ChooseAccountsViewModel @Inject constructor(
                 _state.update {
                     it.copy(
                         availableAccountItems = accountItems.toPersistentList(),
-                        error = null,
                         showProgress = false,
                         isContinueButtonEnabled = !it.isExactAccountsCount && it.numberOfAccounts == 0
                     )
@@ -125,7 +124,6 @@ data class ChooseAccountUiState(
     val isContinueButtonEnabled: Boolean = false,
     val oneTimeRequest: Boolean = false,
     val isSingleChoice: Boolean = false,
-    val error: String? = null,
     val showProgress: Boolean = true,
     val showBackButton: Boolean = false,
     val selectedAccounts: List<AccountItemUiModel> = emptyList()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -25,8 +24,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.RequiredPersonaFields
-import com.babylon.wallet.android.domain.userFriendlyMessage
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
+import com.babylon.wallet.android.presentation.dapp.DappInteractionFailureDialog
 import com.babylon.wallet.android.presentation.dapp.InitialAuthorizedLoginRoute
 import com.babylon.wallet.android.presentation.status.signing.SigningStatusBottomDialog
 import com.babylon.wallet.android.presentation.ui.composables.BackIconType
@@ -126,31 +125,10 @@ fun DappAuthorizedLoginScreen(
             ) {
                 FullscreenCircularProgressContent()
             }
-
-            when (val dialogState = state.failureDialog) {
-                is DAppLoginUiState.FailureDialog.Closed -> {}
-                is DAppLoginUiState.FailureDialog.Open -> {
-                    BasicPromptAlertDialog(
-                        finish = { viewModel.onAcknowledgeFailureDialog() },
-                        title = {
-                            Text(
-                                text = stringResource(id = R.string.error_dappRequest_invalidRequest),
-                                style = RadixTheme.typography.body1Header,
-                                color = RadixTheme.colors.gray1
-                            )
-                        },
-                        text = {
-                            Text(
-                                text = dialogState.dappRequestException.userFriendlyMessage(),
-                                style = RadixTheme.typography.body2Regular,
-                                color = RadixTheme.colors.gray1
-                            )
-                        },
-                        confirmText = stringResource(id = R.string.common_cancel),
-                        dismissText = null
-                    )
-                }
-            }
+            DappInteractionFailureDialog(
+                dialogState = state.failureDialog,
+                onAcknowledgeFailureDialog = viewModel::onAcknowledgeFailureDialog
+            )
 
             SnackbarUiMessageHandler(
                 message = state.uiMessage,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/DappLoginUnauthorizedNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/DappLoginUnauthorizedNavGraph.kt
@@ -38,9 +38,6 @@ fun NavGraphBuilder.dappLoginUnauthorizedNavGraph(navController: NavController) 
             exitRequestFlow = {
                 navController.popBackStack()
             },
-            dismissErrorDialog = {
-                navController.popBackStack()
-            },
             onAccountCreationClick = {
                 navController.createAccountScreen(CreateAccountRequestSource.ChooseAccount)
             },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsNav.kt
@@ -40,7 +40,6 @@ fun NavController.chooseAccountsOneTime(numberOfAccounts: Int, isExactAccountsCo
 @OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.chooseAccountsOneTime(
     exitRequestFlow: () -> Unit,
-    dismissErrorDialog: () -> Unit,
     onAccountCreationClick: () -> Unit,
     onLoginFlowComplete: () -> Unit,
     onPersonaOnetime: (RequiredPersonaFields) -> Unit,
@@ -64,7 +63,6 @@ fun NavGraphBuilder.chooseAccountsOneTime(
         OneTimeChooseAccountsScreen(
             viewModel = hiltViewModel(),
             exitRequestFlow = exitRequestFlow,
-            dismissErrorDialog = dismissErrorDialog,
             onAccountCreationClick = onAccountCreationClick,
             sharedViewModel = sharedVM,
             onLoginFlowComplete = onLoginFlowComplete,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
@@ -30,7 +30,6 @@ import kotlinx.collections.immutable.persistentListOf
 fun OneTimeChooseAccountsScreen(
     viewModel: OneTimeChooseAccountsViewModel,
     exitRequestFlow: () -> Unit,
-    dismissErrorDialog: () -> Unit,
     onAccountCreationClick: () -> Unit,
     sharedViewModel: DAppUnauthorizedLoginViewModel,
     onLoginFlowComplete: () -> Unit,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
@@ -2,14 +2,10 @@ package com.babylon.wallet.android.presentation.dapp.unauthorized.accountonetime
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.material.AlertDialog
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,6 +15,7 @@ import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.model.DApp
 import com.babylon.wallet.android.domain.model.RequiredPersonaFields
 import com.babylon.wallet.android.domain.model.resources.metadata.NameMetadataItem
+import com.babylon.wallet.android.presentation.dapp.DappInteractionFailureDialog
 import com.babylon.wallet.android.presentation.dapp.authorized.account.AccountItemUiModel
 import com.babylon.wallet.android.presentation.dapp.unauthorized.login.DAppUnauthorizedLoginViewModel
 import com.babylon.wallet.android.presentation.dapp.unauthorized.login.Event
@@ -116,34 +113,9 @@ fun OneTimeChooseAccountsScreen(
             interactionState = it
         )
     }
-    state.error?.let { error ->
-        DAppAlertDialog(
-            title = stringResource(id = R.string.dAppRequest_chooseAccounts_verificationErrorTitle),
-            body = error,
-            dismissErrorDialog = dismissErrorDialog
-        )
-    }
-}
-
-@Composable
-fun DAppAlertDialog(
-    title: String,
-    body: String,
-    dismissErrorDialog: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    AlertDialog(
-        modifier = modifier,
-        onDismissRequest = {},
-        title = { Text(text = title, color = Color.Black) },
-        text = { Text(text = body, color = Color.Black) },
-        confirmButton = {
-            TextButton(
-                onClick = dismissErrorDialog
-            ) {
-                Text(stringResource(id = R.string.common_ok), color = Color.Black)
-            }
-        }
+    DappInteractionFailureDialog(
+        dialogState = sharedState.failureDialogState,
+        onAcknowledgeFailureDialog = sharedViewModel::onAcknowledgeFailureDialog
     )
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsViewModel.kt
@@ -49,7 +49,6 @@ class OneTimeChooseAccountsViewModel @Inject constructor(
                 _state.update {
                     it.copy(
                         availableAccountItems = accountItems.toPersistentList(),
-                        error = null,
                         showProgress = false,
                         isContinueButtonEnabled = !it.isExactAccountsCount && it.numberOfAccounts == 0
                     )
@@ -106,14 +105,13 @@ class OneTimeChooseAccountsViewModel @Inject constructor(
 }
 
 sealed interface OneTimeChooseAccountsEvent : OneOffEvent {
-    object NavigateToCompletionScreen : OneTimeChooseAccountsEvent
-    object FailedToSendResponse : OneTimeChooseAccountsEvent
+    data object NavigateToCompletionScreen : OneTimeChooseAccountsEvent
+    data object FailedToSendResponse : OneTimeChooseAccountsEvent
 }
 
 data class OneTimeChooseAccountUiState(
     val availableAccountItems: ImmutableList<AccountItemUiModel> = persistentListOf(),
     val isContinueButtonEnabled: Boolean = false,
-    val error: String? = null,
     val showProgress: Boolean = true,
     val numberOfAccounts: Int,
     val isExactAccountsCount: Boolean,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
@@ -24,8 +24,8 @@ import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.RequiredPersonaFields
 import com.babylon.wallet.android.domain.userFriendlyMessage
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
+import com.babylon.wallet.android.presentation.dapp.FailureDialogState
 import com.babylon.wallet.android.presentation.dapp.InitialUnauthorizedLoginRoute
-import com.babylon.wallet.android.presentation.dapp.unauthorized.login.DAppUnauthorizedLoginUiState.FailureDialog
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUiMessageHandler
 import kotlinx.coroutines.flow.filterIsInstance
@@ -69,9 +69,9 @@ fun DappUnauthorizedLoginScreen(
             FullscreenCircularProgressContent()
         }
 
-        when (val dialogState = state.failureDialog) {
-            is FailureDialog.Closed -> {}
-            is FailureDialog.Open -> {
+        when (val dialogState = state.failureDialogState) {
+            is FailureDialogState.Closed -> {}
+            is FailureDialogState.Open -> {
                 BasicPromptAlertDialog(
                     finish = { viewModel.onAcknowledgeFailureDialog() },
                     title = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/BottomPrimaryButton.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/BottomPrimaryButton.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.presentation.ui.composables
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -20,7 +21,7 @@ fun BottomPrimaryButton(
     text: String,
     buttonPadding: PaddingValues = PaddingValues(horizontal = RadixTheme.dimensions.paddingDefault)
 ) {
-    Column(modifier = modifier) {
+    Column(modifier = modifier.background(RadixTheme.colors.defaultBackground)) {
         Divider(color = RadixTheme.colors.gray5)
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
         RadixPrimaryButton(

--- a/profile/src/main/java/rdx/works/profile/di/EncryptionModule.kt
+++ b/profile/src/main/java/rdx/works/profile/di/EncryptionModule.kt
@@ -17,7 +17,6 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object EncryptionModule {
 
-    @Suppress("InjectDispatcher")
     private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
         name = DATA_STORE_NAME
     )


### PR DESCRIPTION
## Description
- removed unused `error` property
- created composable out of Dialog used in dapp login flow
- properly update signing state after ledger signature failure

## How to test
ROLA flow
1. Send accounts request with proof, at least 1 of the accounts should be ledger account
2. Cancel signature or close tab in browser
3. Observe dialog not fully dismissed.

## PR submission checklist
- [x] I have tested that canceling request that contains account with proof dismiss signing state sheet 
