### PR TITLE
Add link icon in history button

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -307,13 +308,17 @@ fun AssetsContent(
                             exit = fadeOut()
                         ) {
                             Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.SpaceEvenly
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = RadixTheme.dimensions.paddingXSmall),
+                                horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
                             ) {
                                 HistoryButton(
+                                    modifier = Modifier.weight(1f),
                                     onHistoryClick = onHistoryClick
                                 )
                                 TransferButton(
+                                    modifier = Modifier.weight(1f),
                                     accountAddress = accountAddress,
                                     onTransferClick = onTransferClick
                                 )
@@ -380,14 +385,16 @@ private fun TransferButton(
         onClick = { onTransferClick(accountAddress) },
         containerColor = RadixTheme.colors.white.copy(alpha = 0.2f),
         contentColor = RadixTheme.colors.white,
-        shape = RadixTheme.shapes.circle
-    ) {
-        Icon(
-            painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_transfer),
-            tint = RadixTheme.colors.white,
-            contentDescription = null
-        )
-    }
+        shape = RadixTheme.shapes.circle,
+        leadingContent = {
+            Icon(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_transfer),
+                tint = RadixTheme.colors.white,
+                contentDescription = null
+            )
+        }
+    )
 }
 
 @Composable
@@ -401,14 +408,24 @@ private fun HistoryButton(
         modifier = modifier,
         containerColor = RadixTheme.colors.white.copy(alpha = 0.2f),
         contentColor = RadixTheme.colors.white,
-        shape = RadixTheme.shapes.circle
-    ) {
-        Icon(
-            painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_watch_later),
-            tint = RadixTheme.colors.white,
-            contentDescription = null
-        )
-    }
+        shape = RadixTheme.shapes.circle,
+        leadingContent = {
+            Icon(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_watch_later),
+                tint = RadixTheme.colors.white,
+                contentDescription = null
+            )
+        },
+        trailingContent = {
+            Icon(
+                modifier = Modifier.size(16.dp),
+                painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_link_out),
+                tint = RadixTheme.colors.white.copy(alpha = 0.5f),
+                contentDescription = null
+            )
+        }
+    )
 }
 
 @Preview

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountTopBar.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountTopBar.kt
@@ -130,14 +130,15 @@ fun AccountTopBar(
                     onClick = { onTransferClick(accountAddress) },
                     containerColor = RadixTheme.colors.white.copy(alpha = 0.2f),
                     contentColor = RadixTheme.colors.white,
-                    shape = RadixTheme.shapes.circle
-                ) {
-                    Icon(
-                        painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_transfer),
-                        tint = RadixTheme.colors.white,
-                        contentDescription = null
-                    )
-                }
+                    shape = RadixTheme.shapes.circle,
+                    leadingContent = {
+                        Icon(
+                            painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_transfer),
+                            tint = RadixTheme.colors.white,
+                            contentDescription = null
+                        )
+                    }
+                )
             }
 
             AnimatedVisibility(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsScreen.kt
@@ -245,7 +245,7 @@ private fun ConnectorSettingBox(
             },
             containerColor = RadixTheme.colors.gray3,
             contentColor = RadixTheme.colors.gray1,
-            icon = {
+            leadingContent = {
                 Icon(
                     painter = painterResource(
                         id = com.babylon.wallet.android.designsystem.R.drawable.ic_qr_code_scanner
@@ -304,7 +304,7 @@ private fun ImportOlympiaWalletSettingBox(
                 },
                 containerColor = RadixTheme.colors.gray3,
                 contentColor = RadixTheme.colors.gray1,
-                icon = {
+                leadingContent = {
                     Icon(
                         painter = painterResource(
                             id = com.babylon.wallet.android.designsystem.R.drawable.ic_qr_code_scanner

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -219,7 +219,7 @@ private fun ActiveLinkedConnectorsListContent(
                             .padding(horizontal = RadixTheme.dimensions.paddingMedium),
                         text = stringResource(id = R.string.linkedConnectors_linkNewConnector),
                         onClick = onLinkNewConnectorClick,
-                        icon = {
+                        leadingContent = {
                             Icon(
                                 painter = painterResource(id = DSR.ic_qr_code_scanner),
                                 contentDescription = null

--- a/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/RadixSecondaryButton.kt
+++ b/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/RadixSecondaryButton.kt
@@ -38,7 +38,8 @@ fun RadixSecondaryButton(
     isLoading: Boolean = false,
     enabled: Boolean = true,
     throttleClicks: Boolean = false,
-    icon: @Composable (() -> Unit)? = null
+    leadingContent: @Composable (() -> Unit)? = null,
+    trailingContent: @Composable (() -> Unit)? = null
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -76,8 +77,9 @@ fun RadixSecondaryButton(
                     strokeWidth = 2.dp
                 )
             } else {
-                icon?.invoke()
+                leadingContent?.invoke()
                 Text(text = text, style = RadixTheme.typography.button)
+                trailingContent?.invoke()
             }
         }
     }
@@ -87,7 +89,11 @@ fun RadixSecondaryButton(
 @Composable
 fun RadixSecondaryButtonPreview() {
     RadixWalletTheme {
-        RadixSecondaryButton(text = "Secondary button", onClick = {}, modifier = Modifier.size(200.dp, 50.dp))
+        RadixSecondaryButton(
+            text = "Secondary button",
+            onClick = {},
+            modifier = Modifier.size(200.dp, 50.dp)
+        )
     }
 }
 
@@ -95,9 +101,14 @@ fun RadixSecondaryButtonPreview() {
 @Composable
 fun RadixSecondaryButtonWithIconPreview() {
     RadixWalletTheme {
-        RadixSecondaryButton(text = "Secondary button", onClick = {}, modifier = Modifier.size(200.dp, 50.dp)) {
-            Icon(painter = painterResource(id = R.drawable.ic_search), contentDescription = "")
-        }
+        RadixSecondaryButton(
+            text = "Secondary button",
+            onClick = {},
+            modifier = Modifier.size(200.dp, 50.dp),
+            leadingContent = {
+                Icon(painter = painterResource(id = R.drawable.ic_search), contentDescription = "")
+            }
+        )
     }
 }
 


### PR DESCRIPTION
## Description
* Added `trailingContent` in secondary button
* Renamed `icon` to `leadingContent`
* Added link icon
* Resized both buttons and icons to look like the zeplin screen.
* Replaced every lambda usage of the old `icon` to use the parameter, so as not to add the icon in the trailing section whenever the lambda was used without the param's name.

## How to test
1. Just open the account screen

## Screenshot
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/66ab2690-b9f5-4f3a-908e-f4ec3141e966" width="300">

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
