### PR TITLE
Fix pool and validator checks

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/resources/metadata/StandardMetadataItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/resources/metadata/StandardMetadataItem.kt
@@ -108,9 +108,16 @@ data class OwnerKeyHashesMetadataItem(
 }
 
 data class ValidatorMetadataItem(
-    val validatorAddress: String
+    private val address: String
 ) : StandardMetadataItem {
     override val key: String = ExplicitMetadataKey.VALIDATOR.key
+
+    val validatorAddress: String?
+        get() = address.takeIf { it.isNotBlank() && it.startsWith(HRP_VALIDATOR) }
+
+    companion object {
+        private const val HRP_VALIDATOR = "validator_"
+    }
 }
 
 data class ClaimAmountMetadataItem(
@@ -126,9 +133,16 @@ data class ClaimEpochMetadataItem(
 }
 
 data class PoolMetadataItem(
-    val poolAddress: String
+    private val address: String
 ) : StandardMetadataItem {
     override val key: String = ExplicitMetadataKey.POOL.key
+
+    val poolAddress: String?
+        get() = address.takeIf { it.isNotBlank() && it.startsWith(HRP_POOL) }
+
+    companion object {
+        private const val HRP_POOL = "pool_"
+    }
 }
 
 data class PoolUnitMetadataItem(


### PR DESCRIPTION
## Description
We need to filter out pool and validator addresses which HRP don't start with `pool_` or `validator_` respectively.

## How to test:
Include this account `account_rdx128pe4v2k9kqngq5pq5ssgfugndvwp0l9zm7j5sg0ducm85kpfz4vcz` into your profile. You should now see the LP token being listed under tokens and not pool units.

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
