### PR TITLE
ABW-2664 - ModalBottomSheet migrated towards material3.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
@@ -28,9 +28,7 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -42,6 +40,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -50,7 +49,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -86,7 +84,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 import rdx.works.profile.data.model.pernetwork.Network.Account.OnLedgerSettings.ThirdPartyDeposits
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SpecificAssetsDepositsScreen(
     sharedViewModel: AccountThirdPartyDepositsViewModel,
@@ -96,8 +94,7 @@ fun SpecificAssetsDepositsScreen(
     val state by sharedViewModel.state.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true
+        skipPartiallyExpanded = true
     )
     val kb = LocalSoftwareKeyboardController.current
     val hideCallback = {
@@ -151,52 +148,55 @@ fun SpecificAssetsDepositsScreen(
             )
         )
     }
-    DefaultModalSheetLayout(
-        modifier = modifier,
-        wrapContent = true,
-        sheetContent = {
-            AddAssetSheet(
-                onResourceAddressChanged = sharedViewModel::assetExceptionAddressTyped,
-                asset = state.assetExceptionToAdd,
-                onAddAsset = {
-                    hideCallback()
-                    sharedViewModel.onAddAssetException()
-                },
-                modifier = Modifier
-                    .navigationBarsPadding()
-                    .fillMaxWidth()
-                    .background(RadixTheme.colors.gray4)
-                    .clip(RadixTheme.shapes.roundedRectTopDefault),
-                onAssetExceptionRuleChanged = sharedViewModel::onAssetExceptionRuleChanged,
-                onDismiss = {
-                    hideCallback()
+
+    SpecificAssetsDepositsContent(
+        onBackClick = onBackClick,
+        onMessageShown = sharedViewModel::onMessageShown,
+        error = state.error,
+        onShowAddAssetSheet = {
+            sharedViewModel.onAssetExceptionRuleChanged(
+                when (it) {
+                    SpecificAssetsTab.Allowed -> ThirdPartyDeposits.DepositAddressExceptionRule.Allow
+                    SpecificAssetsTab.Denied -> ThirdPartyDeposits.DepositAddressExceptionRule.Deny
                 }
             )
+            scope.launch {
+                sheetState.show()
+            }
         },
-        sheetState = sheetState
-    ) {
-        SpecificAssetsDepositsContent(
-            onBackClick = onBackClick,
-            onMessageShown = sharedViewModel::onMessageShown,
-            error = state.error,
-            onShowAddAssetSheet = {
-                sharedViewModel.onAssetExceptionRuleChanged(
-                    when (it) {
-                        SpecificAssetsTab.Allowed -> ThirdPartyDeposits.DepositAddressExceptionRule.Allow
-                        SpecificAssetsTab.Denied -> ThirdPartyDeposits.DepositAddressExceptionRule.Deny
+        modifier = Modifier
+            .navigationBarsPadding()
+            .fillMaxSize()
+            .background(RadixTheme.colors.gray5),
+        allowedAssets = state.allowedAssets,
+        deniedAssets = state.deniedAssets,
+        onDeleteAsset = sharedViewModel::showDeletePrompt
+    )
+
+    if (sheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = modifier,
+            wrapContent = true,
+            sheetContent = {
+                AddAssetSheet(
+                    onResourceAddressChanged = sharedViewModel::assetExceptionAddressTyped,
+                    asset = state.assetExceptionToAdd,
+                    onAddAsset = {
+                        hideCallback()
+                        sharedViewModel.onAddAssetException()
+                    },
+                    modifier = Modifier
+                        .navigationBarsPadding()
+                        .fillMaxWidth()
+                        .background(RadixTheme.colors.gray4)
+                        .clip(RadixTheme.shapes.roundedRectTopDefault),
+                    onAssetExceptionRuleChanged = sharedViewModel::onAssetExceptionRuleChanged,
+                    onDismiss = {
+                        hideCallback()
                     }
                 )
-                scope.launch {
-                    sheetState.show()
-                }
             },
-            modifier = Modifier
-                .navigationBarsPadding()
-                .fillMaxSize()
-                .background(RadixTheme.colors.gray5),
-            allowedAssets = state.allowedAssets,
-            deniedAssets = state.deniedAssets,
-            onDeleteAsset = sharedViewModel::showDeletePrompt
+            sheetState = sheetState
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
@@ -19,21 +19,19 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -68,7 +66,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SpecificDepositorScreen(
     sharedViewModel: AccountThirdPartyDepositsViewModel,
@@ -78,8 +76,7 @@ fun SpecificDepositorScreen(
     val state by sharedViewModel.state.collectAsStateWithLifecycle()
     val scope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true
+        skipPartiallyExpanded = true
     )
     val kb = LocalSoftwareKeyboardController.current
     val hideCallback = {
@@ -125,44 +122,47 @@ fun SpecificDepositorScreen(
             )
         )
     }
-    DefaultModalSheetLayout(
-        modifier = modifier.navigationBarsPadding(),
-        sheetContent = {
-            AddDepositorSheet(
-                onResourceAddressChanged = sharedViewModel::depositorAddressTyped,
-                onAddDepositor = {
-                    hideCallback()
-                    sharedViewModel.onAddDepositor()
-                },
-                modifier = Modifier
-                    .navigationBarsPadding()
-                    .fillMaxWidth()
-                    .background(RadixTheme.colors.gray4)
-                    .clip(RadixTheme.shapes.roundedRectTopDefault),
-                depositor = state.depositorToAdd,
-                onDismiss = {
-                    hideCallback()
-                }
-            )
+
+    SpecificDepositorContent(
+        onBackClick = onBackClick,
+        onMessageShown = sharedViewModel::onMessageShown,
+        error = state.error,
+        onShowAddAssetSheet = {
+            scope.launch {
+                sheetState.show()
+            }
         },
-        wrapContent = true,
-        sheetState = sheetState
-    ) {
-        SpecificDepositorContent(
-            onBackClick = onBackClick,
-            onMessageShown = sharedViewModel::onMessageShown,
-            error = state.error,
-            onShowAddAssetSheet = {
-                scope.launch {
-                    sheetState.show()
-                }
+        modifier = Modifier
+            .navigationBarsPadding()
+            .fillMaxSize()
+            .background(RadixTheme.colors.gray5),
+        allowedDepositors = state.allowedDepositorsUiModels,
+        onDeleteDepositor = sharedViewModel::showDeletePrompt
+    )
+
+    if (sheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = modifier.navigationBarsPadding(),
+            sheetContent = {
+                AddDepositorSheet(
+                    onResourceAddressChanged = sharedViewModel::depositorAddressTyped,
+                    onAddDepositor = {
+                        hideCallback()
+                        sharedViewModel.onAddDepositor()
+                    },
+                    modifier = Modifier
+                        .navigationBarsPadding()
+                        .fillMaxWidth()
+                        .background(RadixTheme.colors.gray4)
+                        .clip(RadixTheme.shapes.roundedRectTopDefault),
+                    depositor = state.depositorToAdd,
+                    onDismiss = {
+                        hideCallback()
+                    }
+                )
             },
-            modifier = Modifier
-                .navigationBarsPadding()
-                .fillMaxSize()
-                .background(RadixTheme.colors.gray5),
-            allowedDepositors = state.allowedDepositorsUiModels,
-            onDeleteDepositor = sharedViewModel::showDeletePrompt
+            wrapContent = true,
+            sheetState = sheetState
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalMaterialApi::class)
-
 package com.babylon.wallet.android.presentation.onboarding.restore.backup
 
 import androidx.activity.compose.BackHandler
@@ -20,19 +18,18 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -111,7 +108,7 @@ fun RestoreFromBackupScreen(
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun RestoreFromBackupContent(
     modifier: Modifier = Modifier,
@@ -136,11 +133,10 @@ private fun RestoreFromBackupContent(
     )
 
     val modalBottomSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true
+        skipPartiallyExpanded = true
     )
     SyncSheetState(
-        bottomSheetState = modalBottomSheetState,
+        state = modalBottomSheetState,
         isSheetVisible = state.isPasswordSheetVisible,
         onSheetClosed = {
             if (state.isPasswordSheetVisible) {
@@ -149,190 +145,192 @@ private fun RestoreFromBackupContent(
         }
     )
 
-    DefaultModalSheetLayout(
-        modifier = modifier,
-        sheetState = modalBottomSheetState,
-        enableImePadding = true,
-        wrapContent = true,
-        sheetContent = {
-            if (state.passwordSheetState is RestoreFromBackupViewModel.State.PasswordSheet.Open) {
-                PasswordSheet(
-                    state = state.passwordSheetState,
-                    onBackClick = onBackClick,
-                    onPasswordTyped = onPasswordTyped,
-                    onPasswordRevealToggle = onPasswordRevealToggle,
-                    onPasswordSubmitted = onPasswordSubmitted
-                )
-            }
-        }
-    ) {
-        Scaffold(
-            topBar = {
-                RadixCenteredTopAppBar(
-                    windowInsets = WindowInsets.statusBars,
-                    title = "",
-                    onBackClick = onBackClick
-                )
-            },
-            bottomBar = {
-                Column(Modifier.navigationBarsPadding()) {
-                    HorizontalDivider(color = RadixTheme.colors.gray5)
+    Scaffold(
+        topBar = {
+            RadixCenteredTopAppBar(
+                windowInsets = WindowInsets.statusBars,
+                title = "",
+                onBackClick = onBackClick
+            )
+        },
+        bottomBar = {
+            Column(Modifier.navigationBarsPadding()) {
+                HorizontalDivider(color = RadixTheme.colors.gray5)
 
-                    RadixPrimaryButton(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(RadixTheme.dimensions.paddingDefault),
-                        text = stringResource(id = R.string.common_continue),
-                        onClick = onSubmitClick,
-                        enabled = state.isContinueEnabled
-                    )
-                }
-            },
-            snackbarHost = {
-                RadixSnackbarHost(
-                    hostState = snackBarHostState,
-                    modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault)
-                )
-            },
-            containerColor = RadixTheme.colors.defaultBackground
-        ) { padding ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding)
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
-            ) {
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = RadixTheme.dimensions.paddingLarge),
-                    text = stringResource(id = R.string.recoverProfileBackup_header_title),
-                    textAlign = TextAlign.Center,
-                    style = RadixTheme.typography.title
-                )
-
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = RadixTheme.dimensions.paddingLarge),
-                    text = stringResource(id = R.string.recoverProfileBackup_header_subtitle),
-                    textAlign = TextAlign.Center,
-                    style = RadixTheme.typography.body1Regular
-                )
-
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(
-                            horizontal = RadixTheme.dimensions.paddingLarge,
-                            vertical = RadixTheme.dimensions.paddingSmall
-                        ),
-                    text = stringResource(id = R.string.androidRecoverProfileBackup_choose_title),
-                    textAlign = TextAlign.Center,
-                    style = RadixTheme.typography.body1Header,
-                    color = RadixTheme.colors.gray1
-                )
-
-                Surface(
-                    modifier = Modifier
-                        .padding(horizontal = RadixTheme.dimensions.paddingDefault),
-                    color = RadixTheme.colors.gray5,
-                    shadowElevation = if (state.restoringProfile != null) 8.dp else 0.dp,
-                    shape = RadixTheme.shapes.roundedRectMedium
-                ) {
-                    if (state.restoringProfile != null) {
-                        Row(
-                            modifier = Modifier
-                                .clickable {
-                                    onRestoringProfileCheckChanged(!state.isRestoringProfileChecked)
-                                }
-                                .padding(RadixTheme.dimensions.paddingDefault),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .padding(start = RadixTheme.dimensions.paddingXSmall)
-                            ) {
-                                Text(
-                                    text = stringResource(
-                                        id = R.string.recoverProfileBackup_backupFrom,
-                                        state.restoringProfile.header.lastUsedOnDevice.description
-                                    ).formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
-                                    color = RadixTheme.colors.gray2,
-                                    style = RadixTheme.typography.body2Regular
-                                )
-
-                                Text(
-                                    text = stringResource(
-                                        id = R.string.recoverProfileBackup_lastModified,
-                                        state.restoringProfile.header.lastUsedOnDevice.date.toDateString()
-                                    ).formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
-                                    color = RadixTheme.colors.gray2,
-                                    style = RadixTheme.typography.body2Regular
-                                )
-
-                                Text(
-                                    text = stringResource(
-                                        id = R.string.recoverProfileBackup_numberOfAccounts,
-                                        state.restoringProfile.header.contentHint.numberOfAccountsOnAllNetworksInTotal
-                                    ).formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
-                                    color = RadixTheme.colors.gray2,
-                                    style = RadixTheme.typography.body2Regular
-                                )
-
-                                Text(
-                                    text = stringResource(
-                                        id = R.string.recoverProfileBackup_numberOfPersonas,
-                                        state.restoringProfile.header.contentHint.numberOfPersonasOnAllNetworksInTotal
-                                    ).formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
-                                    color = RadixTheme.colors.gray2,
-                                    style = RadixTheme.typography.body2Regular
-                                )
-
-                                if (!state.restoringProfile.header.isCompatible) {
-                                    Text(
-                                        text = stringResource(id = R.string.recoverProfileBackup_incompatibleWalletDataLabel),
-                                        color = RadixTheme.colors.red1,
-                                        style = RadixTheme.typography.body2Regular
-                                    )
-                                }
-                            }
-
-                            Checkbox(
-                                checked = state.isRestoringProfileChecked,
-                                onCheckedChange = onRestoringProfileCheckChanged,
-                                colors = CheckboxDefaults.colors(
-                                    checkedColor = RadixTheme.colors.gray1,
-                                    uncheckedColor = RadixTheme.colors.gray2,
-                                    checkmarkColor = Color.White
-                                )
-                            )
-                        }
-                    } else {
-                        Text(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(RadixTheme.dimensions.paddingXLarge),
-                            text = stringResource(id = R.string.androidRecoverProfileBackup_noBackupsAvailable),
-                            color = RadixTheme.colors.gray2,
-                            textAlign = TextAlign.Center,
-                            style = RadixTheme.typography.secondaryHeader
-                        )
-                    }
-                }
-
-                RadixTextButton(
+                RadixPrimaryButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(RadixTheme.dimensions.paddingDefault),
-                    text = stringResource(id = R.string.recoverProfileBackup_importFileButton_title),
-                    onClick = onRestoreFromFileClick
+                    text = stringResource(id = R.string.common_continue),
+                    onClick = onSubmitClick,
+                    enabled = state.isContinueEnabled
                 )
-                OtherRestoreOptionsSection(onOtherRestoreOptionsClick)
             }
+        },
+        snackbarHost = {
+            RadixSnackbarHost(
+                hostState = snackBarHostState,
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault)
+            )
+        },
+        containerColor = RadixTheme.colors.defaultBackground
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+        ) {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = RadixTheme.dimensions.paddingLarge),
+                text = stringResource(id = R.string.recoverProfileBackup_header_title),
+                textAlign = TextAlign.Center,
+                style = RadixTheme.typography.title
+            )
+
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = RadixTheme.dimensions.paddingLarge),
+                text = stringResource(id = R.string.recoverProfileBackup_header_subtitle),
+                textAlign = TextAlign.Center,
+                style = RadixTheme.typography.body1Regular
+            )
+
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = RadixTheme.dimensions.paddingLarge,
+                        vertical = RadixTheme.dimensions.paddingSmall
+                    ),
+                text = stringResource(id = R.string.androidRecoverProfileBackup_choose_title),
+                textAlign = TextAlign.Center,
+                style = RadixTheme.typography.body1Header,
+                color = RadixTheme.colors.gray1
+            )
+
+            Surface(
+                modifier = Modifier
+                    .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+                color = RadixTheme.colors.gray5,
+                shadowElevation = if (state.restoringProfile != null) 8.dp else 0.dp,
+                shape = RadixTheme.shapes.roundedRectMedium
+            ) {
+                if (state.restoringProfile != null) {
+                    Row(
+                        modifier = Modifier
+                            .clickable {
+                                onRestoringProfileCheckChanged(!state.isRestoringProfileChecked)
+                            }
+                            .padding(RadixTheme.dimensions.paddingDefault),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = RadixTheme.dimensions.paddingXSmall)
+                        ) {
+                            Text(
+                                text = stringResource(
+                                    id = R.string.recoverProfileBackup_backupFrom,
+                                    state.restoringProfile.header.lastUsedOnDevice.description
+                                ).formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
+                                color = RadixTheme.colors.gray2,
+                                style = RadixTheme.typography.body2Regular
+                            )
+
+                            Text(
+                                text = stringResource(
+                                    id = R.string.recoverProfileBackup_lastModified,
+                                    state.restoringProfile.header.lastUsedOnDevice.date.toDateString()
+                                ).formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
+                                color = RadixTheme.colors.gray2,
+                                style = RadixTheme.typography.body2Regular
+                            )
+
+                            Text(
+                                text = stringResource(
+                                    id = R.string.recoverProfileBackup_numberOfAccounts,
+                                    state.restoringProfile.header.contentHint.numberOfAccountsOnAllNetworksInTotal
+                                ).formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
+                                color = RadixTheme.colors.gray2,
+                                style = RadixTheme.typography.body2Regular
+                            )
+
+                            Text(
+                                text = stringResource(
+                                    id = R.string.recoverProfileBackup_numberOfPersonas,
+                                    state.restoringProfile.header.contentHint.numberOfPersonasOnAllNetworksInTotal
+                                ).formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
+                                color = RadixTheme.colors.gray2,
+                                style = RadixTheme.typography.body2Regular
+                            )
+
+                            if (!state.restoringProfile.header.isCompatible) {
+                                Text(
+                                    text = stringResource(id = R.string.recoverProfileBackup_incompatibleWalletDataLabel),
+                                    color = RadixTheme.colors.red1,
+                                    style = RadixTheme.typography.body2Regular
+                                )
+                            }
+                        }
+
+                        Checkbox(
+                            checked = state.isRestoringProfileChecked,
+                            onCheckedChange = onRestoringProfileCheckChanged,
+                            colors = CheckboxDefaults.colors(
+                                checkedColor = RadixTheme.colors.gray1,
+                                uncheckedColor = RadixTheme.colors.gray2,
+                                checkmarkColor = Color.White
+                            )
+                        )
+                    }
+                } else {
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(RadixTheme.dimensions.paddingXLarge),
+                        text = stringResource(id = R.string.androidRecoverProfileBackup_noBackupsAvailable),
+                        color = RadixTheme.colors.gray2,
+                        textAlign = TextAlign.Center,
+                        style = RadixTheme.typography.secondaryHeader
+                    )
+                }
+            }
+
+            RadixTextButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(RadixTheme.dimensions.paddingDefault),
+                text = stringResource(id = R.string.recoverProfileBackup_importFileButton_title),
+                onClick = onRestoreFromFileClick
+            )
+            OtherRestoreOptionsSection(onOtherRestoreOptionsClick)
         }
+    }
+
+    if (modalBottomSheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = modifier,
+            sheetState = modalBottomSheetState,
+            enableImePadding = true,
+            wrapContent = true,
+            sheetContent = {
+                if (state.passwordSheetState is RestoreFromBackupViewModel.State.PasswordSheet.Open) {
+                    PasswordSheet(
+                        state = state.passwordSheetState,
+                        onBackClick = onBackClick,
+                        onPasswordTyped = onPasswordTyped,
+                        onPasswordRevealToggle = onPasswordRevealToggle,
+                        onPasswordSubmitted = onPasswordSubmitted
+                    )
+                }
+            }
+        )
     }
 }
 
@@ -364,9 +362,10 @@ private fun OtherRestoreOptionsSection(onOtherRestoreOptionsClick: () -> Unit, m
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SyncSheetState(
-    bottomSheetState: ModalBottomSheetState,
+    state: SheetState,
     isSheetVisible: Boolean,
     onSheetClosed: () -> Unit,
 ) {
@@ -374,14 +373,14 @@ private fun SyncSheetState(
 
     LaunchedEffect(isSheetVisible) {
         if (isSheetVisible) {
-            scope.launch { bottomSheetState.show() }
+            scope.launch { state.show() }
         } else {
-            scope.launch { bottomSheetState.hide() }
+            scope.launch { state.hide() }
         }
     }
 
-    LaunchedEffect(bottomSheetState.isVisible) {
-        if (!bottomSheetState.isVisible) {
+    LaunchedEffect(state.isVisible) {
+        if (!state.isVisible) {
             onSheetClosed()
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/backup/BackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/backup/BackupScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalLayoutApi::class, ExperimentalMaterialApi::class)
-
 package com.babylon.wallet.android.presentation.settings.appsettings.backup
 
 import android.provider.DocumentsContract
@@ -25,17 +23,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.IconButton
-import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -135,7 +132,7 @@ fun BackupScreen(
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun BackupScreenContent(
     modifier: Modifier = Modifier,
@@ -173,12 +170,11 @@ private fun BackupScreenContent(
     }
 
     val modalBottomSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true
+        skipPartiallyExpanded = true
     )
 
     SyncSheetState(
-        bottomSheetState = modalBottomSheetState,
+        sheetState = modalBottomSheetState,
         isSheetVisible = state.isEncryptSheetVisible,
         onSheetClosed = {
             if (state.isEncryptSheetVisible) {
@@ -194,177 +190,180 @@ private fun BackupScreenContent(
         onMessageShown = onUiMessageShown
     )
 
-    DefaultModalSheetLayout(
-        modifier = modifier.fillMaxSize(),
-        sheetState = modalBottomSheetState,
-        sheetContent = {
-            if (state.encryptSheet is BackupViewModel.State.EncryptSheet.Open) {
-                EncryptSheet(
-                    state = state.encryptSheet,
-                    onPasswordTyped = onEncryptPasswordTyped,
-                    onPasswordRevealToggle = onEncryptPasswordRevealToggle,
-                    onPasswordConfirmTyped = onEncryptConfirmPasswordTyped,
-                    onPasswordConfirmRevealToggle = onEncryptPasswordConfirmRevealToggle,
-                    onSubmitClick = onEncryptSubmitClick,
-                    onBackClick = onBackClick
-                )
-            }
-        }
-    ) {
-        Scaffold(
-            topBar = {
-                RadixCenteredTopAppBar(
-                    title = stringResource(R.string.accountSecuritySettings_backups_title),
-                    onBackClick = onBackClick,
-                    windowInsets = WindowInsets.statusBars
-                )
-            },
-            snackbarHost = {
-                RadixSnackbarHost(
-                    hostState = snackBarHostState,
-                    modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault)
-                )
-            },
-            contentWindowInsets = WindowInsets.navigationBars,
-            containerColor = RadixTheme.colors.gray5
-        ) { padding ->
-            Column(
-                modifier = Modifier
-                    .padding(padding)
-                    .verticalScroll(rememberScrollState())
+    Scaffold(
+        topBar = {
+            RadixCenteredTopAppBar(
+                title = stringResource(R.string.accountSecuritySettings_backups_title),
+                onBackClick = onBackClick,
+                windowInsets = WindowInsets.statusBars
+            )
+        },
+        snackbarHost = {
+            RadixSnackbarHost(
+                hostState = snackBarHostState,
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault)
+            )
+        },
+        contentWindowInsets = WindowInsets.navigationBars,
+        containerColor = RadixTheme.colors.gray5
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
+                text = stringResource(id = R.string.profileBackup_headerTitle)
+                    .formattedSpans(boldStyle = SpanStyle(fontWeight = FontWeight.Bold)),
+                color = RadixTheme.colors.gray2,
+                style = RadixTheme.typography.body1HighImportance
+            )
+
+            Text(
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
+                text = stringResource(id = R.string.profileBackup_automaticBackups_title),
+                color = RadixTheme.colors.gray2,
+                style = RadixTheme.typography.body1HighImportance
+            )
+
+            Surface(
+                color = RadixTheme.colors.defaultBackground,
+                shadowElevation = 1.dp
             ) {
-                Text(
-                    modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
-                    text = stringResource(id = R.string.profileBackup_headerTitle)
-                        .formattedSpans(boldStyle = SpanStyle(fontWeight = FontWeight.Bold)),
-                    color = RadixTheme.colors.gray2,
-                    style = RadixTheme.typography.body1HighImportance
-                )
-
-                Text(
-                    modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
-                    text = stringResource(id = R.string.profileBackup_automaticBackups_title),
-                    color = RadixTheme.colors.gray2,
-                    style = RadixTheme.typography.body1HighImportance
-                )
-
-                Surface(
-                    color = RadixTheme.colors.defaultBackground,
-                    shadowElevation = 1.dp
+                Column(
+                    modifier = Modifier
+                        .padding(
+                            horizontal = RadixTheme.dimensions.paddingDefault,
+                            vertical = RadixTheme.dimensions.paddingLarge
+                        ),
+                    verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .padding(
-                                horizontal = RadixTheme.dimensions.paddingDefault,
-                                vertical = RadixTheme.dimensions.paddingLarge
-                            ),
-                        verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
-                    ) {
-                        SwitchSettingsItem(
-                            titleRes = R.string.androidProfileBackup_backupWalletData_title,
-                            subtitleRes = R.string.androidProfileBackup_backupWalletData_message,
-                            checked = state.isBackupEnabled,
-                            icon = {
-                                Icon(
-                                    painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_backup),
-                                    tint = RadixTheme.colors.gray1,
-                                    contentDescription = null
-                                )
-                            },
-                            onCheckedChange = onBackupCheckChanged
-                        )
-
-                        NotBackedUpWarning(
-                            backupState = state.backupState,
-                            horizontalSpacing = RadixTheme.dimensions.paddingMedium
-                        )
-
-                        if (state.canAccessSystemBackupSettings) {
-                            RadixSecondaryButton(
-                                modifier = Modifier.fillMaxWidth(),
-                                text = stringResource(id = R.string.androidProfileBackup_openSystemBackupSettings),
-                                onClick = onSystemBackupSettingsClick
+                    SwitchSettingsItem(
+                        titleRes = R.string.androidProfileBackup_backupWalletData_title,
+                        subtitleRes = R.string.androidProfileBackup_backupWalletData_message,
+                        checked = state.isBackupEnabled,
+                        icon = {
+                            Icon(
+                                painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_backup),
+                                tint = RadixTheme.colors.gray1,
+                                contentDescription = null
                             )
-                        }
-                    }
-                }
+                        },
+                        onCheckedChange = onBackupCheckChanged
+                    )
 
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+                    NotBackedUpWarning(
+                        backupState = state.backupState,
+                        horizontalSpacing = RadixTheme.dimensions.paddingMedium
+                    )
 
-                Text(
-                    modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
-                    text = stringResource(id = R.string.profileBackup_manualBackups_title),
-                    color = RadixTheme.colors.gray2,
-                    style = RadixTheme.typography.body1HighImportance
-                )
-
-                Surface(
-                    color = RadixTheme.colors.defaultBackground,
-                    shadowElevation = 1.dp
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .padding(
-                                horizontal = RadixTheme.dimensions.paddingDefault,
-                                vertical = RadixTheme.dimensions.paddingLarge
-                            ),
-                        verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.profileBackup_manualBackups_subtitle)
-                                .formattedSpans(boldStyle = SpanStyle(fontWeight = FontWeight.Bold)),
-                            color = RadixTheme.colors.gray2,
-                            style = RadixTheme.typography.body1HighImportance
-                        )
-
+                    if (state.canAccessSystemBackupSettings) {
                         RadixSecondaryButton(
                             modifier = Modifier.fillMaxWidth(),
-                            text = stringResource(id = R.string.profileBackup_manualBackups_exportButtonTitle),
-                            onClick = onFileBackupClick
+                            text = stringResource(id = R.string.androidProfileBackup_openSystemBackupSettings),
+                            onClick = onSystemBackupSettingsClick
                         )
                     }
                 }
-
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
-
-                Text(
-                    modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
-                    text = stringResource(id = R.string.profileBackup_deleteWallet_buttonTitle),
-                    color = RadixTheme.colors.gray2,
-                    style = RadixTheme.typography.body1HighImportance
-                )
-
-                Surface(
-                    color = RadixTheme.colors.defaultBackground,
-                    shadowElevation = 1.dp
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .padding(
-                                horizontal = RadixTheme.dimensions.paddingDefault,
-                                vertical = RadixTheme.dimensions.paddingLarge
-                            ),
-                        verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.androidProfileBackup_deleteWallet_subtitle)
-                                .formattedSpans(boldStyle = SpanStyle(fontWeight = FontWeight.Bold)),
-                            color = RadixTheme.colors.gray2,
-                            style = RadixTheme.typography.body1HighImportance
-                        )
-                        WarningButton(
-                            text = stringResource(R.string.androidProfileBackup_deleteWallet_confirmButton),
-                            onClick = onDeleteWalletClick
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
             }
+
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+
+            Text(
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
+                text = stringResource(id = R.string.profileBackup_manualBackups_title),
+                color = RadixTheme.colors.gray2,
+                style = RadixTheme.typography.body1HighImportance
+            )
+
+            Surface(
+                color = RadixTheme.colors.defaultBackground,
+                shadowElevation = 1.dp
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(
+                            horizontal = RadixTheme.dimensions.paddingDefault,
+                            vertical = RadixTheme.dimensions.paddingLarge
+                        ),
+                    verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.profileBackup_manualBackups_subtitle)
+                            .formattedSpans(boldStyle = SpanStyle(fontWeight = FontWeight.Bold)),
+                        color = RadixTheme.colors.gray2,
+                        style = RadixTheme.typography.body1HighImportance
+                    )
+
+                    RadixSecondaryButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = stringResource(id = R.string.profileBackup_manualBackups_exportButtonTitle),
+                        onClick = onFileBackupClick
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+
+            Text(
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
+                text = stringResource(id = R.string.profileBackup_deleteWallet_buttonTitle),
+                color = RadixTheme.colors.gray2,
+                style = RadixTheme.typography.body1HighImportance
+            )
+
+            Surface(
+                color = RadixTheme.colors.defaultBackground,
+                shadowElevation = 1.dp
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(
+                            horizontal = RadixTheme.dimensions.paddingDefault,
+                            vertical = RadixTheme.dimensions.paddingLarge
+                        ),
+                    verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.androidProfileBackup_deleteWallet_subtitle)
+                            .formattedSpans(boldStyle = SpanStyle(fontWeight = FontWeight.Bold)),
+                        color = RadixTheme.colors.gray2,
+                        style = RadixTheme.typography.body1HighImportance
+                    )
+                    WarningButton(
+                        text = stringResource(R.string.androidProfileBackup_deleteWallet_confirmButton),
+                        onClick = onDeleteWalletClick
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
         }
+    }
+
+    if (modalBottomSheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = modifier.fillMaxSize(),
+            sheetState = modalBottomSheetState,
+            sheetContent = {
+                if (state.encryptSheet is BackupViewModel.State.EncryptSheet.Open) {
+                    EncryptSheet(
+                        state = state.encryptSheet,
+                        onPasswordTyped = onEncryptPasswordTyped,
+                        onPasswordRevealToggle = onEncryptPasswordRevealToggle,
+                        onPasswordConfirmTyped = onEncryptConfirmPasswordTyped,
+                        onPasswordConfirmRevealToggle = onEncryptPasswordConfirmRevealToggle,
+                        onSubmitClick = onEncryptSubmitClick,
+                        onBackClick = onBackClick
+                    )
+                }
+            }
+        )
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ExportWalletBackupFileDialog(
     modifier: Modifier = Modifier,
@@ -470,9 +469,10 @@ private fun DeleteWalletDialog(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SyncSheetState(
-    bottomSheetState: ModalBottomSheetState,
+    sheetState: SheetState,
     isSheetVisible: Boolean,
     onSheetClosed: () -> Unit,
 ) {
@@ -480,14 +480,14 @@ private fun SyncSheetState(
 
     LaunchedEffect(isSheetVisible) {
         if (isSheetVisible) {
-            scope.launch { bottomSheetState.show() }
+            scope.launch { sheetState.show() }
         } else {
-            scope.launch { bottomSheetState.hide() }
+            scope.launch { sheetState.hide() }
         }
     }
 
-    LaunchedEffect(bottomSheetState.isVisible) {
-        if (!bottomSheetState.isVisible) {
+    LaunchedEffect(sheetState.isVisible) {
+        if (!sheetState.isVisible) {
             onSheetClosed()
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalMaterialApi::class)
-
 package com.babylon.wallet.android.presentation.settings.appsettings.gateways
 
 import androidx.activity.compose.BackHandler
@@ -20,14 +18,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.Scaffold
-import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -86,6 +83,7 @@ fun GatewaysScreen(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun GatewaysContent(
     modifier: Modifier = Modifier,
@@ -103,7 +101,7 @@ private fun GatewaysContent(
     oneOffEvent: Flow<SettingsEditGatewayEvent>
 ) {
     val bottomSheetState =
-        rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden, skipHalfExpanded = true)
+        rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
     BackHandler(enabled = bottomSheetState.isVisible) {
         scope.launch {
@@ -125,100 +123,102 @@ private fun GatewaysContent(
         }
     }
 
-    DefaultModalSheetLayout(
-        modifier = modifier,
-        sheetState = bottomSheetState,
-        wrapContent = true,
-        enableImePadding = true,
-        sheetContent = {
-            AddGatewaySheet(
-                onAddGatewayClick = onAddGatewayClick,
-                newUrl = newUrl,
-                onNewUrlChanged = onNewUrlChanged,
-                onClose = {
-                    scope.launch {
-                        bottomSheetState.hide()
-                    }
-                },
-                newUrlValid = newUrlValid,
-                addingGateway = addingGateway,
-                modifier = Modifier.navigationBarsPadding(),
-                gatewayAddFailure = gatewayAddFailure
+    Scaffold(
+        topBar = {
+            RadixCenteredTopAppBar(
+                title = stringResource(R.string.gateways_title),
+                onBackClick = onBackClick,
+                windowInsets = WindowInsets.statusBars
             )
         }
-    ) {
-        Scaffold(
-            topBar = {
-                RadixCenteredTopAppBar(
-                    title = stringResource(R.string.gateways_title),
-                    onBackClick = onBackClick,
-                    windowInsets = WindowInsets.statusBars
-                )
-            }
-        ) { padding ->
-            Column(
-                modifier = Modifier.padding(padding).fillMaxSize(),
-                horizontalAlignment = Alignment.Start
+    ) { padding ->
+        Column(
+            modifier = Modifier.padding(padding).fillMaxSize(),
+            horizontalAlignment = Alignment.Start
+        ) {
+            HorizontalDivider(color = RadixTheme.colors.gray5)
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                HorizontalDivider(color = RadixTheme.colors.gray5)
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    item {
-                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                        Text(
-                            modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault),
-                            text = stringResource(id = R.string.gateways_subtitle),
-                            style = RadixTheme.typography.body1HighImportance,
-                            color = RadixTheme.colors.gray2
-                        )
-                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                item {
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                    Text(
+                        modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault),
+                        text = stringResource(id = R.string.gateways_subtitle),
+                        style = RadixTheme.typography.body1HighImportance,
+                        color = RadixTheme.colors.gray2
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
 //                    InfoLink( // TODO enable it when we have a link
 //                        stringResource(R.string.gateways_whatIsAGateway),
 //                        modifier = Modifier
 //                            .fillMaxWidth()
 //                            .padding(horizontal = RadixTheme.dimensions.paddingDefault)
 //                    )
-                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
-                        HorizontalDivider(
-                            color = RadixTheme.colors.gray5,
-                            modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault)
-                        )
-                    }
-                    items(gatewayList) { gateway ->
-                        GatewayCard(
-                            gateway = gateway,
-                            onDeleteGateway = onDeleteGateway,
-                            modifier = Modifier
-                                .throttleClickable {
-                                    onGatewayClick(gateway.gateway)
-                                }
-                                .fillMaxWidth()
-                                .padding(RadixTheme.dimensions.paddingDefault)
-                        )
-                        HorizontalDivider(
-                            color = RadixTheme.colors.gray5,
-                            modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault)
-                        )
-                    }
-                    item {
-                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
-                        RadixSecondaryButton(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = RadixTheme.dimensions.paddingDefault),
-                            text = stringResource(id = R.string.gateways_addNewGatewayButtonTitle),
-                            onClick = {
-                                scope.launch {
-                                    bottomSheetState.show()
-                                }
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+                    HorizontalDivider(
+                        color = RadixTheme.colors.gray5,
+                        modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault)
+                    )
+                }
+                items(gatewayList) { gateway ->
+                    GatewayCard(
+                        gateway = gateway,
+                        onDeleteGateway = onDeleteGateway,
+                        modifier = Modifier
+                            .throttleClickable {
+                                onGatewayClick(gateway.gateway)
                             }
-                        )
-                    }
+                            .fillMaxWidth()
+                            .padding(RadixTheme.dimensions.paddingDefault)
+                    )
+                    HorizontalDivider(
+                        color = RadixTheme.colors.gray5,
+                        modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault)
+                    )
+                }
+                item {
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+                    RadixSecondaryButton(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+                        text = stringResource(id = R.string.gateways_addNewGatewayButtonTitle),
+                        onClick = {
+                            scope.launch {
+                                bottomSheetState.show()
+                            }
+                        }
+                    )
                 }
             }
         }
+    }
+
+    if (bottomSheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = modifier,
+            sheetState = bottomSheetState,
+            wrapContent = true,
+            enableImePadding = true,
+            sheetContent = {
+                AddGatewaySheet(
+                    onAddGatewayClick = onAddGatewayClick,
+                    newUrl = newUrl,
+                    onNewUrlChanged = onNewUrlChanged,
+                    onClose = {
+                        scope.launch {
+                            bottomSheetState.hide()
+                        }
+                    },
+                    newUrlValid = newUrlValid,
+                    addingGateway = addingGateway,
+                    modifier = Modifier.navigationBarsPadding(),
+                    gatewayAddFailure = gatewayAddFailure
+                )
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/authorizeddapps/dappdetail/DappDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/authorizeddapps/dappdetail/DappDetailScreen.kt
@@ -22,15 +22,14 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -135,7 +134,7 @@ fun DappDetailScreen(
     )
 }
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DappDetailContent(
     onBackClick: () -> Unit,
@@ -156,7 +155,7 @@ private fun DappDetailContent(
 ) {
     var showDeleteDappPrompt by remember { mutableStateOf(false) }
     val bottomSheetState =
-        rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden, skipHalfExpanded = true)
+        rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
     LaunchedEffect(bottomSheetState) {
         snapshotFlow {
@@ -197,87 +196,88 @@ private fun DappDetailContent(
         )
     }
 
-    DefaultModalSheetLayout(
-        modifier = modifier,
-        sheetState = bottomSheetState,
-        sheetContent = {
-            when (selectedSheetState) {
-                is SelectedSheetState.SelectedPersona -> {
-                    selectedSheetState.persona?.let {
-                        PersonaDetailsSheet(
-                            persona = it,
-                            sharedPersonaAccounts = selectedPersonaSharedAccounts,
-                            onCloseClick = {
-                                scope.launch {
-                                    bottomSheetState.hide()
-                                }
-                            },
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .navigationBarsPadding()
-                                .background(
-                                    RadixTheme.colors.defaultBackground,
-                                    shape = RadixTheme.shapes.roundedRectTopMedium
-                                )
-                                .clip(shape = RadixTheme.shapes.roundedRectTopMedium),
-                            dappName = dAppWithResources?.dApp?.name.orEmpty(),
-                            onDisconnectPersona = { persona ->
-                                scope.launch {
-                                    bottomSheetState.hide()
-                                }
-                                onDisconnectPersona(persona)
-                            },
-                            onEditPersona = onEditPersona,
-                            onEditAccountSharing = onEditAccountSharing
-                        )
-                    }
-                }
-
-                else -> {}
-            }
-        },
-        content = {
-            Scaffold(
-                topBar = {
-                    Column {
-                        RadixCenteredTopAppBar(
-                            title = dAppWithResources?.dApp?.name.orEmpty(),
-                            onBackClick = onBackClick,
-                            windowInsets = WindowInsets.statusBars
-                        )
-                        HorizontalDivider(color = RadixTheme.colors.gray5)
-                    }
-                }
-            ) { padding ->
-                Box(modifier = Modifier.padding(padding)) {
-                    DappDetails(
-                        modifier = Modifier.fillMaxSize(),
-                        dAppWithResources = dAppWithResources,
-                        personaList = personaList,
-                        onPersonaClick = { persona ->
-                            onPersonaClick(persona)
-                            scope.launch {
-                                bottomSheetState.show()
-                            }
-                        },
-                        onFungibleTokenClick = { fungibleResource ->
-                            onFungibleTokenClick(fungibleResource)
-                        },
-                        onNonFungibleClick = { nftItem ->
-                            onNftClick(nftItem)
-                        },
-                        onDeleteDapp = {
-                            showDeleteDappPrompt = true
-                        }
-                    )
-
-                    if (loading) {
-                        FullscreenCircularProgressContent()
-                    }
-                }
+    Scaffold(
+        topBar = {
+            Column {
+                RadixCenteredTopAppBar(
+                    title = dAppWithResources?.dApp?.name.orEmpty(),
+                    onBackClick = onBackClick,
+                    windowInsets = WindowInsets.statusBars
+                )
+                HorizontalDivider(color = RadixTheme.colors.gray5)
             }
         }
-    )
+    ) { padding ->
+        Box(modifier = Modifier.padding(padding)) {
+            DappDetails(
+                modifier = Modifier.fillMaxSize(),
+                dAppWithResources = dAppWithResources,
+                personaList = personaList,
+                onPersonaClick = { persona ->
+                    onPersonaClick(persona)
+                    scope.launch {
+                        bottomSheetState.show()
+                    }
+                },
+                onFungibleTokenClick = { fungibleResource ->
+                    onFungibleTokenClick(fungibleResource)
+                },
+                onNonFungibleClick = { nftItem ->
+                    onNftClick(nftItem)
+                },
+                onDeleteDapp = {
+                    showDeleteDappPrompt = true
+                }
+            )
+
+            if (loading) {
+                FullscreenCircularProgressContent()
+            }
+        }
+    }
+
+    if (bottomSheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = modifier,
+            sheetState = bottomSheetState,
+            sheetContent = {
+                when (selectedSheetState) {
+                    is SelectedSheetState.SelectedPersona -> {
+                        selectedSheetState.persona?.let {
+                            PersonaDetailsSheet(
+                                persona = it,
+                                sharedPersonaAccounts = selectedPersonaSharedAccounts,
+                                onCloseClick = {
+                                    scope.launch {
+                                        bottomSheetState.hide()
+                                    }
+                                },
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .navigationBarsPadding()
+                                    .background(
+                                        RadixTheme.colors.defaultBackground,
+                                        shape = RadixTheme.shapes.roundedRectTopMedium
+                                    )
+                                    .clip(shape = RadixTheme.shapes.roundedRectTopMedium),
+                                dappName = dAppWithResources?.dApp?.name.orEmpty(),
+                                onDisconnectPersona = { persona ->
+                                    scope.launch {
+                                        bottomSheetState.hide()
+                                    }
+                                    onDisconnectPersona(persona)
+                                },
+                                onEditPersona = onEditPersona,
+                                onEditAccountSharing = onEditAccountSharing
+                            )
+                        }
+                    }
+
+                    else -> {}
+                }
+            }
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaScreen.kt
@@ -16,18 +16,16 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -103,7 +101,7 @@ fun CreatePersonaScreen(
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CreatePersonaContent(
     onPersonaNameChange: (String) -> Unit,
@@ -124,7 +122,7 @@ fun CreatePersonaContent(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     val bottomSheetState =
-        rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden, skipHalfExpanded = true)
+        rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
     BackHandler(enabled = bottomSheetState.isVisible) {
         scope.launch {
@@ -132,81 +130,84 @@ fun CreatePersonaContent(
             keyboardController?.hide()
         }
     }
-    DefaultModalSheetLayout(
-        modifier = modifier,
-        sheetState = bottomSheetState,
-        sheetContent = {
-            AddFieldSheet(
-                onBackClick = {
-                    scope.launch {
-                        bottomSheetState.hide()
-                    }
-                },
-                fieldsToAdd = fieldsToAdd,
-                onAddFields = {
-                    scope.launch { bottomSheetState.hide() }
-                    onAddFields()
-                },
-                onSelectionChanged = onSelectionChanged,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .navigationBarsPadding(),
-                anyFieldSelected = anyFieldSelected
-            )
-        }
-    ) {
-        Scaffold(
-            topBar = {
-                RadixCenteredTopAppBar(
-                    title = stringResource(id = R.string.empty),
-                    onBackClick = onBackClick,
-                    windowInsets = WindowInsets.statusBars
-                )
-            },
-            bottomBar = {
-                Column {
-                    val context = LocalContext.current
 
-                    HorizontalDivider(color = RadixTheme.colors.gray5)
-                    RadixPrimaryButton(
-                        text = stringResource(id = R.string.createPersona_saveAndContinueButtonTitle),
-                        onClick = {
-                            context.findFragmentActivity()?.let { activity ->
-                                activity.biometricAuthenticate { authenticatedSuccessfully ->
-                                    if (authenticatedSuccessfully) {
-                                        onPersonaCreateClick()
-                                    }
+    Scaffold(
+        topBar = {
+            RadixCenteredTopAppBar(
+                title = stringResource(id = R.string.empty),
+                onBackClick = onBackClick,
+                windowInsets = WindowInsets.statusBars
+            )
+        },
+        bottomBar = {
+            Column {
+                val context = LocalContext.current
+
+                HorizontalDivider(color = RadixTheme.colors.gray5)
+                RadixPrimaryButton(
+                    text = stringResource(id = R.string.createPersona_saveAndContinueButtonTitle),
+                    onClick = {
+                        context.findFragmentActivity()?.let { activity ->
+                            activity.biometricAuthenticate { authenticatedSuccessfully ->
+                                if (authenticatedSuccessfully) {
+                                    onPersonaCreateClick()
                                 }
                             }
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(dimensions.paddingDefault)
-                            .navigationBarsPadding()
-                            .imePadding(),
-                        enabled = continueButtonEnabled
-                    )
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(dimensions.paddingDefault)
+                        .navigationBarsPadding()
+                        .imePadding(),
+                    enabled = continueButtonEnabled
+                )
+            }
+        },
+        containerColor = RadixTheme.colors.defaultBackground
+    ) { padding ->
+        CreatePersonaContentList(
+            onPersonaNameChange = onPersonaNameChange,
+            personaName = personaName,
+            currentFields = currentFields,
+            onValueChanged = onValueChanged,
+            onDeleteField = onDeleteField,
+            addButtonEnabled = fieldsToAdd.isNotEmpty(),
+            modifier = Modifier.padding(padding),
+            onAddFieldClick = {
+                scope.launch {
+                    bottomSheetState.show()
                 }
             },
-            containerColor = RadixTheme.colors.defaultBackground
-        ) { padding ->
-            CreatePersonaContentList(
-                onPersonaNameChange = onPersonaNameChange,
-                personaName = personaName,
-                currentFields = currentFields,
-                onValueChanged = onValueChanged,
-                onDeleteField = onDeleteField,
-                addButtonEnabled = fieldsToAdd.isNotEmpty(),
-                modifier = Modifier.padding(padding),
-                onAddFieldClick = {
-                    scope.launch {
-                        bottomSheetState.show()
-                    }
-                },
-                onPersonaDisplayNameFocusChanged = onPersonaDisplayNameFocusChanged,
-                onFieldFocusChanged = onFieldFocusChanged
-            )
-        }
+            onPersonaDisplayNameFocusChanged = onPersonaDisplayNameFocusChanged,
+            onFieldFocusChanged = onFieldFocusChanged
+        )
+    }
+
+    if (bottomSheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = modifier,
+            sheetState = bottomSheetState,
+            sheetContent = {
+                AddFieldSheet(
+                    onBackClick = {
+                        scope.launch {
+                            bottomSheetState.hide()
+                        }
+                    },
+                    fieldsToAdd = fieldsToAdd,
+                    onAddFields = {
+                        scope.launch { bottomSheetState.hide() }
+                        onAddFields()
+                    },
+                    onSelectionChanged = onSelectionChanged,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .navigationBarsPadding(),
+                    anyFieldSelected = anyFieldSelected
+                )
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailScreen.kt
@@ -15,12 +15,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -119,7 +118,7 @@ fun PersonaDetailScreen(
     )
 }
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun PersonaDetailContent(
     modifier: Modifier = Modifier,
@@ -135,63 +134,65 @@ private fun PersonaDetailContent(
     onHidePersona: () -> Unit
 ) {
     val bottomSheetState =
-        rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.Hidden, skipHalfExpanded = true)
+        rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val scope = rememberCoroutineScope()
 
-    DefaultModalSheetLayout(
-        modifier = modifier,
-        sheetState = bottomSheetState,
-        sheetContent = {
-            selectedDApp?.let {
-                DAppDetailsSheetContent(
-                    modifier = Modifier.navigationBarsPadding(),
-                    onBackClick = {
-                        scope.launch {
-                            bottomSheetState.hide()
-                        }
-                    },
-                    dApp = it
+    Scaffold(
+        topBar = {
+            Column {
+                RadixCenteredTopAppBar(
+                    title = persona?.displayName.orEmpty(),
+                    onBackClick = onBackClick,
+                    windowInsets = WindowInsets.statusBars
                 )
-            }
-        }
-    ) {
-        Scaffold(
-            topBar = {
-                Column {
-                    RadixCenteredTopAppBar(
-                        title = persona?.displayName.orEmpty(),
-                        onBackClick = onBackClick,
-                        windowInsets = WindowInsets.statusBars
-                    )
 
-                    HorizontalDivider(color = RadixTheme.colors.gray5)
-                }
-            },
-            containerColor = RadixTheme.colors.defaultBackground
-        ) { padding ->
-            if (persona != null) {
-                PersonaDetailList(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(padding),
-                    persona = persona,
-                    authorizedDapps = authorizedDapps,
-                    onDAppClick = {
-                        onDAppClick(it)
-                        scope.launch {
-                            bottomSheetState.show()
-                        }
-                    },
-                    onEditPersona = onEditPersona,
-                    hasAuthKey = hasAuthKey,
-                    onCreateAndUploadAuthKey = onCreateAndUploadAuthKey,
-                    loading = loading,
-                    onHidePersona = onHidePersona
-                )
-            } else {
-                FullscreenCircularProgressContent()
+                HorizontalDivider(color = RadixTheme.colors.gray5)
             }
+        },
+        containerColor = RadixTheme.colors.defaultBackground
+    ) { padding ->
+        if (persona != null) {
+            PersonaDetailList(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(padding),
+                persona = persona,
+                authorizedDapps = authorizedDapps,
+                onDAppClick = {
+                    onDAppClick(it)
+                    scope.launch {
+                        bottomSheetState.show()
+                    }
+                },
+                onEditPersona = onEditPersona,
+                hasAuthKey = hasAuthKey,
+                onCreateAndUploadAuthKey = onCreateAndUploadAuthKey,
+                loading = loading,
+                onHidePersona = onHidePersona
+            )
+        } else {
+            FullscreenCircularProgressContent()
         }
+    }
+
+    if (bottomSheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = modifier,
+            sheetState = bottomSheetState,
+            sheetContent = {
+                selectedDApp?.let {
+                    DAppDetailsSheetContent(
+                        modifier = Modifier.navigationBarsPadding(),
+                        onBackClick = {
+                            scope.launch {
+                                bottomSheetState.hide()
+                            }
+                        },
+                        dApp = it
+                    )
+                }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -14,15 +14,13 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -148,7 +146,7 @@ fun TransactionReviewScreen(
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TransactionPreviewContent(
     modifier: Modifier = Modifier,
@@ -177,8 +175,7 @@ private fun TransactionPreviewContent(
     dismissTransactionErrorDialog: () -> Unit
 ) {
     val modalBottomSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true
+        skipPartiallyExpanded = true
     )
     val snackBarHostState = remember { SnackbarHostState() }
 
@@ -205,7 +202,7 @@ private fun TransactionPreviewContent(
     BackHandler(onBack = onBackClick)
 
     SyncSheetState(
-        bottomSheetState = modalBottomSheetState,
+        sheetState = modalBottomSheetState,
         isSheetVisible = state.isSheetVisible,
         onSheetClosed = {
             if (state.isSheetVisible) {
@@ -214,152 +211,154 @@ private fun TransactionPreviewContent(
         }
     )
 
-    DefaultModalSheetLayout(
-        modifier = modifier.fillMaxSize(),
-        sheetState = modalBottomSheetState,
-        sheetContent = {
-            BottomSheetContent(
-                modifier = Modifier.navigationBarsPadding(),
-                sheetState = state.sheetState,
-                transactionFees = state.transactionFees,
-                insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
-                onGuaranteesCloseClick = onGuaranteesCloseClick,
-                onGuaranteesApplyClick = onGuaranteesApplyClick,
-                onGuaranteeValueChanged = onGuaranteeValueChanged,
-                onGuaranteeValueIncreased = onGuaranteeValueIncreased,
-                onGuaranteeValueDecreased = onGuaranteeValueDecreased,
-                onCloseDAppSheet = onBackClick,
-                onChangeFeePayerClick = onChangeFeePayerClick,
-                onSelectFeePayerClick = onSelectFeePayerClick,
-                onPayerSelected = onPayerSelected,
-                onFeePaddingAmountChanged = onFeePaddingAmountChanged,
-                onTipPercentageChanged = onTipPercentageChanged,
-                onViewDefaultModeClick = onViewDefaultModeClick,
-                onViewAdvancedModeClick = onViewAdvancedModeClick
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            TransactionPreviewHeader(
+                onBackClick = onBackClick,
+                state = state,
+                onRawManifestClick = onRawManifestToggle,
+                scrollBehavior = scrollBehavior
             )
-        }
-    ) {
-        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
-        Scaffold(
-            modifier = Modifier
-                .fillMaxSize()
-                .nestedScroll(scrollBehavior.nestedScrollConnection),
-            topBar = {
-                TransactionPreviewHeader(
-                    onBackClick = onBackClick,
-                    state = state,
-                    onRawManifestClick = onRawManifestToggle,
-                    scrollBehavior = scrollBehavior
-                )
-            },
-            snackbarHost = {
-                RadixSnackbarHost(
-                    modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
-                    hostState = snackBarHostState
-                )
-            },
-            containerColor = RadixTheme.colors.defaultBackground
-        ) { padding ->
-            Box(modifier = Modifier.padding(padding)) {
-                if (state.isLoading) {
-                    FullscreenCircularProgressContent()
-                } else {
-                    AnimatedVisibility(
-                        visible = state.isRawManifestVisible,
-                        enter = fadeIn(),
-                        exit = fadeOut()
+        },
+        snackbarHost = {
+            RadixSnackbarHost(
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
+                hostState = snackBarHostState
+            )
+        },
+        containerColor = RadixTheme.colors.defaultBackground
+    ) { padding ->
+        Box(modifier = Modifier.padding(padding)) {
+            if (state.isLoading) {
+                FullscreenCircularProgressContent()
+            } else {
+                AnimatedVisibility(
+                    visible = state.isRawManifestVisible,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    Column(
+                        modifier = Modifier.verticalScroll(rememberScrollState())
                     ) {
-                        Column(
-                            modifier = Modifier.verticalScroll(rememberScrollState())
-                        ) {
-                            ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5, topEdge = true)
-                            RawManifestView(
-                                modifier = Modifier
-                                    .background(color = RadixTheme.colors.gray5)
-                                    .padding(RadixTheme.dimensions.paddingDefault),
-                                manifest = state.rawManifest
-                            )
-                            ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5)
-                            NetworkFeeContent(
-                                fees = state.transactionFees,
-                                noFeePayerSelected = state.noFeePayerSelected,
-                                insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
-                                isNetworkFeeLoading = state.isNetworkFeeLoading,
-                                onCustomizeClick = onCustomizeClick
-                            )
-                            SlideToSignButton(
-                                modifier = Modifier.padding(
-                                    horizontal = RadixTheme.dimensions.paddingXLarge,
-                                    vertical = RadixTheme.dimensions.paddingDefault
-                                ),
-                                enabled = state.isSubmitEnabled,
-                                isSubmitting = state.isSubmitting,
-                                onSwipeComplete = onApproveTransaction
-                            )
-                        }
+                        ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5, topEdge = true)
+                        RawManifestView(
+                            modifier = Modifier
+                                .background(color = RadixTheme.colors.gray5)
+                                .padding(RadixTheme.dimensions.paddingDefault),
+                            manifest = state.rawManifest
+                        )
+                        ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5)
+                        NetworkFeeContent(
+                            fees = state.transactionFees,
+                            noFeePayerSelected = state.noFeePayerSelected,
+                            insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
+                            isNetworkFeeLoading = state.isNetworkFeeLoading,
+                            onCustomizeClick = onCustomizeClick
+                        )
+                        SlideToSignButton(
+                            modifier = Modifier.padding(
+                                horizontal = RadixTheme.dimensions.paddingXLarge,
+                                vertical = RadixTheme.dimensions.paddingDefault
+                            ),
+                            enabled = state.isSubmitEnabled,
+                            isSubmitting = state.isSubmitting,
+                            onSwipeComplete = onApproveTransaction
+                        )
                     }
+                }
 
-                    AnimatedVisibility(
-                        visible = !state.isRawManifestVisible,
-                        enter = fadeIn(),
-                        exit = fadeOut()
+                AnimatedVisibility(
+                    visible = !state.isRawManifestVisible,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    Column(
+                        modifier = Modifier.verticalScroll(rememberScrollState())
                     ) {
-                        Column(
-                            modifier = Modifier.verticalScroll(rememberScrollState())
-                        ) {
-                            ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5, topEdge = true)
-                            when (val preview = state.previewType) {
-                                is PreviewType.None -> {}
-                                is PreviewType.UnacceptableManifest -> {
-                                    return@AnimatedVisibility
-                                }
-
-                                is PreviewType.NonConforming -> {}
-                                is PreviewType.Transfer -> {
-                                    TransactionPreviewTypeContent(
-                                        modifier = Modifier.background(RadixTheme.colors.gray5),
-                                        state = state,
-                                        preview = preview,
-                                        onPromptForGuarantees = promptForGuarantees,
-                                        onDappClick = onDAppClick,
-                                        onFungibleResourceClick = onFungibleResourceClick,
-                                        onNonFungibleResourceClick = onNonFungibleResourceClick
-                                    )
-                                    ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5)
-                                    PresentingProofsContent(
-                                        badges = preview.badges.toPersistentList()
-                                    )
-                                }
-
-                                is PreviewType.AccountsDepositSettings -> {
-                                    AccountDepositSettingsTypeContent(
-                                        modifier = Modifier.background(RadixTheme.colors.gray5),
-                                        preview = preview
-                                    )
-                                    ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5)
-                                }
+                        ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5, topEdge = true)
+                        when (val preview = state.previewType) {
+                            is PreviewType.None -> {}
+                            is PreviewType.UnacceptableManifest -> {
+                                return@AnimatedVisibility
                             }
-                            NetworkFeeContent(
-                                fees = state.transactionFees,
-                                noFeePayerSelected = state.noFeePayerSelected,
-                                insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
-                                isNetworkFeeLoading = state.isNetworkFeeLoading,
-                                onCustomizeClick = onCustomizeClick
-                            )
-                            SlideToSignButton(
-                                modifier = Modifier.padding(
-                                    horizontal = RadixTheme.dimensions.paddingXLarge,
-                                    vertical = RadixTheme.dimensions.paddingDefault
-                                ),
-                                enabled = state.isSubmitEnabled,
-                                isSubmitting = state.isSubmitting,
-                                onSwipeComplete = onApproveTransaction
-                            )
+
+                            is PreviewType.NonConforming -> {}
+                            is PreviewType.Transfer -> {
+                                TransactionPreviewTypeContent(
+                                    modifier = Modifier.background(RadixTheme.colors.gray5),
+                                    state = state,
+                                    preview = preview,
+                                    onPromptForGuarantees = promptForGuarantees,
+                                    onDappClick = onDAppClick,
+                                    onFungibleResourceClick = onFungibleResourceClick,
+                                    onNonFungibleResourceClick = onNonFungibleResourceClick
+                                )
+                                ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5)
+                                PresentingProofsContent(
+                                    badges = preview.badges.toPersistentList()
+                                )
+                            }
+
+                            is PreviewType.AccountsDepositSettings -> {
+                                AccountDepositSettingsTypeContent(
+                                    modifier = Modifier.background(RadixTheme.colors.gray5),
+                                    preview = preview
+                                )
+                                ReceiptEdge(modifier = Modifier.fillMaxWidth(), color = RadixTheme.colors.gray5)
+                            }
                         }
+                        NetworkFeeContent(
+                            fees = state.transactionFees,
+                            noFeePayerSelected = state.noFeePayerSelected,
+                            insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
+                            isNetworkFeeLoading = state.isNetworkFeeLoading,
+                            onCustomizeClick = onCustomizeClick
+                        )
+                        SlideToSignButton(
+                            modifier = Modifier.padding(
+                                horizontal = RadixTheme.dimensions.paddingXLarge,
+                                vertical = RadixTheme.dimensions.paddingDefault
+                            ),
+                            enabled = state.isSubmitEnabled,
+                            isSubmitting = state.isSubmitting,
+                            onSwipeComplete = onApproveTransaction
+                        )
                     }
                 }
             }
         }
+    }
+
+    if (modalBottomSheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = modifier.fillMaxSize(),
+            sheetState = modalBottomSheetState,
+            sheetContent = {
+                BottomSheetContent(
+                    modifier = Modifier.navigationBarsPadding(),
+                    sheetState = state.sheetState,
+                    transactionFees = state.transactionFees,
+                    insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
+                    onGuaranteesCloseClick = onGuaranteesCloseClick,
+                    onGuaranteesApplyClick = onGuaranteesApplyClick,
+                    onGuaranteeValueChanged = onGuaranteeValueChanged,
+                    onGuaranteeValueIncreased = onGuaranteeValueIncreased,
+                    onGuaranteeValueDecreased = onGuaranteeValueDecreased,
+                    onCloseDAppSheet = onBackClick,
+                    onChangeFeePayerClick = onChangeFeePayerClick,
+                    onSelectFeePayerClick = onSelectFeePayerClick,
+                    onPayerSelected = onPayerSelected,
+                    onFeePaddingAmountChanged = onFeePaddingAmountChanged,
+                    onTipPercentageChanged = onTipPercentageChanged,
+                    onViewDefaultModeClick = onViewDefaultModeClick,
+                    onViewAdvancedModeClick = onViewAdvancedModeClick
+                )
+            }
+        )
     }
 }
 
@@ -425,10 +424,10 @@ private fun BottomSheetContent(
     }
 }
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SyncSheetState(
-    bottomSheetState: ModalBottomSheetState,
+    sheetState: SheetState,
     isSheetVisible: Boolean,
     onSheetClosed: () -> Unit,
 ) {
@@ -436,14 +435,14 @@ private fun SyncSheetState(
 
     LaunchedEffect(isSheetVisible) {
         if (isSheetVisible) {
-            scope.launch { bottomSheetState.show() }
+            scope.launch { sheetState.show() }
         } else {
-            scope.launch { bottomSheetState.hide() }
+            scope.launch { sheetState.hide() }
         }
     }
 
-    LaunchedEffect(bottomSheetState.isVisible) {
-        if (!bottomSheetState.isVisible) {
+    LaunchedEffect(sheetState.isVisible) {
+        if (!sheetState.isVisible) {
             onSheetClosed()
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalMaterialApi::class, ExperimentalMaterialApi::class, ExperimentalMaterialApi::class)
-
 package com.babylon.wallet.android.presentation.transfer
 
 import androidx.activity.compose.BackHandler
@@ -16,13 +14,12 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetState
-import androidx.compose.material.ModalBottomSheetValue
-import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -100,10 +97,10 @@ fun TransferScreen(
     )
 }
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TransferContent(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     onBackClick: () -> Unit,
     state: State,
     onMessageStateChanged: (Boolean) -> Unit,
@@ -135,12 +132,11 @@ fun TransferContent(
     val focusManager = LocalFocusManager.current
 
     val bottomSheetState = rememberModalBottomSheetState(
-        initialValue = ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true
+        skipPartiallyExpanded = true
     )
 
     SyncSheetState(
-        bottomSheetState = bottomSheetState,
+        sheetState = bottomSheetState,
         isSheetVisible = state.isSheetVisible,
         onSheetClosed = onSheetClosed
     )
@@ -172,219 +168,222 @@ fun TransferContent(
         }
     }
 
-    DefaultModalSheetLayout(
-        modifier = modifier,
-        sheetState = bottomSheetState,
-        sheetContent = {
-            when (val sheetState = state.sheet) {
-                is State.Sheet.ChooseAccounts -> {
-                    ChooseAccountSheet(
-                        onCloseClick = onSheetClosed,
-                        state = sheetState,
-                        onOwnedAccountSelected = onOwnedAccountSelected,
-                        onChooseAccountSubmitted = onChooseAccountSubmitted,
-                        onAddressDecoded = onAddressDecoded,
-                        onQrCodeIconClick = onQrCodeIconClick,
-                        cancelQrScan = cancelQrScan,
-                        onAddressChanged = onAddressTyped
-                    )
-                }
-
-                is State.Sheet.ChooseAssets -> {
-                    ChooseAssetsSheet(
-                        state = sheetState,
-                        onTabSelected = { onChooseAssetTabSelected(it) },
-                        onCloseClick = onSheetClosed,
-                        onAssetSelectionChanged = onAssetSelectionChanged,
-                        onNextNFtsPageRequest = onNextNFTsPageRequest,
-                        onStakesRequest = onStakesRequest,
-                        onUiMessageShown = onUiMessageShown,
-                        onChooseAssetsSubmitted = onChooseAssetsSubmitted
-                    )
-                }
-
-                is State.Sheet.None -> {}
-            }
-        }
-    ) {
-        Scaffold(
-            modifier = Modifier.imePadding(),
-            topBar = {
-                RadixCenteredTopAppBar(
-                    title = stringResource(id = R.string.empty),
-                    onBackClick = onBackClick,
-                    backIconType = BackIconType.Close,
-                    windowInsets = WindowInsets.statusBars
-                )
-            },
-            containerColor = RadixTheme.colors.defaultBackground
-        ) { padding ->
-            LazyColumn(
-                modifier = Modifier.pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) },
-                contentPadding = padding + PaddingValues(horizontal = RadixTheme.dimensions.paddingDefault),
-            ) {
-                item {
-                    Row(
+    Scaffold(
+        modifier = modifier.imePadding(),
+        topBar = {
+            RadixCenteredTopAppBar(
+                title = stringResource(id = R.string.empty),
+                onBackClick = onBackClick,
+                backIconType = BackIconType.Close,
+                windowInsets = WindowInsets.statusBars
+            )
+        },
+        containerColor = RadixTheme.colors.defaultBackground
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.pointerInput(Unit) { detectTapGestures(onTap = { focusManager.clearFocus() }) },
+            contentPadding = padding + PaddingValues(horizontal = RadixTheme.dimensions.paddingDefault),
+        ) {
+            item {
+                Row(
+                    modifier = Modifier
+                        .padding(bottom = RadixTheme.dimensions.paddingDefault),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
                         modifier = Modifier
-                            .padding(bottom = RadixTheme.dimensions.paddingDefault),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            modifier = Modifier
-                                .padding(
-                                    start = RadixTheme.dimensions.paddingSmall
-                                ),
-                            text = stringResource(id = R.string.assetTransfer_header_transfer),
-                            style = RadixTheme.typography.title,
-                            color = RadixTheme.colors.gray1,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Spacer(modifier = Modifier.weight(1f))
-                        if (state.messageState is State.Message.None) {
-                            RadixTextButton(
-                                text = stringResource(id = R.string.assetTransfer_header_addMessageButton),
-                                onClick = { onMessageStateChanged(true) },
-                                leadingIcon = {
-                                    Icon(
-                                        painter = painterResource(id = R.drawable.ic_add_message),
-                                        contentDescription = ""
-                                    )
-                                }
-                            )
-                        }
-                    }
-                }
-
-                if (state.messageState is State.Message.Added) {
-                    item {
-                        TransferMessage(
-                            message = state.messageState.message,
-                            onMessageChanged = onMessageChanged,
-                            onMessageClose = { onMessageStateChanged(false) }
-                        )
-                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                    }
-                }
-
-                state.fromAccount?.let { account ->
-                    item {
-                        Text(
-                            modifier = Modifier
-                                .padding(
-                                    horizontal = RadixTheme.dimensions.paddingMedium,
-                                    vertical = RadixTheme.dimensions.paddingXSmall
-                                ),
-                            text = stringResource(
-                                id = R.string.assetTransfer_accountList_fromLabel
-                            ).uppercase(),
-                            style = RadixTheme.typography.body1Link,
-                            color = RadixTheme.colors.gray2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-
-                        SimpleAccountCard(
-                            modifier = Modifier.fillMaxWidth(),
-                            account = account
-                        )
-                    }
-                }
-
-                item {
-                    StrokeLine(height = 50.dp)
-                }
-
-                item {
-                    Row {
-                        Text(
-                            modifier = Modifier
-                                .padding(
-                                    horizontal = RadixTheme.dimensions.paddingMedium,
-                                    vertical = RadixTheme.dimensions.paddingXSmall
-                                ),
-                            text = stringResource(
-                                id = R.string.assetTransfer_accountList_toLabel
-                            ).uppercase(),
-                            style = RadixTheme.typography.body1Link,
-                            color = RadixTheme.colors.gray2,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        StrokeLine(height = 30.dp)
-                    }
-                }
-
-                items(state.targetAccounts.size) { index ->
-                    val targetAccount = state.targetAccounts[index]
-                    TargetAccountCard(
-                        onChooseAccountClick = {
-                            focusManager.clearFocus()
-                            onChooseAccountForSkeleton(targetAccount)
-                        },
-                        onAddAssetsClick = {
-                            focusManager.clearFocus()
-                            onAddAssetsClick(targetAccount)
-                        },
-                        onRemoveAssetClicked = { spendingAsset ->
-                            onRemoveAssetClick(targetAccount, spendingAsset)
-                        },
-                        onAmountTyped = { spendingAsset, amount ->
-                            onAmountTyped(targetAccount, spendingAsset, amount)
-                        },
-                        onMaxAmountClicked = { spendingAsset ->
-                            focusManager.clearFocus()
-                            onMaxAmountClicked(targetAccount, spendingAsset)
-                        },
-                        onDeleteClick = {
-                            deleteAccountClick(targetAccount)
-                        },
-                        isDeletable = !(targetAccount is TargetAccount.Skeleton && index == 0),
-                        targetAccount = targetAccount
-                    )
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                }
-
-                item {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = RadixTheme.dimensions.paddingDefault),
-                        horizontalArrangement = Arrangement.End
-                    ) {
-                        RadixTextButton(
-                            text = stringResource(
-                                id = R.string.assetTransfer_accountList_addAccountButton
+                            .padding(
+                                start = RadixTheme.dimensions.paddingSmall
                             ),
-                            onClick = addAccountClick,
+                        text = stringResource(id = R.string.assetTransfer_header_transfer),
+                        style = RadixTheme.typography.title,
+                        color = RadixTheme.colors.gray1,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Spacer(modifier = Modifier.weight(1f))
+                    if (state.messageState is State.Message.None) {
+                        RadixTextButton(
+                            text = stringResource(id = R.string.assetTransfer_header_addMessageButton),
+                            onClick = { onMessageStateChanged(true) },
                             leadingIcon = {
                                 Icon(
-                                    painter = painterResource(
-                                        id = R.drawable.ic_add_account
-                                    ),
+                                    painter = painterResource(id = R.drawable.ic_add_message),
                                     contentDescription = ""
                                 )
                             }
                         )
                     }
+                }
+            }
 
-                    val isEnabled = remember(state) { state.isSubmitEnabled }
+            if (state.messageState is State.Message.Added) {
+                item {
+                    TransferMessage(
+                        message = state.messageState.message,
+                        onMessageChanged = onMessageChanged,
+                        onMessageClose = { onMessageStateChanged(false) }
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                }
+            }
 
-                    RadixPrimaryButton(
-                        text = stringResource(id = R.string.assetTransfer_sendTransferButton),
-                        onClick = onTransferSubmit,
+            state.fromAccount?.let { account ->
+                item {
+                    Text(
                         modifier = Modifier
-                            .padding(vertical = RadixTheme.dimensions.paddingDefault)
-                            .fillMaxWidth(),
-                        enabled = isEnabled
+                            .padding(
+                                horizontal = RadixTheme.dimensions.paddingMedium,
+                                vertical = RadixTheme.dimensions.paddingXSmall
+                            ),
+                        text = stringResource(
+                            id = R.string.assetTransfer_accountList_fromLabel
+                        ).uppercase(),
+                        style = RadixTheme.typography.body1Link,
+                        color = RadixTheme.colors.gray2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                    SimpleAccountCard(
+                        modifier = Modifier.fillMaxWidth(),
+                        account = account
                     )
                 }
             }
+
+            item {
+                StrokeLine(height = 50.dp)
+            }
+
+            item {
+                Row {
+                    Text(
+                        modifier = Modifier
+                            .padding(
+                                horizontal = RadixTheme.dimensions.paddingMedium,
+                                vertical = RadixTheme.dimensions.paddingXSmall
+                            ),
+                        text = stringResource(
+                            id = R.string.assetTransfer_accountList_toLabel
+                        ).uppercase(),
+                        style = RadixTheme.typography.body1Link,
+                        color = RadixTheme.colors.gray2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    StrokeLine(height = 30.dp)
+                }
+            }
+
+            items(state.targetAccounts.size) { index ->
+                val targetAccount = state.targetAccounts[index]
+                TargetAccountCard(
+                    onChooseAccountClick = {
+                        focusManager.clearFocus()
+                        onChooseAccountForSkeleton(targetAccount)
+                    },
+                    onAddAssetsClick = {
+                        focusManager.clearFocus()
+                        onAddAssetsClick(targetAccount)
+                    },
+                    onRemoveAssetClicked = { spendingAsset ->
+                        onRemoveAssetClick(targetAccount, spendingAsset)
+                    },
+                    onAmountTyped = { spendingAsset, amount ->
+                        onAmountTyped(targetAccount, spendingAsset, amount)
+                    },
+                    onMaxAmountClicked = { spendingAsset ->
+                        focusManager.clearFocus()
+                        onMaxAmountClicked(targetAccount, spendingAsset)
+                    },
+                    onDeleteClick = {
+                        deleteAccountClick(targetAccount)
+                    },
+                    isDeletable = !(targetAccount is TargetAccount.Skeleton && index == 0),
+                    targetAccount = targetAccount
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+            }
+
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = RadixTheme.dimensions.paddingDefault),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    RadixTextButton(
+                        text = stringResource(
+                            id = R.string.assetTransfer_accountList_addAccountButton
+                        ),
+                        onClick = addAccountClick,
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(
+                                    id = R.drawable.ic_add_account
+                                ),
+                                contentDescription = ""
+                            )
+                        }
+                    )
+                }
+
+                val isEnabled = remember(state) { state.isSubmitEnabled }
+
+                RadixPrimaryButton(
+                    text = stringResource(id = R.string.assetTransfer_sendTransferButton),
+                    onClick = onTransferSubmit,
+                    modifier = Modifier
+                        .padding(vertical = RadixTheme.dimensions.paddingDefault)
+                        .fillMaxWidth(),
+                    enabled = isEnabled
+                )
+            }
         }
+    }
+
+    if (bottomSheetState.isVisible) {
+        DefaultModalSheetLayout(
+            modifier = Modifier.imePadding(),
+            sheetState = bottomSheetState,
+            sheetContent = {
+                when (val sheetState = state.sheet) {
+                    is State.Sheet.ChooseAccounts -> {
+                        ChooseAccountSheet(
+                            onCloseClick = onSheetClosed,
+                            state = sheetState,
+                            onOwnedAccountSelected = onOwnedAccountSelected,
+                            onChooseAccountSubmitted = onChooseAccountSubmitted,
+                            onAddressDecoded = onAddressDecoded,
+                            onQrCodeIconClick = onQrCodeIconClick,
+                            cancelQrScan = cancelQrScan,
+                            onAddressChanged = onAddressTyped
+                        )
+                    }
+
+                    is State.Sheet.ChooseAssets -> {
+                        ChooseAssetsSheet(
+                            state = sheetState,
+                            onTabSelected = { onChooseAssetTabSelected(it) },
+                            onCloseClick = onSheetClosed,
+                            onAssetSelectionChanged = onAssetSelectionChanged,
+                            onNextNFtsPageRequest = onNextNFTsPageRequest,
+                            onStakesRequest = onStakesRequest,
+                            onUiMessageShown = onUiMessageShown,
+                            onChooseAssetsSubmitted = onChooseAssetsSubmitted
+                        )
+                    }
+
+                    is State.Sheet.None -> {}
+                }
+            }
+        )
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SyncSheetState(
-    bottomSheetState: ModalBottomSheetState,
+    sheetState: SheetState,
     isSheetVisible: Boolean,
     onSheetClosed: () -> Unit,
 ) {
@@ -395,14 +394,14 @@ private fun SyncSheetState(
 
     LaunchedEffect(isSheetVisible) {
         if (isSheetVisible) {
-            scope.launch { bottomSheetState.show() }
+            scope.launch { sheetState.show() }
         } else {
-            scope.launch { bottomSheetState.hide() }
+            scope.launch { sheetState.hide() }
         }
     }
 
-    LaunchedEffect(bottomSheetState.isVisible) {
-        if (!bottomSheetState.isVisible) {
+    LaunchedEffect(sheetState.isVisible) {
+        if (!sheetState.isVisible) {
             onSheetClosed()
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
@@ -183,6 +183,7 @@ private fun ChooseAccountContent(
 ) {
     LazyColumn(
         modifier = modifier
+            .fillMaxSize()
             .navigationBarsPadding(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DefaultModalSheetLayout.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DefaultModalSheetLayout.kt
@@ -2,13 +2,14 @@ package com.babylon.wallet.android.presentation.ui.composables
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -16,25 +17,28 @@ import androidx.compose.ui.graphics.Color
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.ui.modifier.applyIf
 
-@OptIn(ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DefaultModalSheetLayout(
     modifier: Modifier = Modifier,
-    sheetState: ModalBottomSheetState,
+    sheetState: SheetState,
     heightFraction: Float = 0.9f,
     enableImePadding: Boolean = false,
     wrapContent: Boolean = false,
-    sheetContent: @Composable () -> Unit,
-    content: @Composable () -> Unit
+    sheetContent: @Composable () -> Unit
 ) {
+    val windowInsets = WindowInsets(0)
+
     BoxWithConstraints(modifier = modifier) {
         val sheetHeight = maxHeight * heightFraction
-        ModalBottomSheetLayout(
+        ModalBottomSheet(
             sheetState = sheetState,
-            sheetBackgroundColor = RadixTheme.colors.defaultBackground,
+            containerColor = RadixTheme.colors.defaultBackground,
             scrimColor = Color.Black.copy(alpha = 0.3f),
-            sheetShape = RadixTheme.shapes.roundedRectTopDefault,
-            sheetContent = {
+            dragHandle = {},
+            windowInsets = windowInsets,
+            shape = RadixTheme.shapes.roundedRectTopDefault,
+            content = {
                 Box(
                     modifier = Modifier
                         .applyIf(enableImePadding, Modifier.imePadding())
@@ -45,9 +49,8 @@ fun DefaultModalSheetLayout(
                 ) {
                     sheetContent()
                 }
-            }
-        ) {
-            content()
-        }
+            },
+            onDismissRequest = { }
+        )
     }
 }


### PR DESCRIPTION
## Description
This PR covers migration of ModalBottomSheet towards material3. More info here -> https://developer.android.com/jetpack/compose/designsystems/material2-material3

## How to test

Ideally we should check the following areas as that is where the code has been affected:
- AccountSettingsScreen
- SpecificAssetsDepositsScreen
- SpecificDepositorScreen
- SpecificDepositorScreen
- BackupScreen
- GatewaysScreen
- DappDetailScreen
- CreatePersonaScreen
- PersonaDetailScreen
- PersonaEditScreen
- TransactionReviewScreen
- TransferScreen


## PR submission checklist
- [x] I have tested screens linked above to see if UI is not broken.
