### PR TITLE
ABW-2495 - Backup section moved to Account Security & Settings.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsItem.kt
@@ -13,8 +13,8 @@ sealed interface SettingsItem {
         data object ImportOlympiaWallet : TopLevelSettings
         data object AuthorizedDapps : TopLevelSettings
         data class Personas(val showBackupSecurityPrompt: Boolean = false) : TopLevelSettings
-        data object AccountSecurityAndSettings : TopLevelSettings
-        data class AppSettings(val showNotificationWarning: Boolean) : TopLevelSettings
+        data class AccountSecurityAndSettings(val showNotificationWarning: Boolean) : TopLevelSettings
+        data object AppSettings : TopLevelSettings
 
         @StringRes
         fun descriptionRes(): Int {
@@ -23,7 +23,7 @@ sealed interface SettingsItem {
                 ImportOlympiaWallet -> R.string.settings_importFromLegacyWallet
                 AuthorizedDapps -> R.string.settings_authorizedDapps
                 is Personas -> R.string.settings_personas
-                AccountSecurityAndSettings -> R.string.settings_accountSecurityAndSettings
+                is AccountSecurityAndSettings -> R.string.settings_accountSecurityAndSettings
                 is AppSettings -> R.string.settings_appSettings
             }
         }
@@ -33,7 +33,7 @@ sealed interface SettingsItem {
             return when (this) {
                 AuthorizedDapps -> DSR.ic_authorized_dapps
                 is Personas -> DSR.ic_personas
-                AccountSecurityAndSettings -> DSR.ic_security
+                is AccountSecurityAndSettings -> DSR.ic_security
                 is AppSettings -> DSR.ic_app_settings
                 else -> null
             }
@@ -44,6 +44,7 @@ sealed interface SettingsItem {
         data object SeedPhrases : AccountSecurityAndSettingsItem
         data object LedgerHardwareWallets : AccountSecurityAndSettingsItem
         data object DepositGuarantees : AccountSecurityAndSettingsItem
+        data class Backups(val backupState: BackupState) : AccountSecurityAndSettingsItem
         data object ImportFromLegacyWallet : AccountSecurityAndSettingsItem
 
         @StringRes
@@ -52,6 +53,7 @@ sealed interface SettingsItem {
                 SeedPhrases -> R.string.displayMnemonics_seedPhrases
                 LedgerHardwareWallets -> R.string.settings_ledgerHardwareWallets
                 DepositGuarantees -> R.string.settings_depositGuarantees_title
+                is Backups -> R.string.settings_backups
                 ImportFromLegacyWallet -> R.string.settings_importFromLegacyWallet
             }
         }
@@ -62,6 +64,7 @@ sealed interface SettingsItem {
                 SeedPhrases -> com.babylon.wallet.android.designsystem.R.drawable.ic_seed_phrases
                 LedgerHardwareWallets -> com.babylon.wallet.android.designsystem.R.drawable.ic_ledger_hardware_wallets
                 DepositGuarantees -> com.babylon.wallet.android.designsystem.R.drawable.ic_filter_list
+                is Backups -> com.babylon.wallet.android.designsystem.R.drawable.ic_backup
                 ImportFromLegacyWallet -> com.babylon.wallet.android.designsystem.R.drawable.ic_app_settings
             }
         }
@@ -70,7 +73,6 @@ sealed interface SettingsItem {
     sealed interface AppSettingsItem {
         data object LinkedConnectors : AppSettingsItem
         data object Gateways : AppSettingsItem
-        data class Backups(val backupState: BackupState) : AppSettingsItem
         data object EntityHiding : AppSettingsItem
         data class DeveloperMode(val enabled: Boolean) : AppSettingsItem
 
@@ -79,7 +81,6 @@ sealed interface SettingsItem {
             return when (this) {
                 LinkedConnectors -> R.string.settings_linkedConnectors
                 Gateways -> R.string.settings_gateways
-                is Backups -> R.string.settings_backups
                 is DeveloperMode -> R.string.appSettings_developerMode_title
                 EntityHiding -> R.string.appSettings_entityHiding_title
             }
@@ -90,7 +91,6 @@ sealed interface SettingsItem {
             return when (this) {
                 LinkedConnectors -> com.babylon.wallet.android.designsystem.R.drawable.ic_desktop_connection
                 Gateways -> com.babylon.wallet.android.designsystem.R.drawable.ic_gateways
-                is Backups -> com.babylon.wallet.android.designsystem.R.drawable.ic_backup
                 EntityHiding -> com.babylon.wallet.android.designsystem.R.drawable.ic_entity_hiding
                 else -> null
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsNavGraph.kt
@@ -82,7 +82,7 @@ private fun NavGraphBuilder.settingsAll(navController: NavController) {
                         navController.personasScreen()
                     }
 
-                    SettingsItem.TopLevelSettings.AccountSecurityAndSettings -> {
+                    is SettingsItem.TopLevelSettings.AccountSecurityAndSettings -> {
                         navController.accountSecurityScreen()
                     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsScreen.kt
@@ -159,7 +159,7 @@ private fun SettingsContent(
                                     },
                                     icon = settingsItem.getIcon(),
                                     title = stringResource(id = settingsItem.descriptionRes()),
-                                    showNotificationDot = (settingsItem as? SettingsItem.TopLevelSettings.AppSettings)
+                                    showNotificationDot = (settingsItem as? SettingsItem.TopLevelSettings.AccountSecurityAndSettings)
                                         ?.showNotificationWarning ?: false
                                 )
                             }
@@ -327,8 +327,8 @@ fun SettingsScreenWithoutActiveConnectionPreview() {
                 SettingsItem.TopLevelSettings.ImportOlympiaWallet,
                 SettingsItem.TopLevelSettings.AuthorizedDapps,
                 SettingsItem.TopLevelSettings.Personas(),
-                SettingsItem.TopLevelSettings.AccountSecurityAndSettings,
-                SettingsItem.TopLevelSettings.AppSettings(showNotificationWarning = true)
+                SettingsItem.TopLevelSettings.AccountSecurityAndSettings(showNotificationWarning = true),
+                SettingsItem.TopLevelSettings.AppSettings
             ),
             onSettingClick = {},
             onHideImportOlympiaWalletSettingBox = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsViewModel.kt
@@ -42,8 +42,8 @@ class SettingsViewModel @Inject constructor(
     private val defaultSettings = listOf(
         AuthorizedDapps,
         Personas(),
-        AccountSecurityAndSettings,
-        AppSettings(showNotificationWarning = false)
+        AccountSecurityAndSettings(showNotificationWarning = false),
+        AppSettings
     )
 
     val state: StateFlow<SettingsUiState> = combine(
@@ -64,8 +64,8 @@ class SettingsViewModel @Inject constructor(
             mutated.add(topIndex, ImportOlympiaWallet)
         }
 
-        val withBackupWarning = mutated.mapWhen(predicate = { it is AppSettings }) {
-            AppSettings(showNotificationWarning = backupState.isWarningVisible)
+        val withBackupWarning = mutated.mapWhen(predicate = { it is AccountSecurityAndSettings }) {
+            AccountSecurityAndSettings(showNotificationWarning = backupState.isWarningVisible)
         }
 
         val withPersonaWarning = withBackupWarning.mapWhen(predicate = { it is Personas }) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityNav.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.babylon.wallet.android.presentation.main.MAIN_ROUTE
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.RestoreMnemonicsArgs
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.restoreMnemonics
 import com.babylon.wallet.android.presentation.settings.SettingsItem
@@ -17,6 +18,8 @@ import com.babylon.wallet.android.presentation.settings.accountsecurity.ledgerha
 import com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.confirm.confirmSeedPhrase
 import com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.reveal.revealSeedPhrase
 import com.babylon.wallet.android.presentation.settings.accountsecurity.seedphrases.seedPhrases
+import com.babylon.wallet.android.presentation.settings.appsettings.backup.backupScreen
+import com.babylon.wallet.android.presentation.settings.appsettings.backup.systemBackupSettingsScreen
 
 const val ROUTE_ACCOUNT_SECURITY_SCREEN = "settings_account_security_screen"
 const val ROUTE_ACCOUNT_SECURITY_GRAPH = "settings_account_security_graph"
@@ -47,6 +50,17 @@ fun NavGraphBuilder.accountSecurityNavGraph(
         )
         importLegacyWalletScreen(
             onBackClick = {
+                navController.popBackStack()
+            }
+        )
+        backupScreen(
+            onSystemBackupSettingsClick = {
+                navController.systemBackupSettingsScreen()
+            },
+            onProfileDeleted = {
+                navController.popBackStack(MAIN_ROUTE, false)
+            },
+            onClose = {
                 navController.popBackStack()
             }
         )
@@ -97,6 +111,9 @@ fun NavGraphBuilder.accountSecurityScreen(
                     }
                     SettingsItem.AccountSecurityAndSettingsItem.DepositGuarantees -> {
                         navController.depositGuaranteesScreen()
+                    }
+                    is SettingsItem.AccountSecurityAndSettingsItem.Backups -> {
+                        navController.backupScreen()
                     }
                     SettingsItem.AccountSecurityAndSettingsItem.ImportFromLegacyWallet -> {
                         navController.importLegacyWalletScreen()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityScreen.kt
@@ -4,22 +4,27 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.settings.SettingsItem.AccountSecurityAndSettingsItem
 import com.babylon.wallet.android.presentation.ui.composables.DefaultSettingsItem
+import com.babylon.wallet.android.presentation.ui.composables.NotBackedUpWarning
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
@@ -66,19 +71,41 @@ private fun AccountSecurityContent(
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 appSettings.forEach { accountSecurityAndSettingsItem ->
                     item {
-                        DefaultSettingsItem(
-                            title = stringResource(id = accountSecurityAndSettingsItem.descriptionRes()),
-                            icon = accountSecurityAndSettingsItem.getIcon(),
-                            onClick = {
-                                onAccountSecuritySettingItemClick(accountSecurityAndSettingsItem)
-                            },
-                            subtitle =
-                            if (accountSecurityAndSettingsItem is AccountSecurityAndSettingsItem.DepositGuarantees) {
-                                stringResource(id = R.string.settings_depositGuarantees_subtitle)
-                            } else {
-                                null
-                            }
-                        )
+                        if (accountSecurityAndSettingsItem is AccountSecurityAndSettingsItem.Backups) {
+                            DefaultSettingsItem(
+                                title = stringResource(id = accountSecurityAndSettingsItem.descriptionRes()),
+                                subtitleView = {
+                                    NotBackedUpWarning(backupState = accountSecurityAndSettingsItem.backupState)
+                                },
+                                iconView = accountSecurityAndSettingsItem.getIcon()?.let { iconRes ->
+                                    {
+                                        Icon(
+                                            modifier = Modifier.size(24.dp),
+                                            painter = painterResource(id = iconRes),
+                                            contentDescription = null
+                                        )
+                                    }
+                                },
+                                onClick = {
+                                    onAccountSecuritySettingItemClick(accountSecurityAndSettingsItem)
+                                }
+                            )
+                        } else {
+                            DefaultSettingsItem(
+                                title = stringResource(id = accountSecurityAndSettingsItem.descriptionRes()),
+                                icon = accountSecurityAndSettingsItem.getIcon(),
+                                onClick = {
+                                    onAccountSecuritySettingItemClick(accountSecurityAndSettingsItem)
+                                },
+                                subtitle =
+                                if (accountSecurityAndSettingsItem is AccountSecurityAndSettingsItem.DepositGuarantees) {
+                                    stringResource(id = R.string.settings_depositGuarantees_subtitle)
+                                } else {
+                                    null
+                                },
+
+                                )
+                        }
                         HorizontalDivider(color = RadixTheme.colors.gray5)
                     }
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityScreen.kt
@@ -104,7 +104,7 @@ private fun AccountSecurityContent(
                                     null
                                 },
 
-                                )
+                            )
                         }
                         HorizontalDivider(color = RadixTheme.colors.gray5)
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -12,14 +12,17 @@ import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import rdx.works.core.mapWhen
 import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.domain.GetProfileUseCase
+import rdx.works.profile.domain.backup.GetBackupStateUseCase
 import rdx.works.profile.domain.gateways
 import javax.inject.Inject
 
 @HiltViewModel
 class AccountSecurityViewModel @Inject constructor(
-    private val getProfileUseCase: GetProfileUseCase
+    private val getProfileUseCase: GetProfileUseCase,
+    private val getBackupStateUseCase: GetBackupStateUseCase
 ) : StateViewModel<AccountSecurityUiState>() {
 
     override fun initialState(): AccountSecurityUiState = AccountSecurityUiState(
@@ -40,6 +43,23 @@ class AccountSecurityViewModel @Inject constructor(
                             .apply { add(SettingsItem.AccountSecurityAndSettingsItem.ImportFromLegacyWallet) }
                             .toPersistentSet()
                     )
+                }
+            }
+        }
+        viewModelScope.launch {
+            getBackupStateUseCase().collect { backupState ->
+                _state.update { settingsUiState ->
+                    val settingsList = if (settingsUiState.settings.any { it is SettingsItem.AccountSecurityAndSettingsItem.Backups }) {
+                        settingsUiState.settings.mapWhen(
+                            predicate = { it is SettingsItem.AccountSecurityAndSettingsItem.Backups },
+                            mutation = { SettingsItem.AccountSecurityAndSettingsItem.Backups(backupState = backupState) }
+                        )
+                    } else {
+                        settingsUiState.settings.toMutableList().apply {
+                            add(3, SettingsItem.AccountSecurityAndSettingsItem.Backups(backupState))
+                        }
+                    }
+                    settingsUiState.copy(settings = settingsList.toPersistentSet())
                 }
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/AccountSecurityViewModel.kt
@@ -19,6 +19,7 @@ import rdx.works.profile.domain.backup.GetBackupStateUseCase
 import rdx.works.profile.domain.gateways
 import javax.inject.Inject
 
+@Suppress("MagicNumber")
 @HiltViewModel
 class AccountSecurityViewModel @Inject constructor(
     private val getProfileUseCase: GetProfileUseCase,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsNav.kt
@@ -10,11 +10,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.babylon.wallet.android.presentation.account.createaccount.confirmation.CreateAccountRequestSource
 import com.babylon.wallet.android.presentation.account.createaccount.createAccountScreen
-import com.babylon.wallet.android.presentation.main.MAIN_ROUTE
 import com.babylon.wallet.android.presentation.navigation.Screen
 import com.babylon.wallet.android.presentation.settings.SettingsItem
-import com.babylon.wallet.android.presentation.settings.appsettings.backup.backupScreen
-import com.babylon.wallet.android.presentation.settings.appsettings.backup.systemBackupSettingsScreen
 import com.babylon.wallet.android.presentation.settings.appsettings.entityhiding.hiddenEntitiesScreen
 import com.babylon.wallet.android.presentation.settings.appsettings.gateways.GatewaysScreen
 import com.babylon.wallet.android.presentation.settings.appsettings.linkedconnectors.linkedConnectorsScreen
@@ -43,17 +40,6 @@ fun NavGraphBuilder.appSettingsNavGraph(
         hiddenEntitiesScreen(onBackClick = {
             navController.popBackStack()
         })
-        backupScreen(
-            onSystemBackupSettingsClick = {
-                navController.systemBackupSettingsScreen()
-            },
-            onProfileDeleted = {
-                navController.popBackStack(MAIN_ROUTE, false)
-            },
-            onClose = {
-                navController.popBackStack()
-            }
-        )
     }
 }
 
@@ -86,10 +72,6 @@ fun NavGraphBuilder.appSettingsScreen(
 
                     SettingsItem.AppSettingsItem.Gateways -> {
                         navController.navigate(Screen.SettingsEditGatewayApiDestination.route)
-                    }
-
-                    is SettingsItem.AppSettingsItem.Backups -> {
-                        navController.backupScreen()
                     }
 
                     is SettingsItem.AppSettingsItem.DeveloperMode -> {}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsScreen.kt
@@ -5,27 +5,22 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.settings.SettingsItem
 import com.babylon.wallet.android.presentation.ui.composables.DefaultSettingsItem
-import com.babylon.wallet.android.presentation.ui.composables.NotBackedUpWarning
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.SwitchSettingsItem
 import kotlinx.collections.immutable.ImmutableSet
@@ -93,27 +88,6 @@ private fun AppSettingsContent(
                                     iconResource = appSettingsItem.getIcon(),
                                     checked = appSettingsItem.enabled,
                                     onCheckedChange = onDeveloperModeToggled
-                                )
-                            }
-
-                            is SettingsItem.AppSettingsItem.Backups -> {
-                                DefaultSettingsItem(
-                                    title = stringResource(id = appSettingsItem.descriptionRes()),
-                                    subtitleView = {
-                                        NotBackedUpWarning(backupState = appSettingsItem.backupState)
-                                    },
-                                    iconView = appSettingsItem.getIcon()?.let { iconRes ->
-                                        {
-                                            Icon(
-                                                modifier = Modifier.size(24.dp),
-                                                painter = painterResource(id = iconRes),
-                                                contentDescription = null
-                                            )
-                                        }
-                                    },
-                                    onClick = {
-                                        onAppSettingItemClick(appSettingsItem)
-                                    }
                                 )
                             }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.core.mapWhen
 import rdx.works.profile.domain.GetProfileUseCase
-import rdx.works.profile.domain.backup.GetBackupStateUseCase
 import rdx.works.profile.domain.security
 import rdx.works.profile.domain.security.UpdateDeveloperModeUseCase
 import javax.inject.Inject
@@ -22,7 +21,6 @@ import javax.inject.Inject
 @HiltViewModel
 class AppSettingsViewModel @Inject constructor(
     private val getProfileUseCase: GetProfileUseCase,
-    private val getBackupStateUseCase: GetBackupStateUseCase,
     private val updateDeveloperModeUseCase: UpdateDeveloperModeUseCase
 ) : StateViewModel<AppSettingsUiState>() {
 
@@ -42,23 +40,6 @@ class AppSettingsViewModel @Inject constructor(
                         SettingsItem.AppSettingsItem.DeveloperMode(isInDeveloperMode)
                     }
                 }
-        }
-        viewModelScope.launch {
-            getBackupStateUseCase().collect { backupState ->
-                _state.update { settingsUiState ->
-                    val settingsList = if (settingsUiState.settings.any { it is SettingsItem.AppSettingsItem.Backups }) {
-                        settingsUiState.settings.mapWhen(
-                            predicate = { it is SettingsItem.AppSettingsItem.Backups },
-                            mutation = { SettingsItem.AppSettingsItem.Backups(backupState = backupState) }
-                        )
-                    } else {
-                        settingsUiState.settings.toMutableList().apply {
-                            add(2, SettingsItem.AppSettingsItem.Backups(backupState))
-                        }
-                    }
-                    settingsUiState.copy(settings = settingsList.toPersistentSet())
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Description
This PR moves backups section from **App Settings** into **Account Security & Settings**.

## How to test

1. Verify that Backup section appears under **Account Security & Settings**.
2. Also make sure that red badge indicating backup state appears on **Account Security & Settings** instead of **App Settings**

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/fb6f9b57-5cf0-4dd2-b115-22deb65416c3" width="300">

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/f1268de2-165e-4424-9eb3-e172d4ed5b46" width="300">

## PR submission checklist
- [x] I have verified that Backup section appears under **Account Security & Settings**
