### PR TITLE
[ABW-2625] Terminate gracegully WebRTC when adding link connection

### DIFF
--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
@@ -58,7 +58,7 @@ interface PeerdroidConnector {
 
     suspend fun connectToConnectorExtension(encryptionKey: ByteArray): Result<Unit>
 
-    suspend fun deleteConnector(connectionIdHolder: ConnectionIdHolder)
+    suspend fun deleteConnector(connectionId: ConnectionIdHolder)
 
     fun terminateConnectionToConnectorExtension()
 
@@ -108,7 +108,7 @@ internal class PeerdroidConnectorImpl(
                 return@withContext Result.success(Unit)
             }
 
-            Timber.d("⚙️ establish a link connection with connectionId: $connectionId")
+            Timber.d("⚙️ establishing a link connection with connectionId: $connectionId")
             val webSocketClient = WebSocketClient(applicationContext)
             webSocketClient.initSession(
                 connectionId = connectionId,
@@ -128,17 +128,17 @@ internal class PeerdroidConnectorImpl(
         }
     }
 
-    override suspend fun deleteConnector(connectionIdHolder: ConnectionIdHolder) {
-        Timber.d("⚙️ delete link connection with connectionId: $connectionIdHolder")
+    override suspend fun deleteConnector(connectionId: ConnectionIdHolder) {
+        Timber.d("⚙️ \uD83D\uDDD1️ delete link connection with connectionId: ${connectionId.id}")
         withContext(ioDispatcher) {
-            val webSocketHolder = mapOfWebSockets.remove(connectionIdHolder)
+            val webSocketHolder = mapOfWebSockets.remove(connectionId)
             webSocketHolder?.let {
                 webSocketHolder.listenMessagesJob.cancel()
                 webSocketHolder.webSocketClient.closeSession()
             }
             // close and remove the peer connections and their jobs for this connection id
             val peerConnectionsForTermination = mapOfPeerConnections.values.filter { peerConnectionHolder ->
-                peerConnectionHolder.connectionIdHolder == connectionIdHolder
+                peerConnectionHolder.connectionIdHolder == connectionId
             }
             peerConnectionsForTermination.forEach { peerConnectionHolder ->
                 peerConnectionHolder.observePeerConnectionJob.cancel()
@@ -147,19 +147,19 @@ internal class PeerdroidConnectorImpl(
             mapOfPeerConnections.values.removeAll(peerConnectionsForTermination.toSet())
             // close and remove data channels for this connection id
             val dataChannelsForTermination = mapOfDataChannels.values.filter { dataChannelHolder ->
-                dataChannelHolder.connectionIdHolder == connectionIdHolder
+                dataChannelHolder.connectionIdHolder == connectionId
             }
             dataChannelsForTermination.forEach { dataChannelHolder ->
                 dataChannelHolder.dataChannel.close()
             }
             mapOfDataChannels.values.removeAll(dataChannelsForTermination.toSet())
-            Timber.d("⚙️ link connection with connectionId: $connectionIdHolder deleted ❌")
+            Timber.d("⚙️ \uD83D\uDDD1️ link connection with connectionId: ${connectionId.id} deleted ✅")
         }
     }
 
     override fun terminateConnectionToConnectorExtension() {
-        Timber.d("⚙️ =====> terminate link connection")
         applicationScope.launch(ioDispatcher) {
+            Timber.d("⚙️ \uD83D\uDEAB terminating all link connections and clear: websockets, peer connections, and data channels")
             mapOfWebSockets.values.forEach { webSocketHolder ->
                 webSocketHolder.listenMessagesJob.cancel()
                 webSocketHolder.webSocketClient.closeSession()
@@ -176,7 +176,7 @@ internal class PeerdroidConnectorImpl(
                 dataChannelHolder.dataChannel.close()
             }
             mapOfDataChannels.clear()
-            Timber.d("⚙️ link connection terminated 🚫 <=====")
+            Timber.d("⚙️ \uD83D\uDEAB all link connection terminated and cleared ✅")
         }
     }
 
@@ -205,15 +205,13 @@ internal class PeerdroidConnectorImpl(
             if (mapOfDataChannels.contains(key = connectionIdHolder)) {
                 mapOfDataChannels.getValue(connectionIdHolder).dataChannel.sendMessage(message)
             } else {
-                Timber.e("📯 failed to send message to CE: $connectionIdHolder because its data channel is closed")
+                Timber.e("📯 failed to send message to CE: $connectionIdHolder because its data channel is closed❗")
                 Result.failure(Throwable("failed to send message to CE"))
             }
         }
     }
 
-    override suspend fun sendDataChannelMessageToAllRemoteClients(
-        message: String
-    ): Result<Unit> {
+    override suspend fun sendDataChannelMessageToAllRemoteClients(message: String): Result<Unit> {
         return withContext(ioDispatcher) {
             val jobs = mapOfDataChannels.values.map { channel ->
                 async { channel.dataChannel.sendMessage(message) }
@@ -222,14 +220,14 @@ internal class PeerdroidConnectorImpl(
             if (results.any { it.isSuccess }) {
                 Result.success(Unit)
             } else {
-                Timber.e("📯 failed to send message to all remote clients")
+                Timber.e("📯 failed to send message to all remote clients❗")
                 Result.failure(Throwable("failed to send message to all remote clients"))
             }
         }
     }
 
     private fun listenForMessagesFromRemoteClients(
-        connectionIdHolder: ConnectionIdHolder,
+        connectionId: ConnectionIdHolder,
         webSocketClient: WebSocketClient
     ): Job {
         val job = applicationScope.launch(ioDispatcher) {
@@ -239,27 +237,30 @@ internal class PeerdroidConnectorImpl(
                     when (signalingServerMessage) {
                         is RemoteInfo -> {
                             if (signalingServerMessage is RemoteInfo.ClientConnected) {
-                                Timber.d("⚙️ ⬇️ remote client connected with id: ${signalingServerMessage.remoteClientId}")
+                                Timber.d(
+                                    "⚙️ \uD83D\uDCE1️ remote client connected with remoteClientId: " +
+                                        "${signalingServerMessage.remoteClientId} ⬇️ \uD83D\uDFE9"
+                                )
                                 val peerConnectionReadyForNegotiationDeferred = CompletableDeferred<Unit>()
                                 val remoteClientHolder = RemoteClientHolder(id = signalingServerMessage.remoteClientId)
                                 val peerConnectionHolder = createAndObservePeerConnectionForRemoteClient(
                                     remoteClientHolder = remoteClientHolder,
-                                    connectionIdHolder = connectionIdHolder,
+                                    connectionId = connectionId,
                                     renegotiationDeferred = peerConnectionReadyForNegotiationDeferred
                                 )
                                 peerConnectionReadyForNegotiationDeferred.await()
                                 mapOfPeerConnections[remoteClientHolder] = peerConnectionHolder
-                                Timber.d("⚙️ count of peer connections: ${mapOfPeerConnections.size}")
+                                Timber.d("⚙️ ℹ️ current count of peer connections: ${mapOfPeerConnections.size}")
                             }
                         }
 
                         is RemoteData -> {
                             if (signalingServerMessage is RemoteData.Offer) {
                                 val remoteClientHolder = RemoteClientHolder(id = signalingServerMessage.remoteClientId)
-                                Timber.d("⚙️ ⬇️ offer received from remote client: $remoteClientHolder")
+                                Timber.d("⚙️ \uD83D\uDCE1 offer received from remote client: $remoteClientHolder ⬇️")
                                 val isSuccess = processOfferFromRemoteClientAndSendAnswer(
                                     offer = signalingServerMessage,
-                                    connectionIdHolder = connectionIdHolder,
+                                    connectionId = connectionId,
                                     remoteClientHolder = remoteClientHolder
                                 )
                                 if (isSuccess.not()) {
@@ -268,14 +269,16 @@ internal class PeerdroidConnectorImpl(
                                 }
                             }
                             if (signalingServerMessage is RemoteData.IceCandidate) {
-                                Timber.d("⚙️ ⬇️ ice candidate received from remote client: ${signalingServerMessage.remoteClientId}")
+                                Timber.d(
+                                    "⚙️ \uD83D\uDCE1 ice candidate received from remote client: ${signalingServerMessage.remoteClientId} ⬇️"
+                                )
                                 addRemoteIceCandidateInWebRtc(signalingServerMessage)
                             }
                         }
 
-                        is Confirmation -> {} // TODO do something with this poor but important event
+                        is Confirmation -> {}
                         is Error -> {
-                            Timber.d("⚙️ ⬇️ error")
+                            Timber.d("⚙️ \uD83D\uDCE1 error ❗ ⬇")
                         }
                     }
                 }
@@ -286,7 +289,7 @@ internal class PeerdroidConnectorImpl(
     @Suppress("LongMethod")
     private fun createAndObservePeerConnectionForRemoteClient(
         remoteClientHolder: RemoteClientHolder,
-        connectionIdHolder: ConnectionIdHolder,
+        connectionId: ConnectionIdHolder,
         renegotiationDeferred: CompletableDeferred<Unit>
     ): PeerConnectionHolder {
         val webRtcManager = WebRtcManager(applicationContext)
@@ -300,7 +303,7 @@ internal class PeerdroidConnectorImpl(
             .onEach { event ->
                 when (event) {
                     is PeerConnectionEvent.RenegotiationNeeded -> {
-                        Timber.d("⚙️ ⚡ renegotiation needed 🆗 for remote client: $remoteClientHolder")
+                        Timber.d("⚙️ ⚡ renegotiation needed for remote client: $remoteClientHolder \uD83C\uDD97")
                         renegotiationDeferred.complete(Unit)
                     }
 
@@ -310,7 +313,7 @@ internal class PeerdroidConnectorImpl(
 
                     is PeerConnectionEvent.IceCandidate -> {
                         Timber.d("⚙️ ⚡ ice candidate generated for remote client: $remoteClientHolder")
-                        sendIceCandidateToRemoteClient(connectionIdHolder, remoteClientHolder, event.data)
+                        sendIceCandidateToRemoteClient(connectionId, remoteClientHolder, event.data)
                     }
 
                     is PeerConnectionEvent.SignalingState -> {
@@ -318,41 +321,41 @@ internal class PeerdroidConnectorImpl(
                     }
 
                     is PeerConnectionEvent.Connected -> {
-                        Timber.d("⚙️ ⚡ peer connection connected 🟢 for remote client: $remoteClientHolder")
+                        Timber.d("⚙️ ⚡ peer connection connected for remote client: $remoteClientHolder \uD83D\uDFE2")
                         val dataChannel = DataChannelWrapper(
-                            connectionIdHolder = connectionIdHolder,
+                            connectionIdHolder = connectionId,
                             webRtcDataChannel = webRtcManager.getDataChannel()
                         )
                         dataChannelObserver.value = dataChannel
-                        mapOfDataChannels[connectionIdHolder] = DataChannelHolder(
-                            connectionIdHolder = connectionIdHolder,
+                        mapOfDataChannels[connectionId] = DataChannelHolder(
+                            connectionIdHolder = connectionId,
                             dataChannel = dataChannel
                         )
                         isAnyChannelConnected.emit(mapOfDataChannels.values.isNotEmpty())
-                        Timber.d("⚙️ count of data channels: ${mapOfDataChannels.size}")
+                        Timber.d("⚙️ ℹ️ current count of data channels: ${mapOfDataChannels.size}")
                     }
 
                     is PeerConnectionEvent.Disconnected -> {
-                        Timber.d("⚙️ ⚡ peer connection disconnected 🔴 for remote client: $remoteClientHolder")
-                        terminatePeerConnectionAndDataChannel(remoteClientHolder, connectionIdHolder)
+                        Timber.d("⚙️ ⚡ peer connection disconnected for remote client: $remoteClientHolder \uD83D\uDD34")
+                        terminatePeerConnectionAndDataChannel(remoteClientHolder, connectionId)
                         isAnyChannelConnected.emit(mapOfDataChannels.values.isNotEmpty())
                     }
 
                     is PeerConnectionEvent.Failed -> {
-                        Timber.d("⚙️ ⚡ peer connection failed ❌ for remote client: $remoteClientHolder")
-                        terminatePeerConnectionAndDataChannel(remoteClientHolder, connectionIdHolder)
+                        Timber.d("⚙️ ⚡ peer connection failed for remote client: $remoteClientHolder ❌")
+                        terminatePeerConnectionAndDataChannel(remoteClientHolder, connectionId)
                     }
                 }
             }
             .catch { exception ->
-                Timber.e("⚙️ ⚡ an exception occurred: ${exception.localizedMessage}")
+                Timber.e("⚙️ ⚡ an exception occurred: ${exception.localizedMessage} ❗")
             }
             .cancellable()
             .flowOn(ioDispatcher)
             .launchIn(applicationScope)
 
         return PeerConnectionHolder(
-            connectionIdHolder = connectionIdHolder,
+            connectionIdHolder = connectionId,
             webRtcManager = webRtcManager,
             observePeerConnectionJob = job
         )
@@ -360,22 +363,24 @@ internal class PeerdroidConnectorImpl(
 
     private fun terminatePeerConnectionAndDataChannel(
         remoteClientHolder: RemoteClientHolder,
-        connectionIdHolder: ConnectionIdHolder
+        connectionId: ConnectionIdHolder
     ) {
+        Timber.d("⚙️ \uD83D\uDED1 terminating link connection for connectionId: ${connectionId.id}")
         val peerConnectionHolder = mapOfPeerConnections.remove(remoteClientHolder)
         peerConnectionHolder?.let {
             peerConnectionHolder.observePeerConnectionJob.cancel()
             peerConnectionHolder.webRtcManager.close()
         }
-        val dataChannelHolder = mapOfDataChannels.remove(connectionIdHolder)
+        val dataChannelHolder = mapOfDataChannels.remove(connectionId)
         dataChannelHolder?.let {
             dataChannelHolder.dataChannel.close()
         }
+        Timber.d("⚙️ \uD83D\uDED1 link connection terminated for connectionId: ${connectionId.id} ✅")
     }
 
     private suspend fun processOfferFromRemoteClientAndSendAnswer(
         offer: RemoteData.Offer,
-        connectionIdHolder: ConnectionIdHolder,
+        connectionId: ConnectionIdHolder,
         remoteClientHolder: RemoteClientHolder
     ): Boolean {
         suspend fun setRemoteDescriptionFromOffer(offer: RemoteData.Offer): Boolean {
@@ -385,12 +390,9 @@ internal class PeerdroidConnectorImpl(
             )
             val webRtcManager = mapOfPeerConnections.getValue(remoteClientHolder).webRtcManager
             return webRtcManager.setRemoteDescription(sessionDescription)
-                .onSuccess {
-                    Timber.d("⚙️ ⚡ remote description is set for remote client: $remoteClientHolder")
-                }
                 .onFailure {
                     Timber.e(
-                        "⚙️ ⚡ failed to set remote description:${it.message} for remote client: $remoteClientHolder"
+                        "⚙️ ⚡ failed to set remote description:${it.message} for remote client: $remoteClientHolder❗"
                     )
                 }
                 .isSuccess
@@ -416,7 +418,7 @@ internal class PeerdroidConnectorImpl(
                 return if (isSet) {
                     // then send the answer to the remote client via signaling server
                     val webSocketClient = mapOfWebSockets.getValue(connectionIdHolder).webSocketClient
-                    Timber.d("⚙️ ⬆️ send answer to the remote client: $remoteClientHolder")
+                    Timber.d("⚙️ \uD83D\uDCE1️ send answer to the remote client: $remoteClientHolder ⬆️")
                     webSocketClient.sendAnswerMessage(
                         remoteClientId = remoteClientHolder.id,
                         answerPayload = sessionDescriptionValue.toAnswerPayload()
@@ -426,13 +428,16 @@ internal class PeerdroidConnectorImpl(
                     false
                 }
             } ?: kotlin.run {
-                Timber.e("⚙️ ⚡ failed to create answer: ${result.exceptionOrNull()?.message}")
+                Timber.e("⚙️ ⚡ failed to create answer: ${result.exceptionOrNull()?.message}❗")
                 return false
             }
         }
 
+        // set remote description of remote client to the wallet's WebRTC
         val remoteDescriptionResult = setRemoteDescriptionFromOffer(offer)
-        val answerToRemoteClientResult = createAndSendAnswerToRemoteClient(connectionIdHolder, remoteClientHolder)
+        // create answer with the local description and send it to remote client
+        val answerToRemoteClientResult = createAndSendAnswerToRemoteClient(connectionId, remoteClientHolder)
+        // both must succeed
         return remoteDescriptionResult && answerToRemoteClientResult
     }
 
@@ -442,11 +447,8 @@ internal class PeerdroidConnectorImpl(
     ): Boolean {
         val webRtcManager = mapOfPeerConnections.getValue(remoteClientHolder).webRtcManager
         return webRtcManager.setLocalDescription(localSessionDescription)
-            .onSuccess {
-                Timber.d("⚙️ ⚡ local description is set for remote client: $remoteClientHolder")
-            }
             .onFailure {
-                Timber.e("⚙️ ⚡ failed to set local description:${it.message} for remote client: $remoteClientHolder")
+                Timber.e("⚙️ ⚡ failed to set local description:${it.message} for remote client: $remoteClientHolder❗")
             }
             .isSuccess
     }
@@ -454,19 +456,18 @@ internal class PeerdroidConnectorImpl(
     private suspend fun addRemoteIceCandidateInWebRtc(iceCandidate: RemoteData.IceCandidate) {
         val remoteIceCandidate = iceCandidate.remoteIceCandidate
         val remoteClientHolder = RemoteClientHolder(id = iceCandidate.remoteClientId)
-        Timber.d("⚙️ ⚡ set remote ice candidate in local WebRTC for remote client: $remoteClientHolder")
         val webRtcManager = mapOfPeerConnections.getValue(remoteClientHolder).webRtcManager
         webRtcManager.addRemoteIceCandidate(remoteIceCandidate = remoteIceCandidate)
     }
 
     private fun sendIceCandidateToRemoteClient(
-        connectionIdHolder: ConnectionIdHolder,
+        connectionId: ConnectionIdHolder,
         remoteClientHolder: RemoteClientHolder,
         iceCandidateData: PeerConnectionEvent.IceCandidate.Data
     ) {
-        Timber.d("⚙️ ⬆️ send ice candidate to the remote client: $remoteClientHolder")
+        Timber.d("⚙️ \uD83D\uDCE1️ send ice candidate to the remote client: $remoteClientHolder ⬆️")
         applicationScope.launch(ioDispatcher) {
-            val webSocketClient = mapOfWebSockets.getValue(connectionIdHolder).webSocketClient
+            val webSocketClient = mapOfWebSockets.getValue(connectionId).webSocketClient
             webSocketClient.sendIceCandidateMessage(
                 remoteClientId = remoteClientHolder.id,
                 iceCandidateData = iceCandidateData

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
@@ -456,7 +456,7 @@ internal class PeerdroidConnectorImpl(
     private suspend fun addRemoteIceCandidateInWebRtc(iceCandidate: RemoteData.IceCandidate) {
         val remoteIceCandidate = iceCandidate.remoteIceCandidate
         val remoteClientHolder = RemoteClientHolder(id = iceCandidate.remoteClientId)
-        val webRtcManager = mapOfPeerConnections.getValue(remoteClientHolder).webRtcManager
+        val webRtcManager = mapOfPeerConnections[remoteClientHolder]?.webRtcManager ?: return
         webRtcManager.addRemoteIceCandidate(remoteIceCandidate = remoteIceCandidate)
     }
 
@@ -467,7 +467,7 @@ internal class PeerdroidConnectorImpl(
     ) {
         Timber.d("⚙️ \uD83D\uDCE1️ send ice candidate to the remote client: $remoteClientHolder ⬆️")
         applicationScope.launch(ioDispatcher) {
-            val webSocketClient = mapOfWebSockets.getValue(connectionId).webSocketClient
+            val webSocketClient = mapOfWebSockets[connectionId]?.webSocketClient ?: return@launch
             webSocketClient.sendIceCandidateMessage(
                 remoteClientId = remoteClientHolder.id,
                 iceCandidateData = iceCandidateData

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
@@ -173,7 +173,6 @@ internal class PeerdroidLinkImpl(
                     is PeerConnectionEvent.Disconnected -> {
                         Timber.d("🗼 ⚡ signaling state changed: peer connection disconnected 🔴")
                         terminate()
-                        addConnectionDeferred.complete(Result.success(Unit))
                     }
                     is PeerConnectionEvent.Failed -> {
                         Timber.d("🗼 ⚡ signaling state changed: peer connection failed ❌")

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
@@ -172,7 +172,7 @@ internal class PeerdroidLinkImpl(
                     }
                     is PeerConnectionEvent.Disconnected -> {
                         Timber.d("🗼 ⚡ signaling state changed: peer connection disconnected 🔴")
-                        terminate()
+                        terminateWithSuccess()
                     }
                     is PeerConnectionEvent.Failed -> {
                         Timber.d("🗼 ⚡ signaling state changed: peer connection failed ❌")
@@ -252,7 +252,7 @@ internal class PeerdroidLinkImpl(
         addConnectionDeferred.complete(Result.failure(Throwable("data channel couldn't initialize")))
     }
 
-    private suspend fun terminate() {
+    private suspend fun terminateWithSuccess() {
         Timber.d("🗼️ terminate webrtc and web socket connection \uD83D\uDEAB")
         webSocketClientJob?.cancel()
         webSocketClient.closeSession()

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
@@ -52,7 +52,7 @@ internal class PeerdroidLinkImpl(
         addConnectionDeferred = CompletableDeferred()
         // get connection id from encryption key
         val connectionId = encryptionKey.blake2Hash().toHexString()
-        Timber.d("🛠️️ add new link connection with connection id: $connectionId")
+        Timber.d("\uD83D\uDDFC️ add new link connection with connectionId: $connectionId")
 
         withContext(ioDispatcher) {
             // Leave this method here because WebRTC takes too long to initialize its components
@@ -80,52 +80,56 @@ internal class PeerdroidLinkImpl(
         webSocketClient
             .listenForMessages()
             .onStart { // for debugging
-                Timber.d("🛠️️ ▶️️ start observing incoming messages from signaling server")
+                Timber.d("\uD83D\uDDFC start observing incoming messages from signaling server ▶️️")
             }
             .onCompletion {
-                Timber.d("🛠️️ ⏹️️ end observing incoming messages from signaling server")
+                Timber.d("\uD83D\uDDFC️️ end observing incoming messages from signaling server ⏹️")
             }
             .onEach { incomingMessage ->
                 when (incomingMessage) {
                     is SignalingServerMessage.RemoteInfo.ClientConnected -> {
-                        Timber.d("🛠️️ ⬇️ connector extension is connected with id: ${incomingMessage.remoteClientId} 📬")
+                        Timber.d(
+                            "🗼️ \uD83D\uDCE1️ connector extension is connected with id: ${incomingMessage.remoteClientId} ⬇️ \uD83D\uDFE9"
+                        )
                     }
                     is SignalingServerMessage.RemoteData.Offer -> {
-                        Timber.d("🛠️️ ⬇️ offer received from connector extension: ${incomingMessage.remoteClientId}")
+                        Timber.d("🗼️ \uD83D\uDCE1️️ offer received from connector extension: ${incomingMessage.remoteClientId} ⬇️")
                         setRemoteDescriptionFromOffer(incomingMessage)
                         createAndSendAnswerToRemoteClient()
                     }
                     is SignalingServerMessage.RemoteData.Answer -> {
-                        Timber.d("🛠️️ ⬇️ answer received from connector extension: ${incomingMessage.remoteClientId}")
+                        Timber.d("🗼️ \uD83D\uDCE1️️ answer received from connector extension: ${incomingMessage.remoteClientId} ⬇️")
                     }
                     is SignalingServerMessage.RemoteData.IceCandidate -> {
-                        Timber.d("🛠️️ ⬇️ ice candidate received from connector extension: ${incomingMessage.remoteClientId}")
+                        Timber.d("🗼️ \uD83D\uDCE1️️ ice candidate received from connector extension: ${incomingMessage.remoteClientId} ⬇️")
                         addRemoteIceCandidateInWebRtc(incomingMessage)
                     }
                     is SignalingServerMessage.Confirmation -> {
-                        Timber.d("🛠️️ ⬇️ confirmation received for requestId: ${incomingMessage.requestId}")
+//                        Timber.d("🗼️ \uD83D\uDCE1️️ confirmation received for requestId: ${incomingMessage.requestId} ⬇️")
                     }
                     is SignalingServerMessage.Error.InvalidMessage -> {
-                        Timber.d("🛠️️ ⬇️ invalid message error: ${incomingMessage.errorMessage}")
+                        Timber.d("🗼️ \uD83D\uDCE1️️ invalid message error: ${incomingMessage.errorMessage} ⬇️")
                     }
                     is SignalingServerMessage.RemoteInfo.MissingClient -> {
-                        Timber.d("🛠️️ ⬇️ missing connector extension error, request id: ${incomingMessage.requestId}")
+                        Timber.d("🗼️ \uD83D\uDCE1️️ missing connector extension error, request id: ${incomingMessage.requestId} ⬇️")
                     }
                     is SignalingServerMessage.RemoteInfo.ClientDisconnected -> {
-                        Timber.d("🛠️️ ⬇️ connector extension disconnected with id: ${incomingMessage.remoteClientId} 📪")
+                        Timber.d(
+                            "🗼️ \uD83D\uDCE1️️ connector extension disconnected with id: ${incomingMessage.remoteClientId} ⬇️ \uD83D\uDFE5"
+                        )
                     }
                     is SignalingServerMessage.Error.Validation -> {
-                        Timber.d("🛠️️ ⬇️ validation error")
+                        Timber.d("🗼️ \uD83D\uDCE1️️ validation error ❗ ⬇️")
                         terminateWithError()
                     }
                     is SignalingServerMessage.Error.Unknown -> {
-                        Timber.d("🛠️️ ⬇️ unknown error")
+                        Timber.d("🗼️ \uD83D\uDCE1️️ unknown error ❗ ⬇️")
                         terminateWithError()
                     }
                 }
             }
             .catch { exception ->
-                Timber.e("🛠️️ ⬇️ an exception occurred: ${exception.localizedMessage}")
+                Timber.e("🗼️ ⬇️ an exception occurred: ${exception.localizedMessage}")
                 terminateWithError()
             }
             .flowOn(ioDispatcher)
@@ -139,42 +143,42 @@ internal class PeerdroidLinkImpl(
         webRtcManager
             .createPeerConnection("")
             .onStart { // for debugging
-                Timber.d("🛠️ start observing webrtc events")
+                Timber.d("🗼 ⚡ start observing webrtc events ▶️")
             }
             .onCompletion { // for debugging
-                Timber.d("🛠️ end observing webrtc events")
+                Timber.d("🗼 ⚡ end observing webrtc events ⏹️")
             }
             .onEach { event ->
                 when (event) {
                     PeerConnectionEvent.RenegotiationNeeded -> {
-                        Timber.d("🛠️ renegotiation needed 🆗")
+                        Timber.d("🗼 ⚡ renegotiation needed 🆗")
                     }
                     is PeerConnectionEvent.IceGatheringChange -> {
-                        Timber.d("🛠️ ice gathering state changed: ${event.state}")
+                        Timber.d("🗼 ⚡ ice gathering state changed: ${event.state}")
                     }
                     is PeerConnectionEvent.IceCandidate -> {
-                        Timber.d("🛠️ ice candidate generated")
+                        Timber.d("🗼 ⚡ ice candidate generated")
                         sendIceCandidateToRemoteClient(event.data)
                     }
                     is PeerConnectionEvent.SignalingState -> {
-                        Timber.d("🛠️ signaling state changed: ${event.message}")
+                        Timber.d("🗼 ⚡ signaling state changed: ${event.message}")
                     }
                     PeerConnectionEvent.Connected -> {
-                        Timber.d("🛠️ signaling state changed: peer connection connected 🟢")
+                        Timber.d("🗼 ⚡ signaling state changed: peer connection connected 🟢")
                     }
                     is PeerConnectionEvent.Disconnected -> {
-                        Timber.d("🛠️ signaling state changed: peer connection disconnected 🔴")
+                        Timber.d("🗼 ⚡ signaling state changed: peer connection disconnected 🔴")
                         terminate()
                         addConnectionDeferred.complete(Result.success(Unit))
                     }
                     is PeerConnectionEvent.Failed -> {
-                        Timber.d("🛠️ signaling state changed: peer connection failed ❌")
+                        Timber.d("🗼 ⚡ signaling state changed: peer connection failed ❌")
                         terminateWithError()
                     }
                 }
             }
             .catch { exception ->
-                Timber.e("🛠️ an exception occurred: ${exception.localizedMessage}")
+                Timber.e("🗼 ⚡ an exception occurred: ${exception.localizedMessage}")
                 terminateWithError()
             }
             .completeWhenDisconnected()
@@ -195,7 +199,7 @@ internal class PeerdroidLinkImpl(
                 )
                 if (isSet) {
                     // then send the answer to the connector extension via signaling server
-                    Timber.d("🛠️️ ⬆️ send answer to the connector extension")
+                    Timber.d("🗼 \uD83D\uDCE1️ send answer to the connector extension ⬆️")
                     webSocketClient.sendAnswerMessage(
                         remoteClientId = "",
                         answerPayload = sessionDescriptionValue.toAnswerPayload()
@@ -205,20 +209,13 @@ internal class PeerdroidLinkImpl(
                 }
             }
             .onFailure { throwable ->
-                Timber.e("🛠️️ failed to create answer: ${throwable.message}")
+                Timber.e("🗼️ failed to create answer: ${throwable.message}❗")
                 terminateWithError()
             }
     }
 
     private suspend fun setLocalDescription(localSessionDescription: SessionDescriptionWrapper): Boolean {
-        return webRtcManager.setLocalDescription(localSessionDescription)
-            .onSuccess {
-                Timber.d("🛠️️ local description is set")
-            }
-            .onFailure { throwable ->
-                Timber.e("🛠️️ failed to set local description:${throwable.message} ")
-            }
-            .isSuccess
+        return webRtcManager.setLocalDescription(localSessionDescription).isSuccess
     }
 
     private suspend fun setRemoteDescriptionFromOffer(offer: SignalingServerMessage.RemoteData.Offer) {
@@ -227,17 +224,10 @@ internal class PeerdroidLinkImpl(
             sessionDescriptionValue = SessionDescriptionWrapper.SessionDescriptionValue(offer.sdp)
         )
         webRtcManager.setRemoteDescription(sessionDescription)
-            .onSuccess {
-                Timber.d("🛠️️ remote description is set")
-            }
-            .onFailure { throwable ->
-                Timber.e("🛠️️ failed to set remote description:${throwable.message} ")
-                terminateWithError()
-            }
     }
 
     private suspend fun sendIceCandidateToRemoteClient(iceCandidateData: PeerConnectionEvent.IceCandidate.Data) {
-        Timber.d("🛠️️ ⬆️ send ice candidate to the connector extension")
+        Timber.d("🗼️ \uD83D\uDCE1️ send ice candidate to the connector extension ⬆️")
         withContext(ioDispatcher) {
             webSocketClient.sendIceCandidateMessage(
                 remoteClientId = "",
@@ -248,7 +238,6 @@ internal class PeerdroidLinkImpl(
 
     private suspend fun addRemoteIceCandidateInWebRtc(iceCandidate: SignalingServerMessage.RemoteData.IceCandidate) {
         val remoteIceCandidate = iceCandidate.remoteIceCandidate
-        Timber.d("🛠️️ set remote ice candidate in local WebRTC")
         webRtcManager.addRemoteIceCandidate(remoteIceCandidate = remoteIceCandidate)
     }
 
@@ -258,7 +247,7 @@ internal class PeerdroidLinkImpl(
     }
 
     private suspend fun terminate() {
-        Timber.d("🛠️️ terminate webrtc and web socket connection")
+        Timber.d("🗼️ terminate webrtc and web socket connection \uD83D\uDEAB")
         webSocketClient.closeSession()
     }
 }

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/WebRtcManager.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/WebRtcManager.kt
@@ -125,7 +125,6 @@ internal class WebRtcManager(applicationContext: Context) {
         peerConnection.let {
             dataChannel = it.createDataChannel(remoteClientId, dataChannelInit)
             Timber.d("🔌 created a data channel for remote client: $remoteClientId")
-            Timber.d("🔌 created a RTC data channel")
         }
     }
 

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/wrappers/datachannel/DataChannelObserverWrapper.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/wrappers/datachannel/DataChannelObserverWrapper.kt
@@ -12,11 +12,11 @@ import timber.log.Timber
 // This is a callbackFlow wrapper of the native DataChannel.Observer callback and it does two things:
 // 1. returns the state of the data channel - when this is changed
 // 2. returns the type of PackageDto - when a message is received
+@Suppress("EmptyFunctionBlock")
 internal fun DataChannel.eventFlow(): Flow<DataChannelMessage> = callbackFlow {
     val callback = object : DataChannel.Observer {
 
         override fun onBufferedAmountChange(p0: Long) {
-            Timber.d("📯 onBufferedAmountChange")
         }
 
         override fun onStateChange() {

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/wrappers/datachannel/DataChannelWrapper.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/wrappers/datachannel/DataChannelWrapper.kt
@@ -48,13 +48,13 @@ data class DataChannelWrapper(
             }
             Result.success(Unit)
         } catch (iobe: IndexOutOfBoundsException) {
-            Timber.e("📯 failed to wrap byte array to byte buffer: ${iobe.localizedMessage}")
+            Timber.e("📯 failed to wrap byte array to byte buffer: ${iobe.localizedMessage}❗")
             Result.failure(Throwable("failed to wrap byte array to byte buffer: ${iobe.localizedMessage}"))
         } catch (exception: Exception) {
             if (exception is CancellationException) {
                 throw exception
             }
-            Timber.e("📯 failed to convert and send the message: ${exception.localizedMessage}")
+            Timber.e("📯 failed to convert and send the message: ${exception.localizedMessage}❗")
             Result.failure(Throwable("failed to send message with exception: ${exception.localizedMessage}"))
         }
     }

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/websocket/WebSocketClient.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/websocket/WebSocketClient.kt
@@ -87,14 +87,14 @@ internal class WebSocketClient(applicationContext: Context) {
                 Timber.d("🛰 successfully connected to signaling server")
                 Result.success(Unit)
             } else {
-                Timber.e("🛰 failed to connect to signaling server")
+                Timber.e("🛰 failed to connect to signaling server❗")
                 Result.failure(Exception("Couldn't establish a connection"))
             }
         } catch (exception: Exception) {
             if (exception is CancellationException) {
                 throw exception
             }
-            Timber.e("🛰 connection exception: ${exception.localizedMessage}")
+            Timber.e("🛰 connection exception: ${exception.localizedMessage}❗")
             Result.failure(exception)
         }
     }
@@ -117,7 +117,7 @@ internal class WebSocketClient(applicationContext: Context) {
                 }
                 ?: flowOf(SignalingServerMessage.Error.Unknown)
         } catch (exception: Exception) {
-            Timber.e("🛰 incoming message exception: ${exception.localizedMessage}")
+            Timber.e("🛰 incoming message exception: ${exception.localizedMessage}❗")
             flowOf(SignalingServerMessage.Error.Unknown)
         }
     }
@@ -185,7 +185,7 @@ internal class WebSocketClient(applicationContext: Context) {
             if (exception is CancellationException) {
                 throw exception
             }
-            Timber.e("🛰 failed to send message: ${exception.localizedMessage}")
+            Timber.e("🛰 failed to send message: ${exception.localizedMessage}❗")
         }
     }
 
@@ -225,7 +225,7 @@ internal class WebSocketClient(applicationContext: Context) {
                 )
             }
             is SignalingServerDto.ValidationError -> {
-                Timber.e("🛰 validation error in signaling server message: ${signalingServerDto.error}")
+                Timber.e("🛰 validation error in signaling server message: ${signalingServerDto.error}❗")
                 SignalingServerMessage.Error.Validation
             }
         }


### PR DESCRIPTION
## Description
This PR fixes termination of WebRTC's job and WebSocket's job when successfully adding a new link connection in wallet settings.

ℹ️   it also incudes a cherry-pick of this [commit of the other PR](https://github.com/radixdlt/babylon-wallet-android/pull/668/commits/9aa046d88f41e9d42583d02e43b481fe6f5a10cb) which contains improved logging for peerdroid module.

⚠️ this will go to the patch release

## How to test
- Add two or more link connections in your wallet and do some transactions for each of them.
- Then delete one of them and do transactions with the other one.

## PR submission checklist
- [x] I have tested wallet with establishing new link connections and doing transactions.
