### PR TITLE
Fix dialogs corners

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
+++ b/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
@@ -138,8 +138,8 @@ fun WalletApp(
                     mainViewModel.clearOlympiaError()
                 }
             },
-            title = stringResource(id = R.string.homePage_profileOlympiaError_title),
-            text = stringResource(id = R.string.homePage_profileOlympiaError_subtitle),
+            titleText = stringResource(id = R.string.homePage_profileOlympiaError_title),
+            messageText = stringResource(id = R.string.homePage_profileOlympiaError_subtitle),
             confirmText = confirmText,
             dismissText = null
         )
@@ -149,8 +149,8 @@ fun WalletApp(
             finish = {
                 mainViewModel.onInvalidRequestMessageShown()
             },
-            title = stringResource(id = R.string.dAppRequest_validationOutcome_invalidRequestTitle),
-            text = it.userFriendlyMessage(),
+            titleText = stringResource(id = R.string.dAppRequest_validationOutcome_invalidRequestTitle),
+            messageText = it.userFriendlyMessage(),
             confirmText = stringResource(
                 id = R.string.common_ok
             ),

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/VerifyDAppUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/VerifyDAppUseCase.kt
@@ -73,8 +73,8 @@ class VerifyDAppUseCase @Inject constructor(
     }
 
     private suspend fun DApp.verify(origin: String) = when {
-        !isDappDefinition -> throw RadixWalletException.DappVerificationException.WrongAccountType
-        !isRelatedWith(origin) -> throw RadixWalletException.DappVerificationException.UnknownWebsite
+        !isDappDefinition -> Result.failure(RadixWalletException.DappVerificationException.WrongAccountType)
+        !isRelatedWith(origin) -> Result.failure(RadixWalletException.DappVerificationException.UnknownWebsite)
         else ->
             wellKnownDAppDefinitionRepository
                 .getWellKnownDAppDefinitions(origin)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/ChooseLedgerScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/ChooseLedgerScreen.kt
@@ -79,7 +79,7 @@ fun ChooseLedgerScreen(
                     color = RadixTheme.colors.gray1
                 )
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.ledgerHardwareDevices_linkConnectorAlert_message),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/recover/scan/AccountRecoveryScanScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/recover/scan/AccountRecoveryScanScreen.kt
@@ -81,8 +81,8 @@ fun AccountRecoveryScanScreen(
             finish = {
                 viewModel.dismissNoMnemonicError()
             },
-            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
-            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            titleText = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            messageText = stringResource(id = R.string.transactionReview_noMnemonicError_text),
             dismissText = null
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
@@ -77,7 +77,7 @@ fun AccountSettingsScreen(
                 }
                 showHideAccountPrompt = false
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.accountSettings_hideAccountConfirmation),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
@@ -126,7 +126,7 @@ fun SpecificAssetsDepositsScreen(
                     color = RadixTheme.colors.gray1
                 )
             },
-            text = {
+            message = {
                 Text(
                     text = when (dialogState.assetException.exceptionRule) {
                         ThirdPartyDeposits.DepositAddressExceptionRule.Allow -> {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
@@ -108,7 +108,7 @@ fun SpecificDepositorScreen(
                     color = RadixTheme.colors.gray1
                 )
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.accountSettings_specificAssetsDeposits_removeDepositorMessage),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/thirdpartydeposits/AccountThirdPartyDepositsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/thirdpartydeposits/AccountThirdPartyDepositsScreen.kt
@@ -76,7 +76,7 @@ fun AccountThirdPartyDepositsScreen(
                 }
                 showCancelPrompt = false
             },
-            text = {
+            message = {
                 androidx.compose.material3.Text(
                     text = stringResource(
                         R.string.accountSettings_thirdPartyDeposits_discardMessage

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DappInteractionFailureDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DappInteractionFailureDialog.kt
@@ -30,7 +30,7 @@ fun DappInteractionFailureDialog(
                         color = RadixTheme.colors.gray1
                     )
                 },
-                text = {
+                message = {
                     Text(
                         text = dialogState.dappRequestException.userFriendlyMessage(),
                         style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
@@ -46,8 +46,8 @@ fun ChooseAccountsScreen(
             finish = {
                 sharedViewModel.dismissNoMnemonicError()
             },
-            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
-            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            titleText = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            messageText = stringResource(id = R.string.transactionReview_noMnemonicError_text),
             dismissText = null
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
@@ -69,8 +69,8 @@ fun DappAuthorizedLoginScreen(
             finish = {
                 viewModel.dismissNoMnemonicError()
             },
-            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
-            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            titleText = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            messageText = stringResource(id = R.string.transactionReview_noMnemonicError_text),
             dismissText = null
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
@@ -79,8 +79,8 @@ fun PersonaDataOnetimeScreen(
             finish = {
                 sharedViewModel.dismissNoMnemonicError()
             },
-            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
-            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            titleText = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            messageText = stringResource(id = R.string.transactionReview_noMnemonicError_text),
             dismissText = null
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
@@ -74,8 +74,8 @@ fun PersonaDataOngoingScreen(
             finish = {
                 sharedViewModel.dismissNoMnemonicError()
             },
-            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
-            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            titleText = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            messageText = stringResource(id = R.string.transactionReview_noMnemonicError_text),
             dismissText = null
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
@@ -82,8 +82,8 @@ fun SelectPersonaScreen(
             finish = {
                 sharedViewModel.dismissNoMnemonicError()
             },
-            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
-            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            titleText = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            messageText = stringResource(id = R.string.transactionReview_noMnemonicError_text),
             dismissText = null
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
@@ -45,8 +45,8 @@ fun OneTimeChooseAccountsScreen(
             finish = {
                 sharedViewModel.dismissNoMnemonicError()
             },
-            title = stringResource(id = R.string.transactionReview_noMnemonicError_title),
-            text = stringResource(id = R.string.transactionReview_noMnemonicError_text),
+            titleText = stringResource(id = R.string.transactionReview_noMnemonicError_title),
+            messageText = stringResource(id = R.string.transactionReview_noMnemonicError_text),
             dismissText = null
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
@@ -81,7 +81,7 @@ fun DappUnauthorizedLoginScreen(
                             color = RadixTheme.colors.gray1
                         )
                     },
-                    text = {
+                    message = {
                         Text(
                             text = dialogState.dappRequestException.userFriendlyMessage(),
                             style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/incompatibleprofile/IncompatibleProfileDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/incompatibleprofile/IncompatibleProfileDialog.kt
@@ -56,7 +56,7 @@ fun IncompatibleProfileContent(
                     color = RadixTheme.colors.gray1
                 )
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.splash_incompatibleProfileVersionAlert_message),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/withoutbackup/RestoreWithoutBackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/withoutbackup/RestoreWithoutBackupScreen.kt
@@ -57,8 +57,8 @@ fun RestoreWithoutBackupScreen(
                     viewModel.onDismissPrompt()
                 }
             },
-            title = stringResource(id = R.string.recoverWalletWithoutProfile_start_useNewWalletAlertTitle),
-            text = when (state.dialogPrompt) {
+            titleText = stringResource(id = R.string.recoverWalletWithoutProfile_start_useNewWalletAlertTitle),
+            messageText = when (state.dialogPrompt) {
                 RestoreWithoutBackupViewModel.State.PromptState.Olympia -> {
                     stringResource(id = R.string.recoverWalletWithoutProfile_start_useNewWalletAlertMessageOlympia)
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/rootdetection/RootDetectionDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/rootdetection/RootDetectionDialog.kt
@@ -46,7 +46,7 @@ fun RootDetectionContent(
                     onCloseApp()
                 }
             },
-            text = stringResource(id = R.string.splash_rootDetection_messageAndroid),
+            messageText = stringResource(id = R.string.splash_rootDetection_messageAndroid),
             confirmText = stringResource(id = R.string.splash_rootDetection_acknowledgeButton),
             dismissText = stringResource(id = R.string.common_cancel)
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -779,7 +779,7 @@ private fun VerifyWithYourSeedPhrasePage(
                 }
                 showOlympiaSeedPhrasePrompt = false
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.importOlympiaAccounts_verifySeedPhrase_keepSeedPhrasePrompt),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
@@ -76,7 +76,7 @@ fun LedgerHardwareWalletsScreen(
                     color = RadixTheme.colors.gray1
                 )
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.ledgerHardwareDevices_linkConnectorAlert_message),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/reveal/RevealSeedPhraseScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/reveal/RevealSeedPhraseScreen.kt
@@ -77,8 +77,8 @@ fun RevealSeedPhraseScreen(
                     onBackClick()
                 }
             },
-            title = stringResource(id = R.string.revealSeedPhrase_warningDialog_title),
-            text = stringResource(id = R.string.revealSeedPhrase_warningDialog_subtitle),
+            titleText = stringResource(id = R.string.revealSeedPhrase_warningDialog_title),
+            messageText = stringResource(id = R.string.revealSeedPhrase_warningDialog_subtitle),
             confirmText = stringResource(id = R.string.revealSeedPhrase_warningDialog_confirmButton)
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/entityhiding/HiddenEntitiesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/entityhiding/HiddenEntitiesScreen.kt
@@ -74,7 +74,7 @@ private fun HiddenEntitiesContent(
                 }
                 showUnhideAllPrompt = false
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.appSettings_entityHiding_unhideAllConfirmation),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/gateways/GatewaysScreen.kt
@@ -368,7 +368,7 @@ private fun GatewayCard(
                     color = RadixTheme.colors.gray1
                 )
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.gateways_removeGatewayAlert_message),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -141,7 +141,7 @@ private fun LinkedConnectorsContent(
                                 color = RadixTheme.colors.gray1
                             )
                         },
-                        text = {
+                        message = {
                             Text(
                                 text = stringResource(id = R.string.linkedConnectors_removeConnectionAlert_message),
                                 style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/authorizeddapps/dappdetail/DappDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/authorizeddapps/dappdetail/DappDetailScreen.kt
@@ -179,7 +179,7 @@ private fun DappDetailContent(
                     color = RadixTheme.colors.gray1
                 )
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.authorizedDapps_removeAuthorizationAlert_message),
                     style = RadixTheme.typography.body2Regular,
@@ -571,7 +571,7 @@ private fun PersonaDetailsSheet(
                     color = RadixTheme.colors.gray1
                 )
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.authorizedDapps_removeAuthorizationAlert_message),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailScreen.kt
@@ -79,7 +79,7 @@ fun PersonaDetailScreen(
                 }
                 showHidePersonaPrompt = false
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.authorizedDapps_personaDetails_hidePersonaConfirmation),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personaedit/PersonaEditScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personaedit/PersonaEditScreen.kt
@@ -136,7 +136,7 @@ private fun PersonaEditContent(
                 }
                 showCancelPrompt = false
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(
                         R.string.editPersona_closeConfirmationDialog_message

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
@@ -113,7 +113,7 @@ fun TransactionStatusDialog(
                             viewModel.onDismissCanceled()
                         }
                     },
-                    text = {
+                    message = {
                         Text(text = stringResource(id = R.string.transactionStatus_dismissDialog_message))
                     },
                     confirmText = stringResource(id = R.string.common_ok),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -122,7 +122,7 @@ fun TransactionReviewScreen(
             is InteractionState.Ledger.Error -> {
                 BasicPromptAlertDialog(
                     finish = { viewModel.onCancelSigningClick() },
-                    text = {
+                    message = {
                         Text(text = it.failure.userFriendlyMessage())
                     },
                     confirmText = stringResource(id = R.string.common_ok),
@@ -184,8 +184,8 @@ private fun TransactionPreviewContent(
                 finish = {
                     dismissTransactionErrorDialog()
                 },
-                title = transactionError.getTitle(),
-                text = transactionError.getMessage(),
+                titleText = transactionError.getTitle(),
+                messageText = transactionError.getMessage(),
                 confirmText = stringResource(id = R.string.common_ok),
                 dismissText = null
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -148,8 +148,8 @@ fun TransferContent(
         if (error.maxAccountAmountLessThanFee) {
             BasicPromptAlertDialog(
                 finish = onLessThanFeeApplied,
-                title = stringResource(id = R.string.assetTransfer_maxAmountDialog_title),
-                text = "Sending the full amount of XRD in this account will require you to pay the transaction fee " +
+                titleText = stringResource(id = R.string.assetTransfer_maxAmountDialog_title),
+                messageText = "Sending the full amount of XRD in this account will require you to pay the transaction fee " +
                     "from a different account.", // TODO R.string.assetTransfer_maxAmountDialog_body2),
                 confirmText = stringResource(id = R.string.common_ok),
                 dismissText = stringResource(id = R.string.common_cancel)
@@ -157,8 +157,8 @@ fun TransferContent(
         } else {
             BasicPromptAlertDialog(
                 finish = onMaxAmountApplied,
-                title = stringResource(id = R.string.assetTransfer_maxAmountDialog_title),
-                text = stringResource(id = R.string.assetTransfer_maxAmountDialog_body),
+                titleText = stringResource(id = R.string.assetTransfer_maxAmountDialog_title),
+                messageText = stringResource(id = R.string.assetTransfer_maxAmountDialog_body),
                 confirmText = stringResource(
                     id = R.string.assetTransfer_maxAmountDialog_sendAllButton,
                     error.maxAccountAmount.displayableQuantity()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLinkConnectorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLinkConnectorScreen.kt
@@ -78,7 +78,7 @@ fun AddLinkConnectorScreen(
                     color = RadixTheme.colors.gray1
                 )
             },
-            text = {
+            message = {
                 Text(
                     text = stringResource(id = R.string.linkedConnectors_incorrectQrMessage),
                     style = RadixTheme.typography.body2Regular,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -215,15 +215,13 @@ fun BasicPromptAlertDialog(
     modifier: Modifier = Modifier,
     finish: (accepted: Boolean) -> Unit,
     title: (@Composable () -> Unit)? = null,
-    text: (@Composable () -> Unit)? = null,
+    message: (@Composable () -> Unit)? = null,
     confirmText: String = stringResource(id = R.string.common_confirm),
     dismissText: String? = stringResource(id = R.string.common_cancel),
     confirmTextColor: Color = RadixTheme.colors.blue2
 ) {
     AlertDialog(
-        modifier = modifier
-            .background(RadixTheme.colors.defaultBackground, shape = RadixTheme.shapes.roundedRectSmall)
-            .clip(RadixTheme.shapes.roundedRectSmall),
+        modifier = modifier,
         onDismissRequest = { finish(false) },
         confirmButton = {
             RadixTextButton(text = confirmText, onClick = { finish(true) }, contentColor = confirmTextColor)
@@ -234,7 +232,9 @@ fun BasicPromptAlertDialog(
             }
         },
         title = title,
-        text = text
+        text = message,
+        shape = RadixTheme.shapes.roundedRectSmall,
+        containerColor = RadixTheme.colors.defaultBackground
     )
 }
 
@@ -242,43 +242,36 @@ fun BasicPromptAlertDialog(
 fun BasicPromptAlertDialog(
     modifier: Modifier = Modifier,
     finish: (accepted: Boolean) -> Unit,
-    title: String? = null,
-    text: String? = null,
+    titleText: String? = null,
+    messageText: String? = null,
     confirmText: String = stringResource(id = R.string.common_confirm),
     dismissText: String? = stringResource(id = R.string.common_cancel),
     confirmTextColor: Color = RadixTheme.colors.blue2
 ) {
-    AlertDialog(
-        modifier = modifier
-            .background(RadixTheme.colors.defaultBackground, shape = RadixTheme.shapes.roundedRectSmall)
-            .clip(RadixTheme.shapes.roundedRectSmall),
-        onDismissRequest = { finish(false) },
-        confirmButton = {
-            RadixTextButton(text = confirmText, onClick = { finish(true) }, contentColor = confirmTextColor)
-        },
-        dismissButton = dismissText?.let {
-            {
-                RadixTextButton(text = it, onClick = { finish(false) })
-            }
-        },
-        title = title?.let {
+    BasicPromptAlertDialog(
+        modifier = modifier,
+        finish = finish,
+        title = titleText?.let {
             {
                 Text(
-                    text = title,
+                    text = it,
                     style = RadixTheme.typography.body1Header,
                     color = RadixTheme.colors.gray1
                 )
             }
         },
-        text = text?.let {
+        message = messageText?.let {
             {
                 Text(
-                    text = text,
+                    text = it,
                     style = RadixTheme.typography.body2Regular,
                     color = RadixTheme.colors.gray1
                 )
             }
-        }
+        },
+        confirmText = confirmText,
+        dismissText = dismissText,
+        confirmTextColor = confirmTextColor
     )
 }
 
@@ -297,7 +290,7 @@ fun NotSecureAlertDialog(
                 color = RadixTheme.colors.gray1
             )
         },
-        text = {
+        message = {
             Text(
                 text = stringResource(id = R.string.biometrics_deviceNotSecureAlert_message),
                 style = RadixTheme.typography.body2Regular,


### PR DESCRIPTION
## Description
1. After the compose update, we can define the shape of the alert dialog without applying a modifier to it. Also the secondary  composable for basic alerts is now reusing the primary one.
2. The check that verifies dapps returns a correct result and does not throw an exception. This bug was created by this PR #732 and essentially when a dapp could not get verified it would crash the app. In order to test this you can try and login with [ROLA](https://dev-sandbox.rdx-works-main.extratools.works/rola) while having the switch of developer mode off.

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
