### PR TITLE
[ABW-2612] Update webrtc lib to 119 and imporve peerdroid logging

### DIFF
--- a/webrtc-library/build.gradle
+++ b/webrtc-library/build.gradle
@@ -1,2 +1,2 @@
 configurations.maybeCreate("default")
-artifacts.add("default", file('libwebrtc-m116.aar'))
+artifacts.add("default", file('libwebrtc-m119.aar'))


### PR DESCRIPTION
## Description
This PR:
- updates the WebRTC library from 116 to 119
- improved the peerdroid logging: removing some unnecessary logs and used more descriptive emojis


## How to test
- if you don't have a link connection then establish a new one and do some transactions
- if you have a link connection then do some transactions. After that delete the link connection, add a new one, and do some other transactions


## PR submission checklist
- [X] I have tested link connection
