### PR TITLE
ABW-2488 - Refactor around dApp Login Auth and UnAuth

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DAppLoginDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DAppLoginDelegate.kt
@@ -1,0 +1,195 @@
+package com.babylon.wallet.android.presentation.dapp
+
+import com.babylon.wallet.android.data.dapp.DappMessenger
+import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
+import com.babylon.wallet.android.data.repository.state.StateRepository
+import com.babylon.wallet.android.domain.RadixWalletException
+import com.babylon.wallet.android.domain.getDappMessage
+import com.babylon.wallet.android.domain.usecases.BuildAuthorizedDappResponseUseCase
+import com.babylon.wallet.android.domain.usecases.BuildUnauthorizedDappResponseUseCase
+import com.babylon.wallet.android.presentation.common.UiMessage
+import com.babylon.wallet.android.presentation.common.ViewModelDelegate
+import com.babylon.wallet.android.presentation.dapp.authorized.login.DAppLoginUiState
+import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
+import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.toUiModel
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import rdx.works.profile.data.model.pernetwork.Network
+import rdx.works.profile.data.repository.DAppConnectionRepository
+import rdx.works.profile.domain.ProfileException
+import rdx.works.profile.domain.gateway.GetCurrentGatewayUseCase
+import javax.inject.Inject
+
+class DAppLoginDelegate @Inject constructor(
+    private val dAppMessenger: DappMessenger,
+    private val dAppConnectionRepository: DAppConnectionRepository,
+    private val getCurrentGatewayUseCase: GetCurrentGatewayUseCase,
+    private val stateRepository: StateRepository,
+    private val incomingRequestRepository: IncomingRequestRepository,
+    private val buildAuthorizedDappResponseUseCase: BuildAuthorizedDappResponseUseCase,
+    private val buildUnauthorizedDappResponseUseCase: BuildUnauthorizedDappResponseUseCase
+) : ViewModelDelegate<DAppLoginUiState>() {
+
+    suspend fun processLoginRequest(
+        requestId: String,
+        sendEvent: (Event) -> Unit,
+        isAuthorizedRequest: Boolean
+    ) {
+        _state.update { it.copy(requestId = requestId) }
+
+        if (isAuthorizedRequest) {
+            val requestToHandle = incomingRequestRepository.getAuthorizedRequest(requestId)
+            if (requestToHandle == null) {
+                sendEvent(Event.CloseLoginFlow)
+                return
+            } else {
+                _state.update { it.copy(authorizeRequest = requestToHandle) }
+            }
+
+            val currentNetworkId = getCurrentGatewayUseCase().network.networkId().value
+            if (currentNetworkId != requestToHandle.requestMetadata.networkId) {
+                handleRequestError(
+                    exception = RadixWalletException.DappRequestException.WrongNetwork(
+                        currentNetworkId,
+                        requestToHandle.requestMetadata.networkId
+                    ),
+                    isAuthorizedRequest = true
+                )
+                return
+            }
+            if (!requestToHandle.isValidRequest()) {
+                handleRequestError(
+                    exception = RadixWalletException.DappRequestException.InvalidRequest,
+                    isAuthorizedRequest = true
+                )
+                return
+            }
+
+            val authorizedDApp = dAppConnectionRepository.getAuthorizedDapp(
+                requestToHandle.requestMetadata.dAppDefinitionAddress
+            )
+
+            _state.update { it.copy(authorizedDApp = authorizedDApp) }
+            _state.update { it.copy(editedDApp = authorizedDApp) }
+
+            stateRepository.getDAppsDetails(
+                definitionAddresses = listOf(requestToHandle.metadata.dAppDefinitionAddress),
+                skipCache = false
+            ).onSuccess { dApps ->
+                dApps.firstOrNull()?.let { dApp ->
+                    _state.update { it.copy(dapp = dApp) }
+                }
+            }.onFailure { error ->
+                _state.update { it.copy(uiMessage = UiMessage.ErrorMessage(error)) }
+            }
+        } else {
+            val requestToHandle = incomingRequestRepository.getUnauthorizedRequest(requestId)
+            if (requestToHandle == null) {
+                sendEvent(Event.CloseLoginFlow)
+                return
+            } else {
+                _state.update { it.copy(unAuthorizeRequest = requestToHandle) }
+            }
+
+            val currentNetworkId = getCurrentGatewayUseCase().network.networkId().value
+            if (currentNetworkId != requestToHandle.requestMetadata.networkId) {
+                handleRequestError(
+                    exception = RadixWalletException.DappRequestException.WrongNetwork(
+                        currentNetworkId,
+                        requestToHandle.requestMetadata.networkId
+                    ),
+                    isAuthorizedRequest = false
+                )
+                return
+            }
+            if (!requestToHandle.isValidRequest()) {
+                handleRequestError(
+                    exception = RadixWalletException.DappRequestException.InvalidRequest,
+                    isAuthorizedRequest = false
+                )
+                return
+            }
+
+            stateRepository.getDAppsDetails(
+                definitionAddresses = listOf(requestToHandle.metadata.dAppDefinitionAddress),
+                skipCache = false
+            ).onSuccess { dApps ->
+                dApps.firstOrNull()?.let { dApp ->
+                    _state.update { it.copy(dapp = dApp) }
+                }
+            }.onFailure { error ->
+                _state.update { it.copy(uiMessage = UiMessage.ErrorMessage(error)) }
+            }
+        }
+    }
+
+    suspend fun handleRequestError(exception: Throwable, isAuthorizedRequest: Boolean) {
+        if (exception is RadixWalletException.DappRequestException) {
+            if (isAuthorizedRequest) {
+                if (exception.cause is RadixWalletException.LedgerCommunicationException) {
+                    return
+                }
+            } else {
+                if (exception is RadixWalletException.LedgerCommunicationException.FailedToSignAuthChallenge) {
+                    return
+                }
+            }
+            if (exception.cause is RadixWalletException.SignatureCancelled) {
+                return
+            }
+            if (exception.cause is ProfileException.NoMnemonic) {
+                _state.update { it.copy(isNoMnemonicErrorVisible = true) }
+                return
+            }
+            dAppMessenger.sendWalletInteractionResponseFailure(
+                remoteConnectorId = _state.value.remoteConnectionId,
+                requestId = _state.value.requestId.orEmpty(),
+                error = exception.ceError,
+                message = exception.getDappMessage()
+            )
+            _state.update { it.copy(failureDialog = FailureDialogState.Open(exception)) }
+        } else {
+            if (isAuthorizedRequest.not() && exception is ProfileException.NoMnemonic) {
+                _state.update { it.copy(isNoMnemonicErrorVisible = true) }
+            }
+        }
+    }
+
+    fun observeSigningState(isAuthorizedRequest: Boolean) {
+        viewModelScope.launch {
+            if (isAuthorizedRequest) {
+                buildAuthorizedDappResponseUseCase.signingState
+            } else {
+                buildUnauthorizedDappResponseUseCase.signingState
+            }.collect { signingState ->
+                _state.update { state ->
+                    state.copy(interactionState = signingState)
+                }
+            }
+        }
+    }
+
+    fun onAcknowledgeFailureDialog(
+        sendEvent: (Event) -> Unit
+    ) = viewModelScope.launch {
+        _state.update { it.copy(failureDialog = FailureDialogState.Closed) }
+        sendEvent(Event.CloseLoginFlow)
+        incomingRequestRepository.requestHandled(requestId = _state.value.requestId.orEmpty())
+    }
+
+    fun onDismissSigningStatusDialog() {
+        _state.update { it.copy(interactionState = null) }
+    }
+
+    fun onSelectPersona(persona: Network.Persona) {
+        _state.update { it.copy(selectedPersona = persona.toUiModel()) }
+    }
+
+    fun onMessageShown() {
+        _state.update { it.copy(uiMessage = null) }
+    }
+
+    fun dismissNoMnemonicError() {
+        _state.update { it.copy(isNoMnemonicErrorVisible = false) }
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DAppLoginEvent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DAppLoginEvent.kt
@@ -1,0 +1,32 @@
+package com.babylon.wallet.android.presentation.dapp
+
+import com.babylon.wallet.android.domain.model.RequiredPersonaFields
+import com.babylon.wallet.android.presentation.common.OneOffEvent
+
+sealed interface DAppLoginEvent : OneOffEvent {
+
+    data object CloseLoginFlow : DAppLoginEvent
+    data class RequestCompletionBiometricPrompt(val isSignatureRequired: Boolean) : DAppLoginEvent
+
+    data object LoginFlowCompleted : DAppLoginEvent
+
+    data class DisplayPermission(
+        val numberOfAccounts: Int,
+        val isExactAccountsCount: Boolean,
+        val oneTime: Boolean = false
+    ) : DAppLoginEvent
+
+    data class PersonaDataOngoing(
+        val personaAddress: String,
+        val requiredPersonaFields: RequiredPersonaFields
+    ) : DAppLoginEvent
+
+    data class PersonaDataOnetime(val requiredPersonaFields: RequiredPersonaFields) : DAppLoginEvent
+
+    data class ChooseAccounts(
+        val numberOfAccounts: Int,
+        val isExactAccountsCount: Boolean,
+        val oneTime: Boolean = false,
+        val showBack: Boolean = true
+    ) : DAppLoginEvent
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DAppLoginUiState.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/DAppLoginUiState.kt
@@ -1,0 +1,40 @@
+package com.babylon.wallet.android.presentation.dapp
+
+import com.babylon.wallet.android.data.transaction.InteractionState
+import com.babylon.wallet.android.domain.model.DApp
+import com.babylon.wallet.android.domain.model.MessageFromDataChannel
+import com.babylon.wallet.android.presentation.common.UiMessage
+import com.babylon.wallet.android.presentation.common.UiState
+import com.babylon.wallet.android.presentation.dapp.authorized.account.AccountItemUiModel
+import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.PersonaUiModel
+import rdx.works.profile.data.model.pernetwork.Network
+import rdx.works.profile.data.model.pernetwork.PersonaData
+
+data class DAppLoginUiState(
+    val dapp: DApp? = null,
+    val uiMessage: UiMessage? = null,
+    val failureDialog: FailureDialogState = FailureDialogState.Closed,
+    val initialAuthorizedLoginRoute: InitialAuthorizedLoginRoute? = null,
+    val initialUnauthorizedLoginRoute: InitialUnauthorizedLoginRoute? = null,
+    val selectedAccountsOngoing: List<AccountItemUiModel> = emptyList(),
+    val selectedOngoingPersonaData: PersonaData? = null,
+    val selectedOneTimePersonaData: PersonaData? = null,
+    val selectedAccountsOneTime: List<AccountItemUiModel> = emptyList(),
+    val selectedPersona: PersonaUiModel? = null,
+    val interactionState: InteractionState? = null,
+    val isNoMnemonicErrorVisible: Boolean = false,
+    val isAuthorizeRequest: Boolean = false,
+    var authorizeRequest: MessageFromDataChannel.IncomingRequest.AuthorizedRequest? = null,
+    var unAuthorizeRequest: MessageFromDataChannel.IncomingRequest.UnauthorizedRequest? = null,
+    var requestId: String? = null,
+    var authorizedDApp: Network.AuthorizedDapp? = null,
+    var editedDApp: Network.AuthorizedDapp? = null
+) : UiState {
+
+    val remoteConnectionId: String
+        get() = if (isAuthorizeRequest) {
+            authorizeRequest?.remoteConnectorId.orEmpty()
+        } else {
+            unAuthorizeRequest?.remoteConnectorId.orEmpty()
+        }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
@@ -115,7 +115,7 @@ fun OneTimeChooseAccountsScreen(
         )
     }
     DappInteractionFailureDialog(
-        dialogState = sharedState.failureDialogState,
+        dialogState = sharedState.failureDialog,
         onAcknowledgeFailureDialog = sharedViewModel::onAcknowledgeFailureDialog
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginScreen.kt
@@ -26,6 +26,7 @@ import com.babylon.wallet.android.domain.userFriendlyMessage
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
 import com.babylon.wallet.android.presentation.dapp.FailureDialogState
 import com.babylon.wallet.android.presentation.dapp.InitialUnauthorizedLoginRoute
+import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUiMessageHandler
 import kotlinx.coroutines.flow.filterIsInstance
@@ -69,7 +70,7 @@ fun DappUnauthorizedLoginScreen(
             FullscreenCircularProgressContent()
         }
 
-        when (val dialogState = state.failureDialogState) {
+        when (val dialogState = state.failureDialog) {
             is FailureDialogState.Closed -> {}
             is FailureDialogState.Open -> {
                 BasicPromptAlertDialog(


### PR DESCRIPTION
## Description
This is Draft work for improving code around **DAppAuthorizedLogin** and **DAppUnauthorizedLogin**.

What I did so far is to find common code and I created delegate that serves this for both Authorised and Unauthorised view models.

Here are my findings:
1. WIth regards to Composable there isn't much code that can be reused. Let me know your thoughts if it makes sense to use One composable but I got a feeling that it will be just moving code around and having them split actually makes sense I think.

2. I tried to reuse as much as I could in View Models however I was hoping there will be more. Let me also know the way I did this with delegate is fine. 

Would like to hear you thoughts on how else it can be improved in terms of common code for both authorised and unauthorised paths.

