### PR TITLE
Task to reformat localization files when it detects line breaks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -250,30 +250,48 @@ tasks.withType(Test.class).configureEach {
     }
 }
 /**
- * Copies the english translation file to the default location.
- * This is needed since Crowdin cannot create pull requests
- * in a path that does not declare the language code.
+ * First reformats all translated files (received from Crowdin), to use new lines
+ * instead of line breaks
  *
- * So assuming that the english language defined in the values-es is the default,
- * this will be the file that gets copied.
+ * As a last step it copies the english translation to the default /values/strings.xml file.
+ *
+ * Both steps are needed, because Crowdin replaces new lines with line breaks.
+ * Strings with line breaks have no effect in XML. Also Crowdin does not create a PR for the
+ * default language.
  */
-task buildDefaultLanguage {
-    copy {
-        from('src/main/res/values-en/strings.xml') {
-            filter {
-                line -> if (line.isEmpty()) {
-                    '\\n\\n'
-                } else {
-                    line
-                }
+tasks.register('reformatLocalizationFiles') {
+    def resDir = new File(projectDir.absolutePath, "/src/main/res/")
+    def inputFiles = resDir.listFiles().findAll {
+        it.name != "values" && it.name.startsWith("values") && (new File(it, "strings.xml")).exists()
+    }.collect { it.absolutePath + "/strings.xml" }
+
+    it.inputs.files(inputFiles)
+    it.outputs.files(inputFiles + (projectDir.absolutePath + "/src/main/res/values/strings.xml"))
+    it.doFirst {
+        inputFiles.forEach { filePath ->
+            def stringsFile = new File(filePath)
+            def stringsNode = new groovy.xml.XmlParser().parse(stringsFile)
+            stringsNode.children().forEach {
+                def node = it as Node
+                def value = node.text()
+                node.setValue(value.replace("\n", "\\n"))
             }
+
+            Writer sw = new FileWriter(stringsFile);
+            PrintWriter pw = new PrintWriter(sw);
+            sw.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
+            def nodePrinter = new groovy.xml.XmlNodePrinter(pw);
+            nodePrinter.setPreserveWhitespace(true);
+            nodePrinter.print(stringsNode);
+            sw.close()
+            pw.close()
         }
-        into 'src/main/res/values/'
     }
-    // Move content from values/strings.xml to values-en/strings.xml
-    copy {
-        from('src/main/res/values/strings.xml')
-        into 'src/main/res/values-en/'
+    it.doLast {
+        copy {
+            from('src/main/res/values-en/strings.xml')
+            into('src/main/res/values/')
+        }
     }
 }
-preBuild.dependsOn buildDefaultLanguage
+preBuild.dependsOn reformatLocalizationFiles

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -581,11 +581,7 @@
   <string name="splash_profileOnAnotherDeviceAlert_claimExisting">Claim Existing Wallet</string>
   <string name="splash_profileOnAnotherDeviceAlert_claimHere">Clear Wallet on This Phone</string>
   <string name="splash_profileOnAnotherDeviceAlert_askLater">Ask Later (no changes)</string>
-  <string name="splash_profileOnAnotherDeviceAlert_message">This wallet is currently configured with a set of Accounts and Personas in use by a different phone.
-\n\n
-To make changes to this wallet, you must claim it for use on this phone instead, removing access by the other phone.
-\n\n
-Or you can clear this wallet from this phone and start fresh.</string>
+  <string name="splash_profileOnAnotherDeviceAlert_message">This wallet is currently configured with a set of Accounts and Personas in use by a different phone.\n\nTo make changes to this wallet, you must claim it for use on this phone instead, removing access by the other phone.\n\nOr you can clear this wallet from this phone and start fresh.</string>
   <string name="splash_rootDetection_messageAndroid">It appears that your device might be rooted. To ensure the security of your Accounts and assets, using the Radix Wallet on rooted devices is not recommended. Please confirm if you wish to continue anyway at your own risk.</string>
   <string name="splash_rootDetection_titleIOS">Possible jailbreak detected</string>
   <string name="splash_rootDetection_messageIOS">It appears that your device might be jailbroken. To ensure the security of your Accounts and assets, using the Radix Wallet on jailbroken devices is not recommended. Please confirm if you wish to continue anyway at your own risk.</string>
@@ -760,14 +756,10 @@ Or you can clear this wallet from this phone and start fresh.</string>
   <string name="addLedgerDevice_nameLedger_detectedType">Detected type: %s</string>
   <string name="addLedgerDevice_nameLedger_namePlaceholder">Green Ledger Nano S+</string>
   <string name="addLedgerDevice_nameLedger_continueButtonTitle">Save and Continue</string>
-  <string name="profileBackup_headerTitle">Backing up your wallet ensures that you can restore access to your Accounts, Personas, and wallet settings on a new phone by re-entering your seed phrase(s).
-\n\n
-**For security, backups do not contain any seed phrases or private keys. You must write them down separately.**</string>
+  <string name="profileBackup_headerTitle">Backing up your wallet ensures that you can restore access to your Accounts, Personas, and wallet settings on a new phone by re-entering your seed phrase(s).\n\n**For security, backups do not contain any seed phrases or private keys. You must write them down separately.**</string>
   <string name="profileBackup_automaticBackups_title">Automatic Backups (recommended)</string>
   <string name="profileBackup_manualBackups_title">Manual Backups</string>
-  <string name="profileBackup_manualBackups_subtitle">A manually exported wallet backup file may also be used for recovery, along with your seed phrase(s).
-\n\n
-Only the **current configuration** of your wallet is backed up with each manual export.</string>
+  <string name="profileBackup_manualBackups_subtitle">A manually exported wallet backup file may also be used for recovery, along with your seed phrase(s).\n\nOnly the **current configuration** of your wallet is backed up with each manual export.</string>
   <string name="profileBackup_manualBackups_exportButtonTitle">Export Wallet Backup File</string>
   <string name="profileBackup_manualBackups_encryptBackupDialogTitle">Encrypt this backup with a password?</string>
   <string name="profileBackup_manualBackups_successMessage">Exported wallet backup file</string>
@@ -799,9 +791,7 @@ Only the **current configuration** of your wallet is backed up with each manual 
   <string name="androidProfileBackup_openSystemBackupSettings">Open System Backup Settings</string>
   <string name="androidProfileBackup_backupWalletData_title">Backup Wallet Data to Cloud</string>
   <string name="androidProfileBackup_backupWalletData_message">Warning: If disabled you might lose access to your Accounts and Personas.</string>
-  <string name="androidProfileBackup_deleteWallet_subtitle">You may delete your wallet. This will clear the Radix Wallet app, clears its contents, and delete any cloud backup.
-\n\n
-**Access to any Accounts or Personas will be permanently lost unless you have a manual backup file.**</string>
+  <string name="androidProfileBackup_deleteWallet_subtitle">You may delete your wallet. This will clear the Radix Wallet app, clears its contents, and delete any cloud backup.\n\n**Access to any Accounts or Personas will be permanently lost unless you have a manual backup file.**</string>
   <string name="androidProfileBackup_deleteWallet_confirmButton">Delete Wallet</string>
   <string name="iOSProfileBackup_iCloudSyncEnabledAlert_title">Enabling iCloud sync</string>
   <string name="iOSProfileBackup_iCloudSyncEnabledAlert_message">iCloud sync is now enabled, but it might take up to an hour before your wallet data is uploaded to iCloud.</string>
@@ -824,9 +814,7 @@ Only the **current configuration** of your wallet is backed up with each manual 
   <string name="iOSProfileBackup_totalAccountsNumberLabel">Number of Accounts: %d</string>
   <string name="iOSProfileBackup_totalPersonasNumberLabel">Number of Personas: %d</string>
   <string name="iOSProfileBackup_incompatibleWalletDataLabel">Incompatible Wallet data</string>
-  <string name="iOSProfileBackup_deleteWallet_subtitle">You may delete your wallet. This will clear the Radix Wallet app, clears its contents, and delete any iCloud backup.
-\n\n
-**Access to any Accounts or Personas will be permanently lost unless you have a manual backup file.**</string>
+  <string name="iOSProfileBackup_deleteWallet_subtitle">You may delete your wallet. This will clear the Radix Wallet app, clears its contents, and delete any iCloud backup.\n\n**Access to any Accounts or Personas will be permanently lost unless you have a manual backup file.**</string>
   <string name="iOSProfileBackup_deleteWallet_confirmButton">Delete Wallet and iCloud Backup</string>
   <string name="iOSProfileBackup_profileNotFoundInCloud">Unable to find wallet backup in iCloud.</string>
   <string name="encryptProfileBackup_header_title">Encrypt Wallet Backup File</string>
@@ -854,11 +842,7 @@ Only the **current configuration** of your wallet is backed up with each manual 
   <string name="recoverSeedPhrase_header_titleOther">Seed Phrase Required</string>
   <string name="recoverSeedPhrase_header_subtitleMainSeedPhrase">Your **Personas** and the following **Accounts** are controlled by your main seed phrase. To recover control, you must re-enter it.</string>
   <string name="recoverSeedPhrase_header_subtitleOtherSeedPhrase">The following **Accounts** are controlled by a seed phrase. To recover control, you must re-enter it.</string>
-  <string name="recoverSeedPhrase_header_subtitleNoMainSeedPhrase">The Radix Wallet always uses a single main “Babylon” seed phrase to generate new Personas and new Accounts (when not using a Ledger device).
-\n\n
-If you do not have access to your previous main seed phrase, you can skip entering it for now. **The Radix Wallet will create a new one, which will be used for new Personas and Accounts.**
-\n\n
-Your old Accounts and Personas will still be listed, but you will have to enter their original seed phrase to use them. Alternatively, you can hide them if you no longer are interested in using them.</string>
+  <string name="recoverSeedPhrase_header_subtitleNoMainSeedPhrase">The Radix Wallet always uses a single main “Babylon” seed phrase to generate new Personas and new Accounts (when not using a Ledger device).\n\nIf you do not have access to your previous main seed phrase, you can skip entering it for now. **The Radix Wallet will create a new one, which will be used for new Personas and Accounts.**\n\nYour old Accounts and Personas will still be listed, but you will have to enter their original seed phrase to use them. Alternatively, you can hide them if you no longer are interested in using them.</string>
   <string name="recoverSeedPhrase_skipButton">Skip This Seed Phrase For Now</string>
   <string name="recoverSeedPhrase_noMainSeedPhraseButton">I Don’t Have the Main Seed Phrase</string>
   <string name="recoverSeedPhrase_enterButton">Enter This Seed Phrase</string>
@@ -921,9 +905,7 @@ Your old Accounts and Personas will still be listed, but you will have to enter 
   <string name="accountRecoveryScan_babylonSection_title">Babylon Accounts</string>
   <string name="accountRecoveryScan_babylonSection_subtitle">Scan for Accounts originally created on the **Babylon** network.</string>
   <string name="accountRecoveryScan_olympiaSection_title">Olympia Accounts</string>
-  <string name="accountRecoveryScan_olympiaSection_subtitle">Scan for Accounts originally created on the **Olympia** network.
-\n\n
-(If you have Olympia Accounts in the Radix Olympia Desktop Wallet, consider using **Import from a Legacy Wallet** instead.</string>
+  <string name="accountRecoveryScan_olympiaSection_subtitle">Scan for Accounts originally created on the **Olympia** network.\n\n(If you have Olympia Accounts in the Radix Olympia Desktop Wallet, consider using **Import from a Legacy Wallet** instead.</string>
   <string name="accountRecoveryScan_olympiaSection_footnote">Note: You will still use the new **Radix Babylon** app on your Ledger device, not the old Radix Ledger app.</string>
   <string name="accountRecoveryScan_seedPhraseButtonTitle">Use Seed Phrase</string>
   <string name="accountRecoveryScan_ledgerButtonTitle">Use Ledger Hardware Wallet</string>
@@ -941,9 +923,7 @@ Your old Accounts and Personas will still be listed, but you will have to enter 
   <string name="accountSecuritySettings_ledgerHardwareWallets_title">Ledger Hardware Wallets</string>
   <string name="accountSecuritySettings_depositGuarantees_title">Default Deposit Guarantees</string>
   <string name="accountSecuritySettings_depositGuarantees_subtitle">Set your default guaranteed minimum for estimated deposits</string>
-  <string name="accountSecuritySettings_depositGuarantees_text">Set the guaranteed minimum deposit to be applied whenever a deposit in a transaction can only be estimated.
-\n\n
-You can always change the guarantee from this default in each transaction.</string>
+  <string name="accountSecuritySettings_depositGuarantees_text">Set the guaranteed minimum deposit to be applied whenever a deposit in a transaction can only be estimated.\n\nYou can always change the guarantee from this default in each transaction.</string>
   <string name="accountSecuritySettings_accountRecoveryScan_title">Account Recovery Scan</string>
   <string name="accountSecuritySettings_accountRecoveryScan_subtitle">Using seed phrase or Ledger device</string>
   <string name="accountSecuritySettings_backups_title">Backups</string>
@@ -976,13 +956,9 @@ You can always change the guarantee from this default in each transaction.</stri
   <string name="recoverWalletWithoutProfile_start_useNewWalletAlertCancel">Cancel</string>
   <string name="recoverWalletWithoutProfile_start_useNewWalletAlertContinue">Continue</string>
   <string name="recoverWalletWithoutProfile_info_headerTitle">Recover Control Without Backup</string>
-  <string name="recoverWalletWithoutProfile_info_headerSubtitle">**If you have no wallet backup in the cloud or as an exported backup file**, you can still restore Account access only using your main “Babylon” seed phrase. You cannot recover your Account names or other wallet settings this way.
-\n\n
-You will be asked to enter your main seed phrase. This is a set of **24 words** that the Radix Wallet mobile app showed you to write down and save securely.</string>
+  <string name="recoverWalletWithoutProfile_info_headerSubtitle">**If you have no wallet backup in the cloud or as an exported backup file**, you can still restore Account access only using your main “Babylon” seed phrase. You cannot recover your Account names or other wallet settings this way.\n\nYou will be asked to enter your main seed phrase. This is a set of **24 words** that the Radix Wallet mobile app showed you to write down and save securely.</string>
   <string name="recoverWalletWithoutProfile_info_continueButton">Continue</string>
   <string name="recoverWalletWithoutProfile_complete_headerTitle">Recovery Complete</string>
-  <string name="recoverWalletWithoutProfile_complete_headerSubtitle">Accounts discovered in the scan have been added to your wallet.
-\n\n
-If you have any “Legacy” Accounts (created on the Olympia network) to import - or any Accounts using a Ledger hardware wallet device - please continue and then use the **Account Recovery Scan** option in your Radix Wallet settings under **Account Security**.</string>
+  <string name="recoverWalletWithoutProfile_complete_headerSubtitle">Accounts discovered in the scan have been added to your wallet.\n\nIf you have any “Legacy” Accounts (created on the Olympia network) to import - or any Accounts using a Ledger hardware wallet device - please continue and then use the **Account Recovery Scan** option in your Radix Wallet settings under **Account Security**.</string>
   <string name="recoverWalletWithoutProfile_complete_continueButton">Continue</string>
 </resources>


### PR DESCRIPTION
## Description
The problem we are facing is that Crowdin replaces `\n` values with line breaks. This has no effect in our app, since line breaks do not result in new lines when loaded from XML.

The focus of this PR is to change the task a bit to be able to correctly replace those line breaks with `\n`. The previous solution only worked when it matched empty lines, which means that it was produced from a string with `\n\n`. Simple new lines could not be detected (although we don't have such a string with one new line yet).

So in order to properly mutate the files we need to use XMLParser and do the mutation on each string node. As a last step of the task we also need to copy the `values-en` strings file to the `values` directory since Crowdin does not provide that.

The task supports incremental builds since it registers what files are affected as inputs and outputs. 

Another goal of this PR is to **commit the file with the `\n` in place so as to see if Crowdin tries to change them with a new PR.**