### PR TITLE
Display data in new line when needed

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
@@ -52,13 +52,13 @@ fun AssetMetadataRow(
 
 @Composable
 fun Metadata.View(modifier: Modifier) {
-    if (this is Metadata.Primitive && this.valueType == MetadataType.Url) {
+    if (isRenderedInNewLine) {
         Column(
             modifier = modifier,
             verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
         ) {
             KeyView()
-            ValueView()
+            ValueView(isRenderedInNewLine = true)
         }
     } else {
         Row(
@@ -66,7 +66,7 @@ fun Metadata.View(modifier: Modifier) {
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             KeyView()
-            ValueView()
+            ValueView(isRenderedInNewLine = false)
         }
     }
 }
@@ -88,7 +88,8 @@ fun Metadata.KeyView(
 
 @Composable
 fun Metadata.ValueView(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isRenderedInNewLine: Boolean
 ) {
     val context = LocalContext.current
     when (this) {
@@ -97,7 +98,7 @@ fun Metadata.ValueView(
             text = stringResource(id = R.string.assetDetails_NFTDetails_complexData),
             style = RadixTheme.typography.body1HighImportance,
             color = RadixTheme.colors.gray1,
-            textAlign = TextAlign.End,
+            textAlign = if (isRenderedInNewLine) TextAlign.Start else TextAlign.End,
             maxLines = 2
         )
 
@@ -116,21 +117,22 @@ fun Metadata.ValueView(
                     text = value,
                     style = RadixTheme.typography.body1HighImportance,
                     color = RadixTheme.colors.gray1,
-                    textAlign = TextAlign.End,
+                    textAlign = if (isRenderedInNewLine) TextAlign.Start else TextAlign.End,
                     maxLines = 2
                 )
+
             MetadataType.String -> ExpandableText(
                 modifier = modifier,
                 text = value,
                 style = RadixTheme.typography.body1HighImportance.copy(
                     color = RadixTheme.colors.gray1,
-                    textAlign = TextAlign.End
+                    textAlign = if (isRenderedInNewLine) TextAlign.Start else TextAlign.End,
                 ),
                 toggleStyle = RadixTheme.typography.body1HighImportance.copy(
-                    color = RadixTheme.colors.gray2,
-                    textAlign = TextAlign.End
+                    color = RadixTheme.colors.gray2
                 ),
             )
+
             MetadataType.Address, MetadataType.NonFungibleGlobalId, MetadataType.NonFungibleLocalId ->
                 ActionableAddressView(
                     modifier = modifier,
@@ -144,7 +146,7 @@ fun Metadata.ValueView(
                     text = value.toBigDecimalOrNull()?.displayableQuantity() ?: value,
                     style = RadixTheme.typography.body1HighImportance,
                     color = RadixTheme.colors.gray1,
-                    textAlign = TextAlign.End,
+                    textAlign = if (isRenderedInNewLine) TextAlign.Start else TextAlign.End,
                     maxLines = 2
                 )
 
@@ -170,3 +172,10 @@ fun Metadata.ValueView(
         }
     }
 }
+
+private const val ASSET_METADATA_SHORT_STRING_THRESHOLD = 40
+private val Metadata.isRenderedInNewLine: Boolean
+    get() = this is Metadata.Primitive && (
+        valueType is MetadataType.Url ||
+            (valueType is MetadataType.String && value.length > ASSET_METADATA_SHORT_STRING_THRESHOLD)
+        )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
@@ -155,7 +155,7 @@ fun Metadata.ValueView(
                     modifier = modifier
                         .fillMaxWidth()
                         .clickable { context.openUrl(value) },
-                    horizontalArrangement = Arrangement.SpaceBetween,
+                    horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialog.kt
@@ -156,7 +156,8 @@ private fun NonFungibleAssetDialogContent(
                                 Text(
                                     text = description,
                                     style = RadixTheme.typography.body1HighImportance,
-                                    color = RadixTheme.colors.gray1
+                                    color = RadixTheme.colors.gray1,
+                                    textAlign = TextAlign.End
                                 )
                             }
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialog.kt
@@ -73,7 +73,14 @@ private fun NonFungibleAssetDialogContent(
 ) {
     BottomSheetDialogWrapper(
         modifier = modifier,
-        onDismiss = onDismiss
+        onDismiss = onDismiss,
+        title = if (state.item != null && state.localId != null) {
+            state.item.name
+        } else if (state.localId == null && state.resource != null) {
+            state.resource.name
+        } else {
+            ""
+        }
     ) {
         Box(modifier = Modifier.fillMaxHeight(fraction = 0.9f)) {
             Column(
@@ -91,6 +98,7 @@ private fun NonFungibleAssetDialogContent(
                             nft = state.item,
                             cropped = false
                         )
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
                     } else if (state.item == null) {
                         Box(
                             modifier = Modifier
@@ -102,8 +110,27 @@ private fun NonFungibleAssetDialogContent(
                                     shape = RoundedCornerShape(NFTCornerRadius)
                                 )
                         )
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
                     }
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+
+                    if (!state.item?.description.isNullOrBlank()) {
+                        Text(
+                            modifier = Modifier
+                                .padding(horizontal = RadixTheme.dimensions.paddingXLarge)
+                                .fillMaxWidth(),
+                            text = state.item?.description.orEmpty(),
+                            style = RadixTheme.typography.body2Regular,
+                            color = RadixTheme.colors.gray1
+                        )
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+                        HorizontalDivider(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = RadixTheme.dimensions.paddingLarge),
+                            color = RadixTheme.colors.gray4
+                        )
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+                    }
 
                     AssetMetadataRow(
                         modifier = Modifier
@@ -128,41 +155,17 @@ private fun NonFungibleAssetDialogContent(
                             )
                         }
                     }
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                    if (state.item != null) {
-                        state.item.name?.let { name ->
-                            AssetMetadataRow(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = RadixTheme.dimensions.paddingXLarge),
-                                key = stringResource(id = R.string.assetDetails_name)
-                            ) {
-                                Text(
-                                    text = name,
-                                    style = RadixTheme.typography.body1HighImportance,
-                                    color = RadixTheme.colors.gray1
-                                )
-                            }
-                        }
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
 
-                        state.item.description?.let { description ->
-                            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                            AssetMetadataRow(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = RadixTheme.dimensions.paddingXLarge),
-                                key = stringResource(id = R.string.assetDetails_NFTDetails_description)
-                            ) {
-                                Text(
-                                    text = description,
-                                    style = RadixTheme.typography.body1HighImportance,
-                                    color = RadixTheme.colors.gray1,
-                                    textAlign = TextAlign.End
-                                )
-                            }
-                        }
+                    if (!state.item?.nonStandardMetadata.isNullOrEmpty()) {
+                        HorizontalDivider(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = RadixTheme.dimensions.paddingLarge),
+                            color = RadixTheme.colors.gray4
+                        )
 
-                        state.item.nonStandardMetadata.forEach { metadata ->
+                        state.item?.nonStandardMetadata?.forEach { metadata ->
                             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                             metadata.View(
                                 modifier = Modifier
@@ -170,23 +173,14 @@ private fun NonFungibleAssetDialogContent(
                                     .padding(horizontal = RadixTheme.dimensions.paddingXLarge)
                             )
                         }
-                    } else {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(16.dp)
-                                .padding(horizontal = RadixTheme.dimensions.paddingXLarge)
-                                .radixPlaceholder(visible = true)
-                        )
+
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
                     }
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                 }
 
                 if (state.localId != null) {
                     HorizontalDivider(
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(top = RadixTheme.dimensions.paddingDefault),
+                        modifier = Modifier.fillMaxWidth(),
                         color = RadixTheme.colors.gray4
                     )
                 }
@@ -241,7 +235,7 @@ private fun NonFungibleAssetDialogContent(
                             .padding(horizontal = RadixTheme.dimensions.paddingXLarge),
                         address = state.resourceAddress
                     )
-                    if (!state.resource?.name.isNullOrBlank()) {
+                    if (!state.resource?.name.isNullOrBlank() && state.localId != null) {
                         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                         AssetMetadataRow(
                             modifier = Modifier


### PR DESCRIPTION
## Description
Data will be displayed in new line when 
1. They are of URL type
2. of String type with more than 40 chars. In the case of strings if they take more than 5 lines to display, we truncate them with a `...Show More` button as previously.

## Video
[short-long.webm](https://github.com/radixdlt/babylon-wallet-android/assets/125959264/24c6cf47-596f-44cf-a9f9-ae56f5379842)

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works