### PR TITLE
ABW-2525 - Introduced specific error type when receiving account does not allow deposits.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -66,6 +66,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
         data class SignCompiledTransactionIntent(override val cause: Throwable? = null) : PrepareTransactionException(cause)
         data class PrepareNotarizedTransaction(override val cause: Throwable? = null) : PrepareTransactionException(cause)
         data class SubmitNotarizedTransaction(override val cause: Throwable? = null) : PrepareTransactionException()
+        data object ReceivingAccountDoesNotAllowDeposits : PrepareTransactionException()
 
         override val ceError: ConnectorExtensionError
             get() = when (this) {
@@ -79,6 +80,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
 
                 CompileTransactionIntent -> WalletErrorType.FailedToCompileTransaction
                 is SignCompiledTransactionIntent -> WalletErrorType.FailedToSignTransaction
+                ReceivingAccountDoesNotAllowDeposits -> WalletErrorType.FailedToPrepareTransaction
             }
     }
 
@@ -291,7 +293,10 @@ fun RadixWalletException.PrepareTransactionException.toUserFriendlyMessage(conte
                 R.string.error_transactionFailure_noFundsToApproveTransaction
 
             RadixWalletException.PrepareTransactionException.CompileTransactionIntent -> R.string.error_transactionFailure_prepare
-            is RadixWalletException.PrepareTransactionException.SignCompiledTransactionIntent -> R.string.error_transactionFailure_prepare
+            is RadixWalletException.PrepareTransactionException.SignCompiledTransactionIntent ->
+                R.string.error_transactionFailure_prepare
+            RadixWalletException.PrepareTransactionException.ReceivingAccountDoesNotAllowDeposits ->
+                R.string.error_transactionFailure_doesNotAllowThirdPartyDeposits
         }
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/UiMessage.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/UiMessage.kt
@@ -87,13 +87,22 @@ sealed class UiMessage(val id: String = UUIDGenerator.uuid().toString()) {
         private val error: Throwable?
     ) : UiMessage() {
 
-        val isDepositRulesErrorVisible = error is RadixWalletException.PrepareTransactionException
+        private val isDepositRulesErrorVisible = error is RadixWalletException.PrepareTransactionException
             .ReceivingAccountDoesNotAllowDeposits
 
-        val isNoMnemonicErrorVisible = error?.cause is ProfileException.NoMnemonic
+        private val isNoMnemonicErrorVisible = error?.cause is ProfileException.NoMnemonic
 
         val isPreviewedInDialog: Boolean
             get() = isDepositRulesErrorVisible || isNoMnemonicErrorVisible
+
+        @Composable
+        fun getTitle(): String {
+            return if (isNoMnemonicErrorVisible) {
+                stringResource(id = R.string.transactionReview_noMnemonicError_title)
+            } else {
+                stringResource(id = R.string.common_errorAlertTitle)
+            }
+        }
 
         @Composable
         override fun getMessage(): String {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -117,8 +117,7 @@ fun TransactionReviewScreen(
         onTipPercentageChanged = viewModel::onTipPercentageChanged,
         onViewDefaultModeClick = viewModel::onViewDefaultModeClick,
         onViewAdvancedModeClick = viewModel::onViewAdvancedModeClick,
-        dismissNoMnemonicErrorDialog = viewModel::dismissNoMnemonicErrorDialog,
-        dismissDepositRulesErrorDialog = viewModel::dismissDepositRulesErrorDialog
+        dismissTransactionErrorDialog = viewModel::dismissTransactionErrorDialog
     )
 
     state.interactionState?.let {
@@ -175,8 +174,7 @@ private fun TransactionPreviewContent(
     onTipPercentageChanged: (String) -> Unit,
     onViewDefaultModeClick: () -> Unit,
     onViewAdvancedModeClick: () -> Unit,
-    dismissNoMnemonicErrorDialog: () -> Unit,
-    dismissDepositRulesErrorDialog: () -> Unit
+    dismissTransactionErrorDialog: () -> Unit
 ) {
     val modalBottomSheetState = rememberModalBottomSheetState(
         initialValue = ModalBottomSheetValue.Hidden,
@@ -186,29 +184,15 @@ private fun TransactionPreviewContent(
 
     state.error?.let { transactionError ->
         if (transactionError.isPreviewedInDialog) {
-            if (transactionError.isNoMnemonicErrorVisible) {
-                BasicPromptAlertDialog(
-                    finish = {
-                        dismissNoMnemonicErrorDialog()
-                    },
-                    title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
-                    text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
-                    dismissText = null
-                )
-            }
-            if (transactionError.isDepositRulesErrorVisible) {
-                val body = stringResource(id = R.string.error_transactionFailure_reviewFailure)
-                val subBody = stringResource(id = R.string.error_transactionFailure_doesNotAllowThirdPartyDeposits)
-                BasicPromptAlertDialog(
-                    finish = {
-                        dismissDepositRulesErrorDialog()
-                    },
-                    title = stringResource(id = R.string.common_errorAlertTitle),
-                    text = "$body\n\n$subBody",
-                    confirmText = stringResource(id = R.string.common_ok),
-                    dismissText = null
-                )
-            }
+            BasicPromptAlertDialog(
+                finish = {
+                    dismissTransactionErrorDialog()
+                },
+                title = transactionError.getTitle(),
+                text = transactionError.getMessage(),
+                confirmText = stringResource(id = R.string.common_ok),
+                dismissText = null
+            )
         } else {
             SnackbarUIMessage(
                 message = transactionError,
@@ -507,8 +491,7 @@ fun TransactionPreviewContentPreview() {
             onTipPercentageChanged = {},
             onViewDefaultModeClick = {},
             onViewAdvancedModeClick = {},
-            dismissDepositRulesErrorDialog = {},
-            dismissNoMnemonicErrorDialog = {}
+            dismissTransactionErrorDialog = {}
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -89,6 +89,19 @@ fun TransactionReviewScreen(
             dismissText = null
         )
     }
+    if (state.isDepositRulesErrorVisible) {
+        val body = stringResource(id = R.string.error_transactionFailure_reviewFailure)
+        val subBody = stringResource(id = R.string.error_transactionFailure_doesNotAllowThirdPartyDeposits)
+        BasicPromptAlertDialog(
+            finish = {
+                viewModel.dismissDepositRulesErrorDialog()
+            },
+            title = stringResource(id = R.string.common_errorAlertTitle),
+            text = "$body\n\n$subBody",
+            confirmText = stringResource(id = R.string.common_ok),
+            dismissText = null
+        )
+    }
 
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.collect {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -220,11 +220,7 @@ class TransactionReviewViewModel @Inject constructor(
         }
     }
 
-    fun dismissNoMnemonicErrorDialog() {
-        _state.update { it.copy(error = null) }
-    }
-
-    fun dismissDepositRulesErrorDialog() {
+    fun dismissTransactionErrorDialog() {
         _state.update { it.copy(error = null) }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -224,6 +224,10 @@ class TransactionReviewViewModel @Inject constructor(
         _state.update { it.copy(isNoMnemonicErrorVisible = false) }
     }
 
+    fun dismissDepositRulesErrorDialog() {
+        _state.update { it.copy(isDepositRulesErrorVisible = false) }
+    }
+
     sealed interface Event : OneOffEvent {
         data class OnFungibleClick(
             val resource: FungibleResource,
@@ -252,6 +256,7 @@ class TransactionReviewViewModel @Inject constructor(
         private val latestFeesMode: Sheet.CustomizeFees.FeesMode = Sheet.CustomizeFees.FeesMode.Default,
         val error: UiMessage? = null,
         val isNoMnemonicErrorVisible: Boolean = false,
+        val isDepositRulesErrorVisible: Boolean = false,
         val ephemeralNotaryPrivateKey: PrivateKey = PrivateKey.EddsaEd25519.newRandom(),
         val interactionState: InteractionState? = null,
         val isTransactionDismissed: Boolean = false

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -221,11 +221,11 @@ class TransactionReviewViewModel @Inject constructor(
     }
 
     fun dismissNoMnemonicErrorDialog() {
-        _state.update { it.copy(isNoMnemonicErrorVisible = false) }
+        _state.update { it.copy(error = null) }
     }
 
     fun dismissDepositRulesErrorDialog() {
-        _state.update { it.copy(isDepositRulesErrorVisible = false) }
+        _state.update { it.copy(error = null) }
     }
 
     sealed interface Event : OneOffEvent {
@@ -254,9 +254,7 @@ class TransactionReviewViewModel @Inject constructor(
         val defaultSignersCount: Int = 0,
         val sheetState: Sheet = Sheet.None,
         private val latestFeesMode: Sheet.CustomizeFees.FeesMode = Sheet.CustomizeFees.FeesMode.Default,
-        val error: UiMessage? = null,
-        val isNoMnemonicErrorVisible: Boolean = false,
-        val isDepositRulesErrorVisible: Boolean = false,
+        val error: UiMessage.TransactionErrorMessage? = null,
         val ephemeralNotaryPrivateKey: PrivateKey = PrivateKey.EddsaEd25519.newRandom(),
         val interactionState: InteractionState? = null,
         val isTransactionDismissed: Boolean = false

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -164,12 +164,19 @@ class TransactionAnalysisDelegate @Inject constructor(
     private fun reportFailure(error: Throwable) {
         logger.w(error)
 
+        val isDepositRulesFailure = error is RadixWalletException.PrepareTransactionException
+            .ReceivingAccountDoesNotAllowDeposits
         _state.update {
             it.copy(
                 isLoading = false,
                 isNetworkFeeLoading = false,
+                isDepositRulesErrorVisible = isDepositRulesFailure,
                 previewType = PreviewType.None,
-                error = UiMessage.ErrorMessage(error)
+                error = if (isDepositRulesFailure.not()) {
+                    UiMessage.ErrorMessage(error)
+                } else {
+                    it.error
+                }
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -85,7 +85,7 @@ class TransactionAnalysisDelegate @Inject constructor(
             // wallet unacceptable manifest
             _state.update {
                 it.copy(
-                    error = UiMessage.ErrorMessage(RadixWalletException.DappRequestException.UnacceptableManifest)
+                    error = UiMessage.TransactionErrorMessage(RadixWalletException.DappRequestException.UnacceptableManifest)
                 )
             }
             PreviewType.UnacceptableManifest
@@ -164,19 +164,12 @@ class TransactionAnalysisDelegate @Inject constructor(
     private fun reportFailure(error: Throwable) {
         logger.w(error)
 
-        val isDepositRulesFailure = error is RadixWalletException.PrepareTransactionException
-            .ReceivingAccountDoesNotAllowDeposits
         _state.update {
             it.copy(
                 isLoading = false,
                 isNetworkFeeLoading = false,
-                isDepositRulesErrorVisible = isDepositRulesFailure,
                 previewType = PreviewType.None,
-                error = if (isDepositRulesFailure.not()) {
-                    UiMessage.ErrorMessage(error)
-                } else {
-                    it.error
-                }
+                error = UiMessage.TransactionErrorMessage(error)
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -285,14 +285,14 @@ private fun RadixBanner(
                 )
 
                 Text(
-                    text = stringResource(id = R.string.homePage_radixBanner_title),
+                    text = "", // stringResource(id = R.string.homePage_radixBanner_title),
                     style = RadixTheme.typography.body1Header,
                     color = RadixTheme.colors.gray1,
                     maxLines = 1,
                 )
 
                 Text(
-                    text = stringResource(id = R.string.homePage_radixBanner_subtitle),
+                    text = "", // stringResource(id = R.string.homePage_radixBanner_subtitle),
                     style = RadixTheme.typography.body2Regular,
                     color = RadixTheme.colors.gray2,
                     textAlign = TextAlign.Center
@@ -301,7 +301,7 @@ private fun RadixBanner(
                 val context = LocalContext.current
                 RadixSecondaryButton(
                     modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(id = R.string.homePage_radixBanner_action),
+                    text = "", // stringResource(id = R.string.homePage_radixBanner_action),
                     contentColor = RadixTheme.colors.gray1,
                     onClick = {
                         context.openUrl(RADIX_START_PAGE_URL)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -506,6 +506,7 @@ You can always change the guarantee from this default in each transaction.</stri
   <string name="error_transactionFailure_prepare">Failed to prepare transaction</string>
   <string name="error_transactionFailure_rejected">Transaction rejected</string>
   <string name="error_transactionFailure_unknown">Unknown error</string>
+  <string name="error_transactionFailure_doesNotAllowThirdPartyDeposits">One of the receiving accounts does not allow Third-Party deposits</string>
   <string name="error_transactionFailure_failedToFindLedger">Failed to find ledger</string>
   <string name="error_transactionFailure_failedToAddLockFee">Failed to add Transaction Fee, try a different amount of fee payer.</string>
   <string name="error_transactionFailure_failedToAddGuarantee">Failed to add Guarantee, try a different percentage, or try skip adding a guarantee.</string>


### PR DESCRIPTION
## Description
This PR introduce specific error type when receiving account does not allow deposits.
Please follow iOS PR for more info -> https://github.com/radixdlt/babylon-wallet-ios/pull/908

## How to test

1. Follow video attached here (including account QR code to scan) -> https://github.com/radixdlt/babylon-wallet-ios/pull/908

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/dc578cfd-2bc4-4885-8722-061b2c9832f4" width="300">


## PR submission checklist
- [x] I have tested transfer to account that does not allow deposits and verified that we see correct error message
