### PR TITLE
Upgrade gradle to 8.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.1.1' apply false
-    id 'com.android.library' version '8.1.1' apply false
+    id 'com.android.application' version '8.2.0' apply false
+    id 'com.android.library' version '8.2.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.10' apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.10'
     id 'org.jetbrains.kotlin.jvm' version '1.9.10' apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 13 13:39:31 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description
Upgrade gradle to 8.2 and get rid of the pop up notification update in Android Studio.

The app has been tested in two different devices after the upgrade. ✅ 
The unit tests run successfully locally. ✅ 
