### PR TITLE
ABW-2526 - Navigation bar padding added to fix Android 14 issue.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -20,8 +21,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.Icon
-import androidx.compose.material.Surface
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -171,6 +172,7 @@ private fun AccountScreenContent(
     Box(
         modifier = modifier
             .pullRefresh(pullToRefreshState)
+            .navigationBarsPadding()
             .background(Brush.horizontalGradient(gradient))
             .statusBarsPadding()
     ) {


### PR DESCRIPTION
## Description
This PR fixes Android 14 padding issue. See ticket to understand the problem.

## How to test

1. Open account detail screen and verify that bottom nav bar is not coloured same as status bar with gradient.

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/62631247-63a6-47a0-9766-d4bf39c2119a" width="300">

## PR submission checklist
- [x] I have verified that bottom nav bar is displayed correctly on Android 14
