### PR TITLE
[ABW-2684] Check link connection state before proceeding with account recovery

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/ChooseLedgerViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/ChooseLedgerViewModel.kt
@@ -117,26 +117,26 @@ class ChooseLedgerViewModel @Inject constructor(
             selectableLedgerDevice.selected
         }?.let { ledgerFactorSource ->
             viewModelScope.launch {
+                if (getProfileUseCase.p2pLinks.first().isEmpty()) {
+                    _state.update {
+                        it.copy(showContent = ChooseLedgerUiState.ShowContent.LinkNewConnector(false))
+                    }
+                    return@launch
+                } else {
+                    if (!state.value.isLinkConnectionEstablished) {
+                        _state.update {
+                            it.copy(
+                                showLinkConnectorPromptState = ShowLinkConnectorPromptState.Show(
+                                    ShowLinkConnectorPromptState.Source.UseLedger
+                                )
+                            )
+                        }
+                        return@launch
+                    }
+                }
                 when (args.ledgerSelectionPurpose) {
                     LedgerSelectionPurpose.CreateAccount -> {
                         // check again if link connector exists
-                        if (getProfileUseCase.p2pLinks.first().isEmpty()) {
-                            _state.update {
-                                it.copy(showContent = ChooseLedgerUiState.ShowContent.LinkNewConnector(false))
-                            }
-                            return@launch
-                        } else {
-                            if (!state.value.isLinkConnectionEstablished) {
-                                _state.update {
-                                    it.copy(
-                                        showLinkConnectorPromptState = ShowLinkConnectorPromptState.Show(
-                                            ShowLinkConnectorPromptState.Source.UseLedger
-                                        )
-                                    )
-                                }
-                                return@launch
-                            }
-                        }
                         if (ensureBabylonFactorSourceExistUseCase.babylonFactorSourceExist().not()) {
                             val authenticationResult = deviceBiometricAuthenticationProvider()
                             if (authenticationResult) {


### PR DESCRIPTION
## Description
PR adds active link connection check when user taps "Continue" when selecting ledger in MARS.

## How to test

1. Open app go to settings/account recovery and pick ledger option.
2. Add ledger (if not already added).
3. While being on "Choose ledger" screen unlink CE in browser.
4. Select ledger and tap continue.

After this fix wallet detect that there is no CE connection and prompt user to link.

## PR submission checklist
- [x] I have tested that user is asked to link new CE if current one is unlinked from the browser
