### PR TITLE
ABW-2636 - Bottom sheet is not dismissed upon tap action

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -378,7 +378,7 @@ private fun NoMainSeedPhraseView(
                 .padding(horizontal = RadixTheme.dimensions.paddingLarge),
             text = stringResource(id = R.string.recoverSeedPhrase_header_subtitleNoMainSeedPhrase)
                 .formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
-            textAlign = TextAlign.Center,
+            textAlign = TextAlign.Start,
             style = RadixTheme.typography.body1Regular
         )
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -4,10 +4,12 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.AnchoredDraggableState
 import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -98,10 +100,12 @@ fun BottomSheetDialogWrapper(
     onDismiss: () -> Unit,
     content: @Composable () -> Unit
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     Box(
         modifier = modifier
             .fillMaxSize()
             .applyIf(addScrim, Modifier.background(Color.Black.copy(alpha = 0.4f)))
+            .clickable(interactionSource = interactionSource, indication = null) { onDismiss() }
     ) {
         BoxWithConstraints(Modifier.align(Alignment.BottomCenter)) {
             val maxHeight = with(LocalDensity.current) {
@@ -131,6 +135,7 @@ fun BottomSheetDialogWrapper(
             }
             Column(
                 modifier = Modifier
+                    .clickable(interactionSource = interactionSource, indication = null) { /* Disable content click */ }
                     .applyIf(
                         dragToDismissEnabled,
                         Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -4,12 +4,10 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.AnchoredDraggableState
 import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.anchoredDraggable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -100,12 +98,10 @@ fun BottomSheetDialogWrapper(
     onDismiss: () -> Unit,
     content: @Composable () -> Unit
 ) {
-    val interactionSource = remember { MutableInteractionSource() }
     Box(
         modifier = modifier
             .fillMaxSize()
             .applyIf(addScrim, Modifier.background(Color.Black.copy(alpha = 0.4f)))
-            .clickable(interactionSource = interactionSource, indication = null) { onDismiss() }
     ) {
         BoxWithConstraints(Modifier.align(Alignment.BottomCenter)) {
             val maxHeight = with(LocalDensity.current) {


### PR DESCRIPTION
## Description
Bottom sheet dialog no longer dismissed when click on box.

## How to test

1. Open bottom sheet for fungible/nft or something else and verify that is not being dismiss on click.

## PR submission checklist
- [x] I have verified that bottom sheet dialogs are not dismissed on click
