### PR TITLE
Fix check for filtering out validators with stakes

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
@@ -59,7 +59,7 @@ data class Assets(
     val ownedValidatorsWithStakes: List<ValidatorWithStakes> by lazy {
         validatorsWithStakes.filterNot {
             (it.liquidStakeUnit == null || it.liquidStakeUnit.fungibleResource.ownedAmount == BigDecimal.ZERO) &&
-            (it.stakeClaimNft == null || it.stakeClaimNft.nonFungibleResource.amount == 0L)
+                (it.stakeClaimNft == null || it.stakeClaimNft.nonFungibleResource.amount == 0L)
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
@@ -85,7 +85,7 @@ data class Assets(
 
     fun fungiblesSize(): Int = ownedFungibles.size
 
-    fun nftsSize(): Int = ownedNonFungibles.sumOf { it.amount }.toInt()
+    fun nonFungiblesSize(): Int = ownedNonFungibles.size
 
     fun poolUnitsSize(): Int = ownedPoolUnits.size + ownedValidatorsWithStakes.size
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
@@ -58,8 +58,8 @@ data class Assets(
 
     val ownedValidatorsWithStakes: List<ValidatorWithStakes> by lazy {
         validatorsWithStakes.filterNot {
-            (it.stakeClaimNft == null || it.stakeClaimNft.nonFungibleResource.amount == 0L) &&
-                it.liquidStakeUnit?.fungibleResource?.ownedAmount == BigDecimal.ZERO
+            (it.liquidStakeUnit == null || it.liquidStakeUnit.fungibleResource.ownedAmount == BigDecimal.ZERO) &&
+            (it.stakeClaimNft == null || it.stakeClaimNft.nonFungibleResource.amount == 0L)
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
@@ -40,7 +40,7 @@ fun LazyListScope.nftsTab(
     collapsibleAssetsState: SnapshotStateMap<String, Boolean>,
     action: AssetsViewAction
 ) {
-    if (assets.nftsSize() == 0) {
+    if (assets.nonFungiblesSize() == 0) {
         item {
             EmptyResourcesContent(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountAssetsRow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountAssetsRow.kt
@@ -93,7 +93,7 @@ private fun AssetsContent(
             val all = assets.ownedFungibles
             all.take(maxVisibleFungibles) to (all.size - maxVisibleFungibles).coerceAtLeast(minimumValue = 0)
         }
-        val nftsCount = remember(assets.nonFungibles) { assets.nftsSize() }
+        val nftsCount = remember(assets.nonFungibles) { assets.nonFungiblesSize() }
         val poolUnitCount = remember(assets.poolUnits, assets.validatorsWithStakes) {
             assets.poolUnitsSize()
         }
@@ -159,7 +159,7 @@ private fun AssetsContent(
                     modifier = Modifier
                         .align(Alignment.CenterStart)
                         .height(iconSize),
-                    text = "${assets.nftsSize()}",
+                    text = "${assets.nonFungiblesSize()}",
                     contentPadding = PaddingValues(
                         start = iconSize + RadixTheme.dimensions.paddingSmall,
                         end = RadixTheme.dimensions.paddingSmall


### PR DESCRIPTION
## Description
This pr fixes the issue for not filtering out correctly validators with stakes that their stake claim is null. Also this PR replaces the number shown in the assets row regarding nfts. It now depicts the number of non-fungible resources the user owns.


## How to test
Use the profile Umair posted in the ticket. You will see the correct validators shown.

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
