### PR TITLE
Fix nft name when it resembles a url

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/StateNonFungibleDetailsResponseItemExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/StateNonFungibleDetailsResponseItemExtensions.kt
@@ -42,12 +42,12 @@ fun StateNonFungibleDetailsResponseItem.toMetadata(): List<Metadata> {
 }
 
 @Suppress("CyclomaticComplexMethod", "LongMethod")
-private fun ProgrammaticScryptoSborValue.toMetadata(): Metadata? = fieldName?.let { key ->
+private fun ProgrammaticScryptoSborValue.toMetadata(isCollection: Boolean = false): Metadata? = fieldName?.let { key ->
     when (val sborValue = this) {
         is ProgrammaticScryptoSborValueString -> Metadata.Primitive(
             key = key,
             value = sborValue.value,
-            valueType = if (key in NFTExplicitMetadataKeys) {
+            valueType = if (!isCollection && key in NFTExplicitMetadataKeys) {
                 // Keep the type as string even if the content resembles another type,
                 // when the key is in the list of explicitly handled NFT data
                 MetadataType.String
@@ -154,21 +154,21 @@ private fun ProgrammaticScryptoSborValue.toMetadata(): Metadata? = fieldName?.le
 
         is ProgrammaticScryptoSborValueArray -> Metadata.Collection(
             key = key,
-            values = sborValue.elements.mapNotNull { it.toMetadata() }
+            values = sborValue.elements.mapNotNull { it.toMetadata(isCollection = true) }
         )
 
         is ProgrammaticScryptoSborValueMap -> Metadata.Map(
             key = key,
             values = sborValue.propertyEntries.mapNotNull { entry ->
-                val entryKey = entry.key.toMetadata() ?: return@mapNotNull null
-                val entryValue = entry.value.toMetadata() ?: return@mapNotNull null
+                val entryKey = entry.key.toMetadata(isCollection = true) ?: return@mapNotNull null
+                val entryValue = entry.value.toMetadata(isCollection = true) ?: return@mapNotNull null
                 entryKey to entryValue
             }.toMap()
         )
 
         is ProgrammaticScryptoSborValueTuple -> Metadata.Collection(
             key = key,
-            values = sborValue.fields.mapNotNull { it.toMetadata() }
+            values = sborValue.fields.mapNotNull { it.toMetadata(isCollection = true) }
         )
 
         is ProgrammaticScryptoSborValueReference -> if (sborValue.value.toAddressOrNull() != null) {


### PR DESCRIPTION
## Description
A bug reported on discord by a user who created NFTs with names that are converted to URLs. In the current implementation all NFT data are processed by the wallet, and especially string data are converted to either URL or Address types if they match that type. This conversion should not happen though for NFT data with keys `"name"` or `"description"` as they should be treated as strings, even if they resemble an address or a URL.

## How to test
Add the address `account_tdx_2_1292jyxrlexx6m877v038jmyjs0cna83l3suppctuy257x5a4unjqds` to your wallet to see a list of NFT collections. One of them is the "Domain Name" collection. Its NFT should now show the domain name.

## Screenshot

Previous
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/e75c132a-c843-4e1f-b86a-bb10a7822cc5" width="300">

Current
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/1dfe336f-280a-4e8b-a6cf-3383b8f498d0" width="30%">


## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
