### PR TITLE
Fix Pool Units tab checkboxes placement and text alignment

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityScreen.kt
@@ -64,7 +64,7 @@ private fun AccountSecurityContent(
         ) {
             Divider(color = RadixTheme.colors.gray5)
             LazyColumn(modifier = Modifier.fillMaxSize()) {
-                appSettings.forEachIndexed { index, accountSecurityAndSettingsItem ->
+                appSettings.forEach { accountSecurityAndSettingsItem ->
                     item {
                         DefaultSettingsItem(
                             title = stringResource(id = accountSecurityAndSettingsItem.descriptionRes()),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/LiquidStakeUnitsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/LiquidStakeUnitsTab.kt
@@ -31,7 +31,6 @@ import com.babylon.wallet.android.domain.model.assets.ValidatorWithStakes
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.model.resources.XrdResource
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
-import com.babylon.wallet.android.presentation.ui.modifier.applyIf
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import rdx.works.core.displayableQuantity
 
@@ -313,6 +312,7 @@ private fun LiquidStakeUnitItem(
     }
 }
 
+@Suppress("CyclomaticComplexMethod")
 @Composable
 private fun StakeClaimNftItem(
     epoch: Long?,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
@@ -94,20 +94,12 @@ private fun PoolUnitItem(
                 poolUnit = resource
             )
             Text(
-                poolName(resource.stake.displayTitle),
+                modifier = Modifier.weight(1f),
+                text = poolName(resource.stake.displayTitle),
                 style = RadixTheme.typography.secondaryHeader,
                 color = RadixTheme.colors.gray1,
                 maxLines = 2
             )
-        }
-        Row(
-            modifier = Modifier
-                .padding(horizontal = RadixTheme.dimensions.paddingLarge)
-                .padding(bottom = RadixTheme.dimensions.paddingLarge),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingMedium)
-        ) {
-            PoolResourcesValues(modifier = Modifier.weight(1f), poolUnit = resource)
 
             if (action is AssetsViewAction.Selection) {
                 val isSelected = remember(resource.stake, action) {
@@ -121,6 +113,13 @@ private fun PoolUnitItem(
                 )
             }
         }
+
+        PoolResourcesValues(
+            modifier = Modifier
+                .padding(horizontal = RadixTheme.dimensions.paddingLarge)
+                .padding(bottom = RadixTheme.dimensions.paddingLarge),
+            poolUnit = resource
+        )
     }
 }
 
@@ -149,7 +148,7 @@ fun PoolResourcesValues(poolUnit: PoolUnit, modifier: Modifier = Modifier) {
                     maxLines = 2
                 )
                 Text(
-                    poolUnit.resourceRedemptionValue(poolResource)?.displayableQuantity().orEmpty(),
+                    text = poolUnit.resourceRedemptionValue(poolResource)?.displayableQuantity().orEmpty(),
                     style = RadixTheme.typography.secondaryHeader,
                     color = RadixTheme.colors.gray1,
                     maxLines = 1


### PR DESCRIPTION
## Description
When selecting a pool unit to transfer with large amounts of redeemable values inside, their titles would be displayed in a new line. The checkbox was taking unnecessary space on the right of the values section, so we moved it on the top right corner, where the name of the pool lays.

**Update**
Also fixed the alignment of the elements when a stake unit's value is too large.

## How to test
You need to have a pool unit with fungibles with large redeemable values. I hardcoded them in `PoolUnitsTab` just to replicate the issue.
 
## Screenshot

Before
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/fb3f4c5b-d3ec-463e-b134-8dc1d833343d" width="300">

Fix
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/06a59932-2140-424b-877d-26439fc9278f" width="30%">

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
