### PR TITLE
Show error when notary and signers cannot be found

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/ResolveNotaryAndSignersUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/ResolveNotaryAndSignersUseCase.kt
@@ -1,0 +1,37 @@
+package com.babylon.wallet.android.domain.usecases
+
+import com.babylon.wallet.android.data.transaction.NotaryAndSigners
+import com.babylon.wallet.android.domain.RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities
+import com.radixdlt.ret.ManifestSummary
+import rdx.works.core.ret.crypto.PrivateKey
+import rdx.works.profile.data.model.pernetwork.Entity
+import rdx.works.profile.domain.GetProfileUseCase
+import rdx.works.profile.domain.accountsOnCurrentNetwork
+import rdx.works.profile.domain.personasOnCurrentNetwork
+import javax.inject.Inject
+
+class ResolveNotaryAndSignersUseCase @Inject constructor(
+    private val profileUseCase: GetProfileUseCase
+) {
+
+    suspend operator fun invoke(summary: ManifestSummary, notary: PrivateKey) = invoke(summary = summary).map {
+        NotaryAndSigners(
+            signers = it,
+            ephemeralNotaryPrivateKey = notary
+        )
+    }
+
+    private suspend operator fun invoke(summary: ManifestSummary): Result<List<Entity>> = runCatching {
+        val requiredAccountAddresses = summary.accountsRequiringAuth.map { it.addressString() }
+        val requiredPersonaAddresses = summary.identitiesRequiringAuth.map { it.addressString() }
+
+        val accounts = profileUseCase.accountsOnCurrentNetwork()
+        val personas = profileUseCase.personasOnCurrentNetwork()
+
+        requiredAccountAddresses.map { address ->
+            accounts.find { it.address == address } ?: throw FailedToFindSigningEntities
+        } + requiredPersonaAddresses.map { address ->
+            personas.find { it.address == address } ?: throw FailedToFindSigningEntities
+        }
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/UiMessage.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/UiMessage.kt
@@ -4,13 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.babylon.wallet.android.R
-import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.asRadixWalletException
 import com.babylon.wallet.android.domain.toUserFriendlyMessage
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import rdx.works.core.UUIDGenerator
-import rdx.works.profile.domain.ProfileException
 
 @Serializable
 sealed class UiMessage(val id: String = UUIDGenerator.uuid().toString()) {
@@ -71,38 +69,6 @@ sealed class UiMessage(val id: String = UUIDGenerator.uuid().toString()) {
     data class ErrorMessage(
         private val error: Throwable?
     ) : UiMessage() {
-
-        @Composable
-        override fun getMessage(): String {
-            val message = error?.asRadixWalletException()?.toUserFriendlyMessage(LocalContext.current) ?: error?.message
-            return if (message.isNullOrEmpty()) {
-                stringResource(id = R.string.common_somethingWentWrong)
-            } else {
-                message
-            }
-        }
-    }
-
-    data class TransactionErrorMessage(
-        private val error: Throwable?
-    ) : UiMessage() {
-
-        private val isDepositRulesErrorVisible = error is RadixWalletException.PrepareTransactionException
-            .ReceivingAccountDoesNotAllowDeposits
-
-        private val isNoMnemonicErrorVisible = error?.cause is ProfileException.NoMnemonic
-
-        val isPreviewedInDialog: Boolean
-            get() = isDepositRulesErrorVisible || isNoMnemonicErrorVisible
-
-        @Composable
-        fun getTitle(): String {
-            return if (isNoMnemonicErrorVisible) {
-                stringResource(id = R.string.transactionReview_noMnemonicError_title)
-            } else {
-                stringResource(id = R.string.common_errorAlertTitle)
-            }
-        }
 
         @Composable
         override fun getMessage(): String {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -114,7 +114,7 @@ fun TransactionReviewScreen(
         onTipPercentageChanged = viewModel::onTipPercentageChanged,
         onViewDefaultModeClick = viewModel::onViewDefaultModeClick,
         onViewAdvancedModeClick = viewModel::onViewAdvancedModeClick,
-        dismissTransactionErrorDialog = viewModel::dismissTransactionErrorDialog
+        dismissTransactionErrorDialog = viewModel::dismissTerminalErrorDialog
     )
 
     state.interactionState?.let {
@@ -179,19 +179,19 @@ private fun TransactionPreviewContent(
     val snackBarHostState = remember { SnackbarHostState() }
 
     state.error?.let { transactionError ->
-        if (transactionError.isPreviewedInDialog) {
+        if (transactionError.isTerminalError) {
             BasicPromptAlertDialog(
                 finish = {
                     dismissTransactionErrorDialog()
                 },
                 titleText = transactionError.getTitle(),
-                messageText = transactionError.getMessage(),
+                messageText = transactionError.uiMessage.getMessage(),
                 confirmText = stringResource(id = R.string.common_ok),
                 dismissText = null
             )
         } else {
             SnackbarUIMessage(
-                message = transactionError,
+                message = transactionError.uiMessage,
                 snackbarHostState = snackBarHostState,
                 onMessageShown = onMessageShown
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
@@ -14,9 +14,9 @@ import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.domain.model.Transferable
 import com.babylon.wallet.android.domain.toConnectorExtensionError
 import com.babylon.wallet.android.domain.usecases.transaction.SubmitTransactionUseCase
-import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.ViewModelDelegate
 import com.babylon.wallet.android.presentation.transaction.PreviewType
+import com.babylon.wallet.android.presentation.transaction.TransactionErrorMessage
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel
 import com.babylon.wallet.android.utils.AppEvent
 import com.babylon.wallet.android.utils.AppEventBus
@@ -212,7 +212,7 @@ class TransactionSubmitDelegate @Inject constructor(
                         _state.update {
                             it.copy(
                                 isSubmitting = false,
-                                error = UiMessage.TransactionErrorMessage(radixWalletException)
+                                error = TransactionErrorMessage(radixWalletException)
                             )
                         }
                         approvalJob = null
@@ -253,7 +253,7 @@ class TransactionSubmitDelegate @Inject constructor(
     private suspend fun reportFailure(error: Throwable) {
         logger.w(error)
         _state.update {
-            it.copy(isSubmitting = false, error = UiMessage.TransactionErrorMessage(error))
+            it.copy(isSubmitting = false, error = TransactionErrorMessage(error))
         }
 
         val currentState = _state.value

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -509,6 +509,7 @@
   <string name="error_transactionFailure_epoch">Failed to get epoch</string>
   <string name="error_transactionFailure_header">Failed to build transaction header</string>
   <string name="error_transactionFailure_manifest">Failed to convert transaction manifest</string>
+  <string name="error_transactionFailure_missingSigners">You don\'t have access to some accounts or personas required to authorise this transaction</string>
   <string name="error_transactionFailure_network">Wrong network</string>
   <string name="error_transactionFailure_noFundsToApproveTransaction">No funds to approve transaction</string>
   <string name="error_transactionFailure_pollStatus">Failed to poll transaction status</string>


### PR DESCRIPTION
## Description
This PR forces the transaction review screen to display an error to the user when the entities needed auth, are missing.

All errors that end up to a dialog are terminal errors, meaning that the transaction will close after the user confirms them.

## How to test
1. Connect some accounts to the sandbox
2. Hide an account
3. Initiate a transaction from sandbox that includes this account
4. You should see the following error. (Added this error to crowdin content may change)

## Screenshot
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/8af4ea8f-5bb0-46d9-8570-d7a99a43ba96" width="300">

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
- [X] I have written unit tests
