### PR TITLE
[ABW-2620] Use concurrent methods in PeerdroidConnector and other minor improvements

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/CreateAccountWithLedgerScreen.kt
@@ -117,7 +117,6 @@ fun CreateAccountWithLedgerScreen(
             AddLinkConnectorScreen(
                 modifier = Modifier,
                 showContent = addLinkConnectorState.showContent,
-                isLoading = addLinkConnectorState.isLoading,
                 onQrCodeScanned = addLinkConnectorViewModel::onQrCodeScanned,
                 onConnectorDisplayNameChanged = addLinkConnectorViewModel::onConnectorDisplayNameChanged,
                 connectorDisplayName = addLinkConnectorState.connectorDisplayName,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -387,7 +387,6 @@ private fun ImportLegacyWalletContent(
             AddLinkConnectorScreen(
                 modifier = Modifier.fillMaxSize(),
                 showContent = addLinkConnectorState.showContent,
-                isLoading = addLinkConnectorState.isLoading,
                 onQrCodeScanned = onLinkConnectorQrCodeScanned,
                 onConnectorDisplayNameChanged = onConnectorDisplayNameChanged,
                 connectorDisplayName = addLinkConnectorState.connectorDisplayName,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
@@ -138,7 +138,6 @@ fun LedgerHardwareWalletsScreen(
                 AddLinkConnectorScreen(
                     modifier = Modifier,
                     showContent = addLinkConnectorState.showContent,
-                    isLoading = addLinkConnectorState.isLoading,
                     onQrCodeScanned = addLinkConnectorViewModel::onQrCodeScanned,
                     onConnectorDisplayNameChanged = addLinkConnectorViewModel::onConnectorDisplayNameChanged,
                     connectorDisplayName = addLinkConnectorState.connectorDisplayName,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/AddLinkConnectorViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/AddLinkConnectorViewModel.kt
@@ -49,7 +49,7 @@ class AddLinkConnectorViewModel @Inject constructor(
     fun onContinueClick() {
         viewModelScope.launch {
             _state.update {
-                it.copy(isLoading = true)
+                it.copy(isAddingNewLinkConnectorInProgress = true)
             }
             val encryptionKey = currentConnectionPassword?.let {
                 parseEncryptionKeyFromConnectionPassword(connectionPassword = it.value)
@@ -82,7 +82,7 @@ class AddLinkConnectorViewModel @Inject constructor(
 }
 
 data class AddLinkConnectorUiState(
-    val isLoading: Boolean,
+    val isAddingNewLinkConnectorInProgress: Boolean,
     val showContent: ShowContent,
     val isContinueButtonEnabled: Boolean,
     val connectorDisplayName: String,
@@ -95,7 +95,7 @@ data class AddLinkConnectorUiState(
 
     companion object {
         val init = AddLinkConnectorUiState(
-            isLoading = false,
+            isAddingNewLinkConnectorInProgress = false,
             showContent = ShowContent.ScanQrCode,
             isContinueButtonEnabled = false,
             connectorDisplayName = ""

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -1,6 +1,5 @@
 package com.babylon.wallet.android.presentation.settings.appsettings.linkedconnectors
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,7 +35,6 @@ import com.babylon.wallet.android.designsystem.composable.RadixSecondaryButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.SampleDataProvider
-import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
 import com.babylon.wallet.android.presentation.ui.composables.AddLinkConnectorScreen
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.DSR
@@ -67,7 +65,6 @@ fun LinkedConnectorsScreen(
         AddLinkConnectorScreen(
             modifier = modifier,
             showContent = addLinkConnectorState.showContent,
-            isLoading = addLinkConnectorState.isLoading,
             onQrCodeScanned = addLinkConnectorViewModel::onQrCodeScanned,
             onConnectorDisplayNameChanged = addLinkConnectorViewModel::onConnectorDisplayNameChanged,
             connectorDisplayName = addLinkConnectorState.connectorDisplayName,
@@ -86,7 +83,7 @@ fun LinkedConnectorsScreen(
     } else {
         LinkedConnectorsContent(
             modifier = modifier,
-            isLoading = state.isLoading,
+            isAddingNewLinkConnectorInProgress = addLinkConnectorState.isAddingNewLinkConnectorInProgress,
             activeLinkedConnectorsList = state.activeConnectors,
             onLinkNewConnectorClick = viewModel::onLinkNewConnectorClick,
             onDeleteConnectorClick = viewModel::onDeleteConnectorClick,
@@ -98,7 +95,7 @@ fun LinkedConnectorsScreen(
 @Composable
 private fun LinkedConnectorsContent(
     modifier: Modifier = Modifier,
-    isLoading: Boolean,
+    isAddingNewLinkConnectorInProgress: Boolean,
     activeLinkedConnectorsList: ImmutableList<P2PLink>,
     onLinkNewConnectorClick: () -> Unit,
     onDeleteConnectorClick: (String) -> Unit,
@@ -120,15 +117,11 @@ private fun LinkedConnectorsContent(
             HorizontalDivider(color = RadixTheme.colors.gray5)
 
             Box(modifier = Modifier.fillMaxSize()) {
-                if (isLoading) {
-                    FullscreenCircularProgressContent()
-                }
-
                 ActiveLinkedConnectorDetails(
                     activeLinkedConnectorsList = activeLinkedConnectorsList,
                     onLinkNewConnectorClick = onLinkNewConnectorClick,
                     onDeleteConnectorClick = { connectionPasswordToDelete = it },
-                    isLoading = isLoading,
+                    isAddingNewLinkConnectorInProgress = isAddingNewLinkConnectorInProgress,
                     modifier = Modifier.fillMaxWidth()
                 )
 
@@ -168,7 +161,7 @@ private fun ActiveLinkedConnectorDetails(
     activeLinkedConnectorsList: ImmutableList<P2PLink>,
     onLinkNewConnectorClick: () -> Unit,
     onDeleteConnectorClick: (String) -> Unit,
-    isLoading: Boolean,
+    isAddingNewLinkConnectorInProgress: Boolean,
     modifier: Modifier = Modifier
 ) {
     Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
@@ -182,7 +175,7 @@ private fun ActiveLinkedConnectorDetails(
         ActiveLinkedConnectorsListContent(
             activeLinkedConnectorsList = activeLinkedConnectorsList,
             onDeleteConnectorClick = onDeleteConnectorClick,
-            isLoading = isLoading,
+            isAddingNewLinkConnectorInProgress = isAddingNewLinkConnectorInProgress,
             onLinkNewConnectorClick = onLinkNewConnectorClick
         )
     }
@@ -193,7 +186,7 @@ private fun ActiveLinkedConnectorsListContent(
     modifier: Modifier = Modifier,
     activeLinkedConnectorsList: ImmutableList<P2PLink>,
     onDeleteConnectorClick: (String) -> Unit,
-    isLoading: Boolean,
+    isAddingNewLinkConnectorInProgress: Boolean,
     onLinkNewConnectorClick: () -> Unit
 ) {
     LazyColumn(modifier) {
@@ -210,23 +203,23 @@ private fun ActiveLinkedConnectorsListContent(
             }
         )
         item {
-            AnimatedVisibility(!isLoading) {
-                Column {
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                    RadixSecondaryButton(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = RadixTheme.dimensions.paddingMedium),
-                        text = stringResource(id = R.string.linkedConnectors_linkNewConnector),
-                        onClick = onLinkNewConnectorClick,
-                        leadingContent = {
-                            Icon(
-                                painter = painterResource(id = DSR.ic_qr_code_scanner),
-                                contentDescription = null
-                            )
-                        }
-                    )
-                }
+            Column {
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                RadixSecondaryButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingMedium),
+                    text = stringResource(id = R.string.linkedConnectors_linkNewConnector),
+                    onClick = onLinkNewConnectorClick,
+                    leadingContent = {
+                        Icon(
+                            painter = painterResource(id = DSR.ic_qr_code_scanner),
+                            contentDescription = null
+                        )
+                    },
+                    isLoading = isAddingNewLinkConnectorInProgress,
+                    enabled = isAddingNewLinkConnectorInProgress.not()
+                )
             }
         }
     }
@@ -273,7 +266,7 @@ fun LinkedConnectorsContentWithoutActiveLinkedConnectorsPreview() {
         LinkedConnectorsContent(
             activeLinkedConnectorsList = persistentListOf(),
             onLinkNewConnectorClick = {},
-            isLoading = false,
+            isAddingNewLinkConnectorInProgress = false,
             onBackClick = {},
             onDeleteConnectorClick = {}
         )
@@ -288,7 +281,7 @@ fun LinkedConnectorsContentWithActiveLinkedConnectorsPreview() {
         LinkedConnectorsContent(
             activeLinkedConnectorsList = SampleDataProvider().p2pLinksSample.toPersistentList(),
             onLinkNewConnectorClick = {},
-            isLoading = false,
+            isAddingNewLinkConnectorInProgress = false,
             onBackClick = {},
             onDeleteConnectorClick = {}
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsViewModel.kt
@@ -39,10 +39,7 @@ class LinkedConnectorsViewModel @Inject constructor(
             getProfileUseCase.p2pLinks
                 .collect { p2pLinks ->
                     _state.update {
-                        it.copy(
-                            isLoading = false,
-                            activeConnectors = p2pLinks.toPersistentList()
-                        )
+                        it.copy(activeConnectors = p2pLinks.toPersistentList())
                     }
                 }
         }
@@ -75,7 +72,6 @@ internal sealed interface Event : OneOffEvent {
 }
 
 data class LinkedConnectorsUiState(
-    val isLoading: Boolean = true,
     val activeConnectors: ImmutableList<P2PLink> = persistentListOf(),
     val showAddLinkConnectorScreen: Boolean = false,
     val triggerCameraPermissionPrompt: Boolean = false

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLinkConnectorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLinkConnectorScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -29,7 +28,6 @@ import com.babylon.wallet.android.designsystem.composable.RadixPrimaryButton
 import com.babylon.wallet.android.designsystem.composable.RadixTextField
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
-import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
 import com.babylon.wallet.android.presentation.settings.appsettings.linkedconnectors.AddLinkConnectorUiState
 import com.babylon.wallet.android.presentation.settings.appsettings.linkedconnectors.qrcode.CameraPreview
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -41,7 +39,6 @@ import com.google.accompanist.permissions.rememberPermissionState
 fun AddLinkConnectorScreen(
     modifier: Modifier,
     showContent: AddLinkConnectorUiState.ShowContent,
-    isLoading: Boolean,
     onQrCodeScanned: (String) -> Unit,
     onConnectorDisplayNameChanged: (String) -> Unit,
     connectorDisplayName: String,
@@ -61,7 +58,6 @@ fun AddLinkConnectorScreen(
     AddLinkConnectorContent(
         modifier = modifier,
         showContent = showContent,
-        isLoading = isLoading,
         isCameraPermissionGranted = cameraPermissionState.status.isGranted,
         onQrCodeScanned = onQrCodeScanned,
         onConnectorDisplayNameChanged = onConnectorDisplayNameChanged,
@@ -97,12 +93,10 @@ fun AddLinkConnectorScreen(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun AddLinkConnectorContent(
     modifier: Modifier = Modifier,
     showContent: AddLinkConnectorUiState.ShowContent,
-    isLoading: Boolean,
     isCameraPermissionGranted: Boolean,
     onQrCodeScanned: (String) -> Unit,
     connectorDisplayName: String,
@@ -125,9 +119,6 @@ private fun AddLinkConnectorContent(
     ) { padding ->
         val keyboardController = LocalSoftwareKeyboardController.current
         Column(modifier = Modifier.padding(padding)) {
-            if (isLoading) {
-                FullscreenCircularProgressContent()
-            }
             when (showContent) {
                 AddLinkConnectorUiState.ShowContent.ScanQrCode -> {
                     if (isCameraPermissionGranted) {
@@ -262,7 +253,6 @@ fun NameNewConnectorPreview() {
     RadixWalletTheme {
         AddLinkConnectorContent(
             showContent = AddLinkConnectorUiState.ShowContent.NameLinkConnector,
-            isLoading = false,
             isCameraPermissionGranted = true,
             onQrCodeScanned = {},
             onConnectorDisplayNameChanged = {},

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/WebRtcManager.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/WebRtcManager.kt
@@ -145,7 +145,7 @@ internal class WebRtcManager(applicationContext: Context) {
     suspend fun addRemoteIceCandidate(remoteIceCandidate: RemoteIceCandidate): Result<Unit> {
         return peerConnection.addSuspendingIceCandidate(remoteIceCandidate = remoteIceCandidate)
             .onSuccess {
-                Timber.d("🔌 added successfully ice candidate")
+//                Timber.d("🔌 added successfully ice candidate")
                 Result.success(Unit)
             }
             .onFailure { throwable ->
@@ -156,7 +156,6 @@ internal class WebRtcManager(applicationContext: Context) {
 
     fun close() {
         Timber.d("🔌 close data channel and peer connection")
-        dataChannel.close()
         peerConnection.close()
     }
 

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/model/PeerConnectionEvent.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/model/PeerConnectionEvent.kt
@@ -30,9 +30,9 @@ internal sealed interface PeerConnectionEvent {
         )
     }
 
-    object RenegotiationNeeded : PeerConnectionEvent
+    data object RenegotiationNeeded : PeerConnectionEvent
 
-    object Connected : PeerConnectionEvent
+    data object Connected : PeerConnectionEvent
 
     data class Disconnected(
         val remoteClientId: String

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/wrappers/datachannel/DataChannelWrapper.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/wrappers/datachannel/DataChannelWrapper.kt
@@ -219,8 +219,15 @@ data class DataChannelWrapper(
     }
 
     fun close() {
-        Timber.d("📯 DataChannelWrapper of ${this.webRtcDataChannel} close for remote connector: ${connectionIdHolder.id} 🔻")
+        Timber.d(
+            "📯 DataChannelWrapper of ${this.webRtcDataChannel} close for remote connector: " +
+                "${connectionIdHolder.id} 🔻 and with remote client id ${this.webRtcDataChannel.label()}"
+        )
+        webRtcDataChannel.unregisterObserver()
         webRtcDataChannel.close()
-        Timber.d("📯 ${this.webRtcDataChannel} state: ${this.webRtcDataChannel.state()}, for remote connector: ${connectionIdHolder.id}")
+        Timber.d(
+            "📯 ${this.webRtcDataChannel} state: ${this.webRtcDataChannel.state()}, for remote connector: " +
+                "${connectionIdHolder.id} and with remote client id ${this.webRtcDataChannel.label()}"
+        )
     }
 }

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/wrappers/peerconnection/PeerConnectionSuspendingWrapper.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/webrtc/wrappers/peerconnection/PeerConnectionSuspendingWrapper.kt
@@ -32,41 +32,31 @@ internal suspend fun PeerConnection.createSuspendingOffer(
 
             p0?.let {
                 continuation.resume(
-                    Result.success(
-                        SessionDescriptionValue(p0.description)
-                    )
+                    Result.success(SessionDescriptionValue(p0.description))
                 )
             } ?: continuation.resume(
-                Result.failure(
-                    Throwable("sessionDescription is null")
-                )
+                Result.failure(Throwable("sessionDescription is null"))
             )
         }
 
         override fun onSetSuccess() {
             Timber.d("🔌 createOffer, onSetSuccess")
             continuation.resume(
-                Result.failure(
-                    Throwable("")
-                )
+                Result.failure(Throwable(""))
             )
         }
 
         override fun onCreateFailure(p0: String?) {
             Timber.e("🔌 createOffer, onCreateFailure $p0")
             continuation.resume(
-                Result.failure(
-                    Throwable("failed to create offer: $p0")
-                )
+                Result.failure(Throwable("failed to create offer: $p0"))
             )
         }
 
         override fun onSetFailure(p0: String?) {
             Timber.e("🔌 createOffer, onSetFailure: $p0")
             continuation.resume(
-                Result.failure(
-                    Throwable("")
-                )
+                Result.failure(Throwable(""))
             )
         }
     }
@@ -91,41 +81,31 @@ internal suspend fun PeerConnection.createSuspendingAnswer(
 
             p0?.let {
                 continuation.resume(
-                    Result.success(
-                        SessionDescriptionValue(p0.description)
-                    )
+                    Result.success(SessionDescriptionValue(p0.description))
                 )
             } ?: continuation.resume(
-                Result.failure(
-                    Throwable("sessionDescription is null")
-                )
+                Result.failure(Throwable("sessionDescription is null"))
             )
         }
 
         override fun onSetSuccess() {
             Timber.d("🔌 createAnswer, onSetSuccess")
             continuation.resume(
-                Result.failure(
-                    Throwable("")
-                )
+                Result.failure(Throwable(""))
             )
         }
 
         override fun onCreateFailure(p0: String?) {
             Timber.e("🔌 createAnswer, onCreateFailure $p0")
             continuation.resume(
-                Result.failure(
-                    Throwable(p0)
-                )
+                Result.failure(Throwable(p0))
             )
         }
 
         override fun onSetFailure(p0: String?) {
             Timber.e("🔌 createAnswer, onSetFailure $p0")
             continuation.resume(
-                Result.failure(
-                    Throwable(p0)
-                )
+                Result.failure(Throwable(p0))
             )
         }
     }
@@ -148,32 +128,28 @@ internal suspend fun PeerConnection.setSuspendingLocalDescription(
             // we want to SET the local session description, not to create one
             // thus return Error result
             continuation.resume(
-                Result.failure(
-                    Throwable("on create success")
-                )
+                Result.failure(Throwable("on create success"))
             )
         }
 
         override fun onSetSuccess() {
             Timber.d("🔌 set successfully local session description")
-            continuation.resume(Result.success(Unit))
+            continuation.resume(
+                Result.success(Unit)
+            )
         }
 
         override fun onCreateFailure(p0: String?) {
             Timber.e("🔌 setLocalDescription, onCreateFailure $p0")
             continuation.resume(
-                Result.failure(
-                    Throwable(p0)
-                )
+                Result.failure(Throwable(p0))
             )
         }
 
         override fun onSetFailure(p0: String?) {
             Timber.e("🔌 setLocalDescription, onSetFailure $p0")
             continuation.resume(
-                Result.failure(
-                    Throwable(p0)
-                )
+                Result.failure(Throwable(p0))
             )
         }
     }
@@ -197,32 +173,28 @@ internal suspend fun PeerConnection.setSuspendingRemoteDescription(
             // we want to SET the remote session description, not to create one
             // thus return Error result
             continuation.resume(
-                Result.failure(
-                    Throwable("on create success")
-                )
+                Result.failure(Throwable("on create success"))
             )
         }
 
         override fun onSetSuccess() {
             Timber.d("🔌 set successfully remote session description")
-            continuation.resume(Result.success(Unit))
+            continuation.resume(
+                Result.success(Unit)
+            )
         }
 
         override fun onCreateFailure(p0: String?) {
             Timber.e("🔌 failed to create remote session description: $p0")
             continuation.resume(
-                Result.failure(
-                    Throwable(p0)
-                )
+                Result.failure(Throwable(p0))
             )
         }
 
         override fun onSetFailure(p0: String?) {
             Timber.e("🔌 failed to set remote session description: $p0")
             continuation.resume(
-                Result.failure(
-                    Throwable(p0)
-                )
+                Result.failure(Throwable(p0))
             )
         }
     }
@@ -242,14 +214,14 @@ internal suspend fun PeerConnection.addSuspendingIceCandidate(
 
     val observer = object : AddIceObserver {
         override fun onAddSuccess() {
-            continuation.resume(Result.success(Unit))
+            continuation.resume(
+                Result.success(Unit)
+            )
         }
 
         override fun onAddFailure(p0: String?) {
             continuation.resume(
-                Result.failure(
-                    Throwable(p0)
-                )
+                Result.failure(Throwable(p0))
             )
         }
     }


### PR DESCRIPTION
## Description
This PR slightly improves Peerdroid:
- replaced the non concurrent `getValue` with concurrent `get` for `ConcurrentHashMap`s in `PeerdroidConnector`
- `WebRtcManager` will unregister the observer and not close the data channel. `DataChannelWrapper` does this already.
- `DataChannelWrapper` now unregister the observer before closing the data channel
- replace suspending `emit` with `tryEmit` in `createAndObservePeerConnectionForRemoteClient`. No need to suspend the flow there.
- disabled some logs because too many are describing the same thing


## How to test

You can create a link with this dev tool: https://d13xro4a77czjs.cloudfront.net/ 
and then try the reconnect test and dapp request test. The former repeatedly opens and close the data channel, and the latter sends non stop requests.
We expect the app to not crash and to be able to set up the data channel.


## PR submission checklist
- [X] I have tested peerdroid with several scenarios
