### PR TITLE
ABW-2616 - Hidden accounts only box shown when all imported accounts are hidden

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -321,7 +321,7 @@ private fun EntitiesView(
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
 
         state.recoverableFactorSource?.let { recoverable ->
-            if (recoverable.allAccountsHidden) {
+            if (recoverable.areAllAccountsHidden) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -4,9 +4,11 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -319,15 +321,32 @@ private fun EntitiesView(
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
 
         state.recoverableFactorSource?.let { recoverable ->
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall),
-                contentPadding = PaddingValues(RadixTheme.dimensions.paddingDefault)
-            ) {
-                items(recoverable.associatedAccounts) { account ->
-                    SimpleAccountCard(
-                        modifier = Modifier.fillMaxWidth(),
-                        account = account
+            if (recoverable.allAccountsHidden) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingXXXLarge)
+                        .background(RadixTheme.colors.gray5, shape = RadixTheme.shapes.roundedRectMedium)
+                ) {
+                    Text(
+                        modifier = Modifier.fillMaxWidth().padding(RadixTheme.dimensions.paddingXLarge),
+                        text = "Hidden accounts only.",
+                        textAlign = TextAlign.Center,
+                        style = RadixTheme.typography.body1HighImportance,
+                        color = RadixTheme.colors.gray2
                     )
+                }
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall),
+                    contentPadding = PaddingValues(RadixTheme.dimensions.paddingDefault)
+                ) {
+                    items(recoverable.nonHiddenAccountsToDisplay) { account ->
+                        SimpleAccountCard(
+                            modifier = Modifier.fillMaxWidth(),
+                            account = account
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -21,6 +21,8 @@ import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.extensions.changeGateway
 import rdx.works.profile.data.model.extensions.factorSourceId
+import rdx.works.profile.data.model.extensions.isHidden
+import rdx.works.profile.data.model.extensions.isNotHidden
 import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.factorsources.FactorSourceFlag
@@ -287,4 +289,10 @@ class RestoreMnemonicsViewModel @Inject constructor(
 data class RecoverableFactorSource(
     val associatedAccounts: List<Network.Account>,
     val factorSource: DeviceFactorSource
-)
+) {
+    val nonHiddenAccountsToDisplay: List<Network.Account>
+        get() = associatedAccounts.filter { it.isNotHidden() }
+
+    val allAccountsHidden: Boolean
+        get() = associatedAccounts.all { it.isHidden() }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -292,6 +292,6 @@ data class RecoverableFactorSource(
     val nonHiddenAccountsToDisplay: List<Network.Account>
         get() = associatedAccounts.filter { it.isHidden().not() }
 
-    val allAccountsHidden: Boolean
+    val areAllAccountsHidden: Boolean
         get() = associatedAccounts.all { it.isHidden() }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -22,7 +22,6 @@ import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.extensions.changeGateway
 import rdx.works.profile.data.model.extensions.factorSourceId
 import rdx.works.profile.data.model.extensions.isHidden
-import rdx.works.profile.data.model.extensions.isNotHidden
 import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.factorsources.FactorSourceFlag
@@ -291,7 +290,7 @@ data class RecoverableFactorSource(
     val factorSource: DeviceFactorSource
 ) {
     val nonHiddenAccountsToDisplay: List<Network.Account>
-        get() = associatedAccounts.filter { it.isNotHidden() }
+        get() = associatedAccounts.filter { it.isHidden().not() }
 
     val allAccountsHidden: Boolean
         get() = associatedAccounts.all { it.isHidden() }

--- a/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
@@ -8,7 +8,7 @@ import rdx.works.profile.data.model.apppreferences.Gateways
 import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.apppreferences.Security
 import rdx.works.profile.data.model.apppreferences.Transaction
-import rdx.works.profile.data.model.extensions.isNotHidden
+import rdx.works.profile.data.model.extensions.isHidden
 import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.factorsources.FactorSourceFlag
@@ -48,8 +48,8 @@ data class Profile(
         header = header.copy(
             contentHint = Header.ContentHint(
                 numberOfNetworks = networks.size,
-                numberOfAccountsOnAllNetworksInTotal = networks.sumOf { network -> network.accounts.count { it.isNotHidden() } },
-                numberOfPersonasOnAllNetworksInTotal = networks.sumOf { network -> network.personas.count { it.isNotHidden() } }
+                numberOfAccountsOnAllNetworksInTotal = networks.sumOf { network -> network.accounts.count { it.isHidden().not() } },
+                numberOfPersonasOnAllNetworksInTotal = networks.sumOf { network -> network.personas.count { it.isHidden().not() } }
             )
         )
     )

--- a/profile/src/main/java/rdx/works/profile/data/model/extensions/EntityExtensions.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/extensions/EntityExtensions.kt
@@ -112,3 +112,7 @@ fun Profile.unhideAllEntities(): Profile {
 fun Entity.isNotHidden(): Boolean {
     return flags.contains(EntityFlag.DeletedByUser).not()
 }
+
+fun Entity.isHidden(): Boolean {
+    return flags.contains(EntityFlag.DeletedByUser)
+}

--- a/profile/src/main/java/rdx/works/profile/data/model/extensions/EntityExtensions.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/extensions/EntityExtensions.kt
@@ -109,10 +109,6 @@ fun Profile.unhideAllEntities(): Profile {
     return copy(networks = updatedNetworks).withUpdatedContentHint()
 }
 
-fun Entity.isNotHidden(): Boolean {
-    return flags.contains(EntityFlag.DeletedByUser).not()
-}
-
 fun Entity.isHidden(): Boolean {
     return flags.contains(EntityFlag.DeletedByUser)
 }


### PR DESCRIPTION

## Description
This PR adds Hidden accounts only indication when restoration from backup.

## How to test

That is the first path:

1. Create at least one account, export the profile, delete the app, go through the restoration and skip seedphrase.
2. After restoration create some new accounts with new main BDFS. 
That is the first path:
3. Hide all previous accounts associated with old BDFS.
4. Export profile and go through restoration.
5. When importing seed phrase accounts from old BDFS, verify that Hidden accounts only box is shown (see screenshot)

Another path:
3. Hide some of the accounts associated with old BDFS, but not all of them.
4. Export profile and go through restoration.
5. When importing seed phrase accounts from old BDFS, verify that you see only accounts that are not hidden, however when you complete restoration all of the accounts are imported and you are able to unhide accounts that were hidden upon importing them.

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/340deb13-bb61-4fa5-8611-628f72dc0e7d" width="30%">

## PR submission checklist
- [x] I have completed restoration with hidden accounts and verified that Hidden accounts only box is shown.
