### PR TITLE
Refactor entity creation

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithBabylonDeviceFactorSourceUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithBabylonDeviceFactorSourceUseCase.kt
@@ -8,14 +8,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
-import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.extensions.mainBabylonFactorSource
-import rdx.works.profile.data.model.factorsources.DerivationPathScheme
 import rdx.works.profile.data.model.pernetwork.Network
 import rdx.works.profile.data.model.pernetwork.addAccounts
-import rdx.works.profile.data.model.pernetwork.nextAccountIndex
-import rdx.works.profile.data.model.pernetwork.nextAppearanceId
 import rdx.works.profile.data.repository.MnemonicRepository
 import rdx.works.profile.data.repository.ProfileRepository
 import rdx.works.profile.derivation.model.NetworkId
@@ -34,28 +30,19 @@ class CreateAccountWithBabylonDeviceFactorSourceUseCase @Inject constructor(
     private val _interactionState = MutableStateFlow<InteractionState?>(null)
     val interactionState: Flow<InteractionState?> = _interactionState.asSharedFlow()
 
-    suspend operator fun invoke(
-        displayName: String,
-        networkID: NetworkId? = null
-    ): Network.Account {
+    suspend operator fun invoke(displayName: String): Network.Account {
         return withContext(defaultDispatcher) {
             val profile = ensureBabylonFactorSourceExistUseCase()
-            val factorSource = profile.mainBabylonFactorSource()
-                ?: error("Babylon factor source is not present")
+            val factorSource = profile.mainBabylonFactorSource() ?: error("Babylon factor source is not present")
             _interactionState.update { InteractionState.Device.DerivingAccounts(factorSource) }
 
-            // Construct new account
-            val networkId = networkID ?: profile.currentNetwork?.knownNetworkId ?: Radix.Gateway.default.network.networkId()
-            val nextAccountIndex = profile.nextAccountIndex(DerivationPathScheme.CAP_26, networkId, factorSource.id)
-            val nextAppearanceId = profile.nextAppearanceId(networkId)
             val mnemonicWithPassphrase = requireNotNull(mnemonicRepository.readMnemonic(factorSource.id).getOrNull())
-            val newAccount = Network.Account.initAccountWithBabylonDeviceFactorSource(
-                entityIndex = nextAccountIndex,
+
+            val newAccount = profile.currentNetwork.createAccountWithBabylon(
                 displayName = displayName,
                 mnemonicWithPassphrase = mnemonicWithPassphrase,
                 deviceFactorSource = factorSource,
-                networkId = networkId,
-                appearanceID = nextAppearanceId
+                onLedgerSettings = Network.Account.OnLedgerSettings.init()
             )
             val resolveResult = resolveAccountsLedgerStateRepository.invoke(listOf(newAccount))
             // Add account to the profile
@@ -66,7 +53,7 @@ class CreateAccountWithBabylonDeviceFactorSourceUseCase @Inject constructor(
             }
             val updatedProfile = profile.addAccounts(
                 accounts = listOf(accountToAdd),
-                onNetwork = networkId
+                onNetwork = NetworkId.from(profile.currentNetwork.networkID)
             )
             // Save updated profile
             profileRepository.saveProfile(updatedProfile)

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithLedgerFactorSourceUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithLedgerFactorSourceUseCase.kt
@@ -39,10 +39,12 @@ class CreateAccountWithLedgerFactorSourceUseCase @Inject constructor(
                     it.id == ledgerFactorSourceID
                 } as LedgerHardwareWalletFactorSource
             // Construct new account
-            val networkId = networkID ?: profile.currentNetwork?.knownNetworkId ?: Radix.Gateway.default.network.networkId()
+            val networkId = networkID ?: profile.currentNetwork.knownNetworkId ?: Radix.Gateway.default.network.networkId()
             val totalAccountsOnNetwork = profile.networks.find { it.networkID == networkId.value }?.accounts?.size ?: 0
             val newAccount = Network.Account.initAccountWithLedgerFactorSource(
-                entityIndex = profile.nextAccountIndex(derivationPath.scheme, networkId, ledgerFactorSourceID),
+                entityIndex = profile.currentNetwork.nextAccountIndex(
+                    ledgerHardwareWalletFactorSource
+                ), // nextAccountIndex(derivationPath.scheme, networkId, ledgerFactorSourceID),
                 displayName = displayName,
                 derivedPublicKeyHex = derivedPublicKeyHex,
                 ledgerFactorSource = ledgerHardwareWalletFactorSource,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountViewModel.kt
@@ -145,10 +145,7 @@ class CreateAccountViewModel @Inject constructor(
                 sendEvent(CreateAccountEvent.AddLedgerDevice(args.networkId))
             } else {
                 handleAccountCreate { name, networkId ->
-                    createAccountWithBabylonDeviceFactorSourceUseCase(
-                        displayName = name,
-                        networkID = networkId
-                    )
+                    createAccountWithBabylonDeviceFactorSourceUseCase(displayName = name)
                 }
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/ChooseLedgerViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/ChooseLedgerViewModel.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.core.UUIDGenerator
-import rdx.works.profile.data.model.factorsources.DerivationPathScheme
+import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.factorsources.LedgerHardwareWalletFactorSource
 import rdx.works.profile.domain.EnsureBabylonFactorSourceExistUseCase
@@ -146,14 +146,14 @@ class ChooseLedgerViewModel @Inject constructor(
                                 return@launch
                             }
                         }
-                        val derivationPath = getProfileUseCase.nextDerivationPathForAccountOnNetwork(
-                            DerivationPathScheme.CAP_26,
-                            networkIdToCreateAccountOn(),
-                            ledgerFactorSource.data.id
-                        )
+                        val derivationPath = getProfileUseCase.invoke().first()
+                            .currentNetwork
+                            .nextDerivationPathForAccountOnNetwork(ledgerFactorSource.data)
                         val result = ledgerMessenger.sendDerivePublicKeyRequest(
                             interactionId = UUIDGenerator.uuid().toString(),
-                            keyParameters = listOf(LedgerInteractionRequest.KeyParameters(Curve.Curve25519, derivationPath.path)),
+                            keyParameters = listOf(
+                                LedgerInteractionRequest.KeyParameters(Curve.Curve25519, derivationPath.path)
+                            ),
                             ledgerDevice = LedgerInteractionRequest.LedgerDevice.from(ledgerFactorSource.data)
                         )
                         result.onSuccess { response ->

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithLedgerFactorSourceUseCaseTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithLedgerFactorSourceUseCaseTest.kt
@@ -15,7 +15,7 @@ import org.mockito.kotlin.whenever
 import rdx.works.profile.data.model.MnemonicWithPassphrase
 import rdx.works.profile.data.model.ProfileState
 import rdx.works.profile.data.model.apppreferences.Radix
-import rdx.works.profile.data.model.factorsources.DerivationPathScheme
+import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.pernetwork.DerivationPath
 import rdx.works.profile.data.model.pernetwork.addAccounts
 import rdx.works.profile.data.model.pernetwork.nextAccountIndex
@@ -55,11 +55,7 @@ internal class CreateAccountWithLedgerFactorSourceUseCaseTest {
             )
             val derivationPath = DerivationPath.forAccount(
                 networkId = network.networkId(),
-                accountIndex = profile.nextAccountIndex(
-                    derivationPathScheme = DerivationPathScheme.CAP_26,
-                    forNetworkId = network.networkId(),
-                    factorSourceID = TestData.ledgerFactorSource.id
-                ),
+                accountIndex = profile.currentNetwork.nextAccountIndex(TestData.ledgerFactorSource),
                 keyType = KeyType.TRANSACTION_SIGNING
             )
             val account = createAccountWithLedgerFactorSourceUseCase(

--- a/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
@@ -130,10 +130,17 @@ data class Profile(
 val Profile.currentGateway: Radix.Gateway
     get() = appPreferences.gateways.current()
 
-val Profile.currentNetwork: Network?
+val Profile.currentNetwork: Network
     get() {
         val currentGateway = currentGateway
-        return networks.find { it.networkID == currentGateway.network.id }
+        return networks.find {
+            it.networkID == currentGateway.network.id
+        } ?: Network(
+            networkID = Radix.Gateway.default.network.id,
+            accounts = identifiedArrayListOf(),
+            personas = identifiedArrayListOf(),
+            authorizedDapps = emptyList()
+        )
     }
 
 /**

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -14,7 +14,6 @@ import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.extensions.factorSourceId
 import rdx.works.profile.data.model.extensions.usesCurve25519
 import rdx.works.profile.data.model.extensions.usesSecp256k1
-import rdx.works.profile.data.model.factorsources.DerivationPathScheme
 import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.factorsources.EntityFlag
 import rdx.works.profile.data.model.factorsources.FactorSource
@@ -126,16 +125,10 @@ suspend fun GetProfileUseCase.accountOnCurrentNetwork(
     account.address == withAddress
 }
 
-suspend fun GetProfileUseCase.nextDerivationPathForAccountOnNetwork(
-    derivationPathScheme: DerivationPathScheme,
-    networkId: Int,
-    factorSourceId: FactorSource.FactorSourceID
-): DerivationPath {
-    val profile = invoke().first()
-    val network = requireNotNull(NetworkId.from(networkId))
+fun Network.nextDerivationPathForAccountOnNetwork(factorSource: FactorSource): DerivationPath {
     return DerivationPath.forAccount(
-        networkId = network,
-        accountIndex = profile.nextAccountIndex(derivationPathScheme, network, factorSourceId),
+        networkId = NetworkId.from(this.networkID),
+        accountIndex = this.nextAccountIndex(factorSource),
         keyType = KeyType.TRANSACTION_SIGNING
     )
 }

--- a/profile/src/main/java/rdx/works/profile/domain/account/MigrateOlympiaAccountsUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/account/MigrateOlympiaAccountsUseCase.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.currentNetwork
+import rdx.works.profile.data.model.extensions.mainBabylonFactorSource
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.factorsources.Slip10Curve
 import rdx.works.profile.data.model.pernetwork.DerivationPath
@@ -32,8 +33,12 @@ class MigrateOlympiaAccountsUseCase @Inject constructor(
     ): List<Network.Account> {
         return withContext(defaultDispatcher) {
             val profile = profileRepository.profile.first()
-            val networkId = profile.currentNetwork?.knownNetworkId ?: Radix.Gateway.default.network.networkId()
-            val appearanceIdOffset = profile.nextAppearanceId(networkId)
+            val networkId = profile.currentNetwork.knownNetworkId ?: Radix.Gateway.default.network.networkId()
+            var appearanceIdOffset = 0
+            val babylonFactorSource = profile.mainBabylonFactorSource()
+            if (babylonFactorSource != null) {
+                appearanceIdOffset = profile.currentNetwork.nextAppearanceId(babylonFactorSource)
+            }
             val migratedAccounts = olympiaAccounts.mapIndexed { index, olympiaAccount ->
                 val babylonAddress = Address.virtualAccountAddressFromOlympiaAddress(
                     olympiaAccountAddress = OlympiaAddress(olympiaAccount.address),

--- a/profile/src/test/java/rdx/works/profile/ProfileGenerationTest.kt
+++ b/profile/src/test/java/rdx/works/profile/ProfileGenerationTest.kt
@@ -12,10 +12,12 @@ import rdx.works.profile.data.model.MnemonicWithPassphrase
 import rdx.works.profile.data.model.Profile
 import rdx.works.profile.data.model.apppreferences.P2PLink
 import rdx.works.profile.data.model.apppreferences.Radix
+import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.extensions.addP2PLink
 import rdx.works.profile.data.model.extensions.renameAccountDisplayName
 import rdx.works.profile.data.model.factorsources.DerivationPathScheme
 import rdx.works.profile.data.model.factorsources.DeviceFactorSource
+import rdx.works.profile.data.model.pernetwork.Network
 import rdx.works.profile.data.model.pernetwork.Network.Account.Companion.initAccountWithBabylonDeviceFactorSource
 import rdx.works.profile.data.model.pernetwork.Network.Persona.Companion.init
 import rdx.works.profile.data.model.pernetwork.addAccounts
@@ -52,10 +54,8 @@ class ProfileGenerationTest {
         assertEquals(
             "Next derivation index for first account",
             0,
-            profile.nextAccountIndex(
-                derivationPathScheme = DerivationPathScheme.CAP_26,
-                forNetworkId = defaultNetwork.networkId(),
-                factorSourceID = babylonFactorSource.id
+            profile.currentNetwork.nextAccountIndex(
+                factorSource = babylonFactorSource
             )
         )
 
@@ -85,10 +85,8 @@ class ProfileGenerationTest {
         assertEquals(
             "Next derivation index for second account",
             1,
-            profile.nextAccountIndex(
-                derivationPathScheme = DerivationPathScheme.CAP_26,
-                forNetworkId = defaultNetwork.networkId(),
-                factorSourceID = babylonFactorSource.id
+            profile.currentNetwork.nextAccountIndex(
+                factorSource = babylonFactorSource
             )
         )
 


### PR DESCRIPTION
_Please take your time to read the description, keep notes for comments/questions. Feel free to post them here, or let's take them in the next Android chapter meeting._

## Description
The purpose of this refactoring is to
- create entities on the current active network. At the moment, we pass the networkId, entityIndex, and appearanceIndex, information that is already known on the current network. Why not to get this information from the already known current network?
- as a result of the above, assign the duty of entity creation on the `Network` and not on the `Profile`

#### This PR showcases the account creation with Babylon factor source and some of the benefits are:
- less profile-related logic in usecases and viewmodels. We keep it simple. A create account use case needs to pass only the display name, mnemonic, the factor source, and onLedgerSettings.
- entity creation is a duty of the `Network` : `EntityCreation`. No need to pass around the information since now the current network has all the information is needed to create an entity.

#### So far I tested the following test cases:
- create a new wallet with a new account. Switch network (stokenet) to create another account.
- create a new account on existing wallet. Switch network (stokenet) to create another account.
- restore from profile json file and create a new account on all available networks
- restore from profile json file but skipped to enter the seed phrase and create a new account on all available networks
- restore from main seed phrase and create new account

All tests succeded.

#### Things to consider
`mainBabylonFactorSource`. I more or less understand the idea behind this extension. However it is used in many many places! IMO when we use this extension almost everywhere as a fallback it is a sign of a bad design. When for example we ask for the `appearanceIndex` and we call the `mainBabylonFactorSource` in the extension function of the `appearanceIndex` is somehow strange, right? It looks like a function that should be called once or maybe twice from the "top/beginning" of the profile or account creation. 


