### PR TITLE
ABW-2601] Do not require signing when accept known rule and spending asset is in receiving account

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
@@ -63,6 +63,17 @@ data class Assets(
         }
     }
 
+    val ownedResources: List<Resource> by lazy {
+        fungibles + nonFungibles +
+            poolUnits.map { it.stake } +
+            validatorsWithStakes
+                .mapNotNull { it.liquidStakeUnit }
+                .map { it.fungibleResource } +
+            validatorsWithStakes
+                .mapNotNull { it.stakeClaimNft }
+                .map { it.nonFungibleResource }
+    }
+
     fun hasXrd(minimumBalance: BigDecimal = BigDecimal(1)): Boolean = ownedXrd?.let {
         it.ownedAmount?.let { amount ->
             amount >= minimumBalance

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
@@ -63,7 +63,10 @@ data class Assets(
         }
     }
 
-    val ownedResources: List<Resource> by lazy {
+    // knownResources of an account is when
+    // it contains a resource with an amount greater than 0
+    // or it had a resource in the past but the amount is 0 now
+    val knownResources: List<Resource> by lazy {
         fungibles + nonFungibles +
             poolUnits.map { it.stake } +
             validatorsWithStakes

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/AccountSelectionCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/AccountSelectionCard.kt
@@ -5,11 +5,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Text
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,7 +27,8 @@ fun AccountSelectionCard(
     checked: Boolean,
     isSingleChoice: Boolean,
     radioButtonClicked: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isEnabledForSelection: Boolean = true
 ) {
     Row(
         modifier = modifier
@@ -65,6 +66,7 @@ fun AccountSelectionCard(
                     disabledSelectedColor = Color.White
                 ),
                 onClick = radioButtonClicked,
+                enabled = isEnabledForSelection
             )
         } else {
             Checkbox(
@@ -89,7 +91,8 @@ fun DAppAccountCardPreview() {
             address = "jf932j9f32o",
             isSingleChoice = false,
             radioButtonClicked = {},
-            checked = true
+            checked = true,
+            isEnabledForSelection = true
         )
     }
 }
@@ -104,7 +107,8 @@ fun DAppAccountCardLargeFontPreview() {
             address = "jf932j9f32o",
             isSingleChoice = false,
             radioButtonClicked = {},
-            checked = true
+            checked = true,
+            isEnabledForSelection = true
         )
     }
 }
@@ -118,7 +122,8 @@ fun DAppAccountCardSingleChoicePreview() {
             address = "jf932j9f32o",
             isSingleChoice = true,
             radioButtonClicked = {},
-            checked = true
+            checked = true,
+            isEnabledForSelection = true
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TargetAccountCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TargetAccountCard.kt
@@ -160,7 +160,7 @@ fun TargetAccountCard(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            targetAccount.assets.forEach { spendingAsset ->
+            targetAccount.spendingAssets.forEach { spendingAsset ->
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     SpendingAssetItem(
                         modifier = Modifier.weight(1f),
@@ -255,7 +255,7 @@ fun TargetAccountCardPreview() {
                 targetAccount = TargetAccount.Owned(
                     account = SampleDataProvider().sampleAccount(),
                     id = UUIDGenerator.uuid().toString(),
-                    assets = persistentSetOf(
+                    spendingAssets = persistentSetOf(
                         SpendingAsset.Fungible(
                             resource = Resource.FungibleResource(
                                 resourceAddress = "resource_rdx_abcd",

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -553,6 +553,7 @@ sealed class TargetAccount {
 
     data class Owned(
         val account: Network.Account,
+        val accountAssetsAddresses: List<String> = emptyList(),
         override val id: String,
         override val spendingAssets: ImmutableSet<SpendingAsset> = persistentSetOf()
     ) : TargetAccount() {
@@ -560,7 +561,10 @@ sealed class TargetAccount {
             get() = account.address
 
         override fun isSignatureRequiredForTransfer(forSpendingAsset: SpendingAsset): Boolean {
-            return account.isSignatureRequiredBasedOnDepositRules(forSpecificAssetAddress = forSpendingAsset.address)
+            return account.isSignatureRequiredBasedOnDepositRules(
+                forSpecificAssetAddress = forSpendingAsset.address,
+                addressesOfAssetsOfTargetAccount = accountAssetsAddresses
+            )
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -311,7 +311,7 @@ class TransferViewModel @Inject constructor(
             val nonFungibleBalances = mutableMapOf<Resource.NonFungibleResource.Item, Int>()
 
             targetAccounts
-                .map { it.assets.filterIsInstance<SpendingAsset.Fungible>() }
+                .map { it.spendingAssets.filterIsInstance<SpendingAsset.Fungible>() }
                 .flatten()
                 .forEach { fungible ->
                     val spentAmount = fungibleBalances[fungible.resource] ?: BigDecimal.ZERO
@@ -319,7 +319,7 @@ class TransferViewModel @Inject constructor(
                 }
 
             targetAccounts
-                .map { it.assets.filterIsInstance<SpendingAsset.NFT>() }
+                .map { it.spendingAssets.filterIsInstance<SpendingAsset.NFT>() }
                 .flatten()
                 .forEach { nft ->
                     val spent = nonFungibleBalances[nft.item] ?: 0
@@ -354,7 +354,8 @@ class TransferViewModel @Inject constructor(
             data class ChooseAccounts(
                 val selectedAccount: TargetAccount,
                 val ownedAccounts: PersistentList<Network.Account>,
-                val mode: Mode = Mode.Chooser
+                val mode: Mode = Mode.Chooser,
+                val isLoadingAssetsForAccount: Boolean
             ) : Sheet {
 
                 val isOwnedAccountsEnabled: Boolean
@@ -388,7 +389,7 @@ class TransferViewModel @Inject constructor(
 
                 val isSubmitEnabled: Boolean
                     get() {
-                        val currentAssetAddresses = targetAccount.assets.map { it.address }.toSet()
+                        val currentAssetAddresses = targetAccount.spendingAssets.map { it.address }.toSet()
                         val currentSub = currentAssetAddresses subtract initialAssetAddress
                         val initialSub = initialAssetAddress subtract currentAssetAddresses
                         val result = currentSub union initialSub
@@ -396,7 +397,7 @@ class TransferViewModel @Inject constructor(
                     }
 
                 val assetsSelectedCount: Int
-                    get() = targetAccount.assets.size
+                    get() = targetAccount.spendingAssets.size
 
                 fun onNFTsLoading(forResource: Resource.NonFungibleResource): ChooseAssets {
                     return copy(nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs + forResource.resourceAddress)
@@ -438,7 +439,7 @@ class TransferViewModel @Inject constructor(
 
                 companion object {
                     fun init(forTargetAccount: TargetAccount): ChooseAssets = ChooseAssets(
-                        initialAssetAddress = forTargetAccount.assets.map { it.address }.toPersistentSet(),
+                        initialAssetAddress = forTargetAccount.spendingAssets.map { it.address }.toPersistentSet(),
                         targetAccount = forTargetAccount
                     )
                 }
@@ -467,7 +468,7 @@ class TransferViewModel @Inject constructor(
 sealed class TargetAccount {
     abstract val address: String
     abstract val id: String
-    abstract val assets: ImmutableSet<SpendingAsset>
+    abstract val spendingAssets: ImmutableSet<SpendingAsset>
 
     abstract fun isSignatureRequiredForTransfer(forSpendingAsset: SpendingAsset): Boolean
 
@@ -480,54 +481,54 @@ sealed class TargetAccount {
 
     val isValidForSubmission: Boolean
         get() = when (this) {
-            is Other -> assets.isNotEmpty() && assets.all { it.isValidForSubmission }
-            is Owned -> assets.isNotEmpty() && assets.all { it.isValidForSubmission }
-            is Skeleton -> assets.isEmpty()
+            is Other -> spendingAssets.isNotEmpty() && spendingAssets.all { it.isValidForSubmission }
+            is Owned -> spendingAssets.isNotEmpty() && spendingAssets.all { it.isValidForSubmission }
+            is Skeleton -> spendingAssets.isEmpty()
         }
 
     val factorSourceId: FactorSource.FactorSourceID.FromHash?
         get() = (this as? Owned)?.account?.factorSourceId() as? FactorSource.FactorSourceID.FromHash
 
-    fun amountSpent(fungibleAsset: SpendingAsset.Fungible): BigDecimal = assets
+    fun amountSpent(fungibleAsset: SpendingAsset.Fungible): BigDecimal = spendingAssets
         .filterIsInstance<SpendingAsset.Fungible>()
         .find { it.address == fungibleAsset.address }
         ?.amountDecimal ?: BigDecimal.ZERO
 
     fun updateAssets(onUpdate: (ImmutableSet<SpendingAsset>) -> ImmutableSet<SpendingAsset>): TargetAccount {
         return when (this) {
-            is Owned -> copy(assets = onUpdate(assets))
-            is Other -> copy(assets = onUpdate(assets))
-            is Skeleton -> copy(assets = onUpdate(assets))
+            is Owned -> copy(spendingAssets = onUpdate(spendingAssets))
+            is Other -> copy(spendingAssets = onUpdate(spendingAssets))
+            is Skeleton -> copy(spendingAssets = onUpdate(spendingAssets))
         }
     }
 
     fun addAsset(asset: SpendingAsset): TargetAccount {
-        val newAssets = assets.toMutableSet().apply {
+        val newSpendingAssets = spendingAssets.toMutableSet().apply {
             add(asset)
         }.toPersistentSet()
 
         return when (this) {
-            is Owned -> copy(assets = newAssets)
-            is Other -> copy(assets = newAssets)
-            is Skeleton -> copy(assets = newAssets)
+            is Owned -> copy(spendingAssets = newSpendingAssets)
+            is Other -> copy(spendingAssets = newSpendingAssets)
+            is Skeleton -> copy(spendingAssets = newSpendingAssets)
         }
     }
 
     fun removeAsset(asset: SpendingAsset): TargetAccount {
-        val newAssets = assets.toMutableSet().apply {
+        val newSpendingAssets = spendingAssets.toMutableSet().apply {
             removeIf { it.address == asset.address }
         }.toPersistentSet()
 
         return when (this) {
-            is Owned -> copy(assets = newAssets)
-            is Other -> copy(assets = newAssets)
-            is Skeleton -> copy(assets = newAssets)
+            is Owned -> copy(spendingAssets = newSpendingAssets)
+            is Other -> copy(spendingAssets = newSpendingAssets)
+            is Skeleton -> copy(spendingAssets = newSpendingAssets)
         }
     }
 
     data class Skeleton(
         override val id: String = UUIDGenerator.uuid().toString(),
-        override val assets: ImmutableSet<SpendingAsset> = persistentSetOf()
+        override val spendingAssets: ImmutableSet<SpendingAsset> = persistentSetOf()
     ) : TargetAccount() {
         override val address: String = ""
 
@@ -538,7 +539,7 @@ sealed class TargetAccount {
         override val address: String,
         val validity: AddressValidity,
         override val id: String,
-        override val assets: ImmutableSet<SpendingAsset> = persistentSetOf()
+        override val spendingAssets: ImmutableSet<SpendingAsset> = persistentSetOf()
     ) : TargetAccount() {
 
         override fun isSignatureRequiredForTransfer(forSpendingAsset: SpendingAsset): Boolean = false
@@ -553,7 +554,7 @@ sealed class TargetAccount {
     data class Owned(
         val account: Network.Account,
         override val id: String,
-        override val assets: ImmutableSet<SpendingAsset> = persistentSetOf()
+        override val spendingAssets: ImmutableSet<SpendingAsset> = persistentSetOf()
     ) : TargetAccount() {
         override val address: String
             get() = account.address

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/AccountsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/AccountsChooserDelegate.kt
@@ -114,9 +114,13 @@ class AccountsChooserDelegate @Inject constructor(
 
                     TargetAccount.Owned(
                         account = ownedAccount,
-                        accountAssetsAddresses = if (areTargetAccountResourcesRequired) fetchKnownResourcesOfOwnedAccount(
-                            ownedAccount = ownedAccount
-                        ) else emptyList(),
+                        accountAssetsAddresses = if (areTargetAccountResourcesRequired) {
+                            fetchKnownResourcesOfOwnedAccount(
+                                ownedAccount = ownedAccount
+                            )
+                        } else {
+                            emptyList()
+                        },
                         id = sheetState.selectedAccount.id,
                         spendingAssets = sheetState.selectedAccount.spendingAssets
                     )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/AccountsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/AccountsChooserDelegate.kt
@@ -115,7 +115,7 @@ class AccountsChooserDelegate @Inject constructor(
                         ).first()
                             .first()
                             .assets
-                            ?.ownedResources
+                            ?.knownResources
                             ?.map { resource ->
                                 resource.resourceAddress
                             }.orEmpty(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/AccountsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/AccountsChooserDelegate.kt
@@ -56,7 +56,7 @@ class AccountsChooserDelegate @Inject constructor(
                     address = address,
                     validity = validity,
                     id = sheetState.selectedAccount.id,
-                    assets = sheetState.selectedAccount.assets
+                    spendingAssets = sheetState.selectedAccount.spendingAssets
                 ),
                 mode = ChooseAccounts.Mode.Chooser
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
@@ -136,7 +136,8 @@ fun ChooseAccountSheet(
                     modifier = Modifier
                         .padding(RadixTheme.dimensions.paddingDefault)
                         .fillMaxWidth(),
-                    enabled = state.isChooseButtonEnabled
+                    enabled = state.isChooseButtonEnabled,
+                    isLoading = state.isLoadingAssetsForAccount
                 )
             }
         }
@@ -333,7 +334,8 @@ private fun ChooseAccountContent(
                         onOwnedAccountSelected(accountItem)
                         focusManager.clearFocus(true)
                     }
-                }
+                },
+                isEnabledForSelection = state.isLoadingAssetsForAccount.not()
             )
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/ChooseAssetsSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/ChooseAssetsSheet.kt
@@ -89,8 +89,8 @@ fun ChooseAssetsSheet(
         containerColor = RadixTheme.colors.gray5
     ) { padding ->
         val collapsibleAssetsState = rememberAssetsViewState(assets = state.assets)
-        val selectedAssets = remember(state.targetAccount.assets) {
-            state.targetAccount.assets.map { it.address }
+        val selectedAssets = remember(state.targetAccount.spendingAssets) {
+            state.targetAccount.spendingAssets.map { it.address }
         }
         LazyColumn(
             modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/prepare/PrepareManifestDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/prepare/PrepareManifestDelegate.kt
@@ -77,9 +77,9 @@ class PrepareManifestDelegate @Inject constructor(
 
             // Deposit to each target account
             targetAccounts.filter { targetAccount ->
-                targetAccount.assets.any { it.address == resource.resourceAddress }
+                targetAccount.spendingAssets.any { it.address == resource.resourceAddress }
             }.forEach { targetAccount ->
-                val spendingFungibleAsset = targetAccount.assets.find {
+                val spendingFungibleAsset = targetAccount.spendingAssets.find {
                     it.address == resource.resourceAddress
                 } as? SpendingAsset.Fungible
                 if (spendingFungibleAsset != null) {
@@ -108,7 +108,7 @@ class PrepareManifestDelegate @Inject constructor(
         targetAccounts: List<TargetAccount>
     ) = apply {
         targetAccounts.forEach { targetAccount ->
-            val nonFungibleSpendingAssets = targetAccount.assets.filterIsInstance<SpendingAsset.NFT>()
+            val nonFungibleSpendingAssets = targetAccount.spendingAssets.filterIsInstance<SpendingAsset.NFT>()
             nonFungibleSpendingAssets.forEach { nft ->
                 val bucket = newBucket()
 
@@ -171,7 +171,7 @@ class PrepareManifestDelegate @Inject constructor(
      */
     private fun TransferViewModel.State.withdrawingFungibles(): Map<Resource.FungibleResource, BigDecimal> {
         val allFungibles: List<SpendingAsset.Fungible> =
-            targetAccounts.map { it.assets.filterIsInstance<SpendingAsset.Fungible>() }.flatten()
+            targetAccounts.map { it.spendingAssets.filterIsInstance<SpendingAsset.Fungible>() }.flatten()
 
         val fungibleAmounts = mutableMapOf<Resource.FungibleResource, BigDecimal>()
         allFungibles.forEach { fungible ->

--- a/profile/src/main/java/rdx/works/profile/data/model/extensions/AccountExtensions.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/extensions/AccountExtensions.kt
@@ -61,7 +61,7 @@ fun Network.Account.OnLedgerSettings.ThirdPartyDeposits.DepositAddressExceptionR
     }
 }
 
-@Suppress("ReturnCount", "UnusedParameter")
+@Suppress("ReturnCount")
 fun Network.Account.isSignatureRequiredBasedOnDepositRules(
     forSpecificAssetAddress: String,
     addressesOfAssetsOfTargetAccount: List<String> = emptyList()
@@ -87,10 +87,10 @@ fun Network.Account.isSignatureRequiredBasedOnDepositRules(
     } else if (hasDenyAll || hasDenyExceptionRuleForAsset) {
         return true
     } else if (hasAcceptKnown) {
-        // TODO will enable when we have the new GW
-//        if (addressesOfAssetsOfTargetAccount.contains(forSpecificAssetAddress)) {
-//            return false
-//        }
+        // and if the receiving account knows the resource then do not require signature
+        if (addressesOfAssetsOfTargetAccount.contains(forSpecificAssetAddress)) {
+            return false
+        }
         return true
     }
 

--- a/profile/src/main/java/rdx/works/profile/data/model/extensions/AccountExtensions.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/extensions/AccountExtensions.kt
@@ -61,6 +61,11 @@ fun Network.Account.OnLedgerSettings.ThirdPartyDeposits.DepositAddressExceptionR
     }
 }
 
+fun Network.Account.hasAcceptKnownDepositRule(): Boolean {
+    val thirdPartyDeposits = this.onLedgerSettings.thirdPartyDeposits
+    return thirdPartyDeposits.depositRule == Network.Account.OnLedgerSettings.ThirdPartyDeposits.DepositRule.AcceptKnown
+}
+
 @Suppress("ReturnCount")
 fun Network.Account.isSignatureRequiredBasedOnDepositRules(
     forSpecificAssetAddress: String,

--- a/profile/src/test/java/rdx/works/profile/accountextensions/TransferBetweenOwnedAccountsTest.kt
+++ b/profile/src/test/java/rdx/works/profile/accountextensions/TransferBetweenOwnedAccountsTest.kt
@@ -218,7 +218,6 @@ class TransferBetweenOwnedAccountsTest {
         assertTrue(profile.networks[0].accounts[0].isSignatureRequiredBasedOnDepositRules(asset1address))
     }
 
-    @Ignore("will enable when we have the new GW")
     @Test
     fun `given accept known and target account has Asset1, when transfer Asset1 from user's own account to user's target account, then signature is not required`() {
         profile = profile.updateThirdPartyDepositSettings(


### PR DESCRIPTION
## Description
This PR adds the missing case for the required signature when during an own transfer the receiving account has accept known rule and the spending asset is known by this account. In this case we should not require signature from the user.
In more details:
- enabled rule in isSignatureRequiredBasedOnDepositRules and its unit test
- added logic in the AccountsChooserDelegate to fetch the resources of the target account when "choose" button is clicked
- when "choose" button is clicked, the button is in loading state until the resources are fetched and **the selection of the other accounts remains disabled**
- renamed `assets` to `spendingAssets` in `TargetAccount` state class

## How to test

1. you have a software `accountS` that contains `resource1`, `resource2`, and a ledger account `accountL` that also contains `resource1` but not the `resource2`
2. set the deposit rule of the ledger account `accountL` to accept known
3. transfer `resource1` from `accountS` to `accountL` => signature is not required
4. transfer `resource2` from `accountS` to `accountL` => signature is required

## Video

https://github.com/radixdlt/babylon-wallet-android/assets/118305718/387352a0-5663-46e5-a246-58e13c0c830f


## PR submission checklist
- [X] I have tested the above scenario and posted with a video
- [X] I have written unit tests
