### PR TITLE
Make current network extension not nullable

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithBabylonDeviceFactorSourceUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithBabylonDeviceFactorSourceUseCase.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
-import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.extensions.mainBabylonFactorSource
 import rdx.works.profile.data.model.factorsources.DerivationPathScheme
@@ -45,7 +44,7 @@ class CreateAccountWithBabylonDeviceFactorSourceUseCase @Inject constructor(
             _interactionState.update { InteractionState.Device.DerivingAccounts(factorSource) }
 
             // Construct new account
-            val networkId = networkID ?: profile.currentNetwork?.knownNetworkId ?: Radix.Gateway.default.network.networkId()
+            val networkId = networkID ?: profile.currentNetwork.knownNetworkId
             val nextAccountIndex = profile.nextAccountIndex(DerivationPathScheme.CAP_26, networkId, factorSource.id)
             val nextAppearanceId = profile.nextAppearanceId(networkId)
             val mnemonicWithPassphrase = requireNotNull(mnemonicRepository.readMnemonic(factorSource.id).getOrNull())

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithLedgerFactorSourceUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/CreateAccountWithLedgerFactorSourceUseCase.kt
@@ -5,7 +5,6 @@ import com.babylon.wallet.android.designsystem.theme.AccountGradientList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
-import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.factorsources.LedgerHardwareWalletFactorSource
@@ -39,7 +38,7 @@ class CreateAccountWithLedgerFactorSourceUseCase @Inject constructor(
                     it.id == ledgerFactorSourceID
                 } as LedgerHardwareWalletFactorSource
             // Construct new account
-            val networkId = networkID ?: profile.currentNetwork?.knownNetworkId ?: Radix.Gateway.default.network.networkId()
+            val networkId = networkID ?: profile.currentNetwork.knownNetworkId
             val totalAccountsOnNetwork = profile.networks.find { it.networkID == networkId.value }?.accounts?.size ?: 0
             val newAccount = Network.Account.initAccountWithLedgerFactorSource(
                 entityIndex = profile.nextAccountIndex(derivationPath.scheme, networkId, ledgerFactorSourceID),

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/GenerateAuthSigningFactorInstanceUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/GenerateAuthSigningFactorInstanceUseCase.kt
@@ -57,7 +57,7 @@ class GenerateAuthSigningFactorInstanceUseCase @Inject constructor(
                     DerivationPath.authSigningDerivationPathFromCap26Path(signingEntityDerivationPath)
                 } else {
                     val profile = getProfileUseCase.invoke().first()
-                    val networkId = requireNotNull(profile.currentNetwork?.knownNetworkId)
+                    val networkId = requireNotNull(profile.currentNetwork.knownNetworkId)
                     DerivationPath.authSigningDerivationPathFromBip44LikePath(networkId, signingEntityDerivationPath)
                 }
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountNav.kt
@@ -2,7 +2,6 @@ package com.babylon.wallet.android.presentation.account.createaccount
 
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.NavController
@@ -70,7 +69,6 @@ fun NavController.createAccountScreen(
     )
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.createAccountScreen(
     onBackClick: () -> Unit,
     onContinueClick: (accountId: String, requestSource: CreateAccountRequestSource?) -> Unit,

--- a/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/Profile.kt
@@ -130,10 +130,17 @@ data class Profile(
 val Profile.currentGateway: Radix.Gateway
     get() = appPreferences.gateways.current()
 
-val Profile.currentNetwork: Network?
+val Profile.currentNetwork: Network
     get() {
         val currentGateway = currentGateway
-        return networks.find { it.networkID == currentGateway.network.id }
+        return networks.find {
+            it.networkID == currentGateway.network.id
+        } ?: Network(
+            networkID = Radix.Gateway.default.network.id,
+            accounts = identifiedArrayListOf(),
+            personas = identifiedArrayListOf(),
+            authorizedDapps = emptyList()
+        )
     }
 
 /**

--- a/profile/src/main/java/rdx/works/profile/data/model/extensions/ProfileExtensions.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/extensions/ProfileExtensions.kt
@@ -123,5 +123,5 @@ fun Profile.mainBabylonFactorSource(): DeviceFactorSource? {
 }
 
 fun Profile.isCurrentNetworkMainnet(): Boolean {
-    return currentNetwork?.networkID == Radix.Network.mainnet.id
+    return currentNetwork.networkID == Radix.Network.mainnet.id
 }

--- a/profile/src/main/java/rdx/works/profile/data/model/pernetwork/Network.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/pernetwork/Network.kt
@@ -25,6 +25,7 @@ import rdx.works.core.toHexString
 import rdx.works.core.toIdentifiedArrayList
 import rdx.works.profile.data.model.MnemonicWithPassphrase
 import rdx.works.profile.data.model.Profile
+import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.compressedPublicKey
 import rdx.works.profile.data.model.currentGateway
 import rdx.works.profile.data.model.extensions.derivationPathEntityIndex
@@ -65,8 +66,8 @@ data class Network(
     @SerialName("authorizedDapps") val authorizedDapps: List<AuthorizedDapp>
 ) {
 
-    val knownNetworkId: NetworkId?
-        get() = NetworkId.values().find { it.value == networkID }
+    val knownNetworkId: NetworkId
+        get() = NetworkId.entries.find { it.value == networkID } ?: Radix.Gateway.default.network.networkId()
 
     @Serializable
     data class Account(

--- a/profile/src/main/java/rdx/works/profile/domain/AddRecoveredAccountsToProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/AddRecoveredAccountsToProfileUseCase.kt
@@ -14,7 +14,7 @@ class AddRecoveredAccountsToProfileUseCase @Inject constructor(
 
     suspend operator fun invoke(accounts: List<Network.Account>): Profile {
         return profileRepository.updateProfile { profile ->
-            val currentNetworkId = profile.currentNetwork?.knownNetworkId ?: error("Current network is not known")
+            val currentNetworkId = profile.currentNetwork.knownNetworkId
             profile.addAccounts(accounts, currentNetworkId)
         }
     }

--- a/profile/src/main/java/rdx/works/profile/domain/GetFactorSourcesWithAccountsUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetFactorSourcesWithAccountsUseCase.kt
@@ -17,8 +17,8 @@ class GetFactorSourcesWithAccountsUseCase @Inject constructor(
         return getProfileUseCase.invoke().map { profile ->
             val result = mutableListOf<DeviceFactorSourceData>()
             val deviceFactorSources = profile.factorSources.filterIsInstance<DeviceFactorSource>()
-            val allAccountsOnNetwork = profile.currentNetwork?.accounts?.notHiddenAccounts().orEmpty()
-            val allPersonasOnNetwork = profile.currentNetwork?.personas?.notHiddenPersonas().orEmpty()
+            val allAccountsOnNetwork = profile.currentNetwork.accounts.notHiddenAccounts()
+            val allPersonasOnNetwork = profile.currentNetwork.personas.notHiddenPersonas()
             deviceFactorSources.forEach { deviceFactorSource ->
                 if (deviceFactorSource.supportsOlympia && deviceFactorSource.supportsBabylon) {
                     val olympiaAccounts = allAccountsOnNetwork.filter {

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -49,7 +49,7 @@ class GetProfileUseCase @Inject constructor(private val profileRepository: Profi
  */
 val GetProfileUseCase.entitiesOnCurrentNetwork: Flow<List<Entity>>
     get() = invoke().map {
-        it.currentNetwork?.accounts?.notHiddenAccounts().orEmpty() + it.currentNetwork?.personas?.notHiddenPersonas().orEmpty()
+        it.currentNetwork.accounts.notHiddenAccounts() + it.currentNetwork.personas.notHiddenPersonas()
     }
 
 suspend fun GetProfileUseCase.currentNetwork(): Network? {
@@ -57,11 +57,11 @@ suspend fun GetProfileUseCase.currentNetwork(): Network? {
 }
 
 val GetProfileUseCase.activeAccountsOnCurrentNetwork
-    get() = invoke().map { it.currentNetwork?.accounts?.notHiddenAccounts().orEmpty() }
+    get() = invoke().map { it.currentNetwork.accounts.notHiddenAccounts() }
 
 val GetProfileUseCase.hiddenAccountsOnCurrentNetwork
     get() = invoke().map {
-        it.currentNetwork?.accounts?.filter { account -> account.flags.contains(EntityFlag.DeletedByUser) }.orEmpty()
+        it.currentNetwork.accounts.filter { account -> account.flags.contains(EntityFlag.DeletedByUser) }
     }
 
 val GetProfileUseCase.factorSources
@@ -73,7 +73,7 @@ val GetProfileUseCase.deviceFactorSources
 private val GetProfileUseCase.deviceFactorSourcesWithAccounts
     get() = invoke().map { profile ->
         val deviceFactorSources = profile.factorSources.filterIsInstance<DeviceFactorSource>()
-        val allAccountsOnNetwork = profile.currentNetwork?.accounts?.notHiddenAccounts().orEmpty()
+        val allAccountsOnNetwork = profile.currentNetwork.accounts.notHiddenAccounts()
         deviceFactorSources.associateWith { deviceFactorSource ->
             allAccountsOnNetwork.filter { it.factorSourceId == deviceFactorSource.id }
         }
@@ -163,11 +163,11 @@ suspend fun GetProfileUseCase.currentNetworkAccountHashes(): Set<ByteArray> {
  * Personas on network
  */
 val GetProfileUseCase.personasOnCurrentNetwork
-    get() = invoke().map { it.currentNetwork?.personas?.notHiddenPersonas().orEmpty() }
+    get() = invoke().map { it.currentNetwork.personas.notHiddenPersonas() }
 
 val GetProfileUseCase.hiddenPersonasOnCurrentNetwork
     get() = invoke().map {
-        it.currentNetwork?.personas?.filter { persona -> persona.flags.contains(EntityFlag.DeletedByUser) }.orEmpty()
+        it.currentNetwork.personas.filter { persona -> persona.flags.contains(EntityFlag.DeletedByUser) }
     }
 
 suspend fun GetProfileUseCase.personasOnCurrentNetwork() = personasOnCurrentNetwork.first()

--- a/profile/src/main/java/rdx/works/profile/domain/account/MigrateOlympiaAccountsUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/account/MigrateOlympiaAccountsUseCase.kt
@@ -6,7 +6,6 @@ import com.radixdlt.ret.OlympiaAddress
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
-import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.data.model.factorsources.FactorSource
 import rdx.works.profile.data.model.factorsources.Slip10Curve
@@ -32,7 +31,7 @@ class MigrateOlympiaAccountsUseCase @Inject constructor(
     ): List<Network.Account> {
         return withContext(defaultDispatcher) {
             val profile = profileRepository.profile.first()
-            val networkId = profile.currentNetwork?.knownNetworkId ?: Radix.Gateway.default.network.networkId()
+            val networkId = profile.currentNetwork.knownNetworkId
             val appearanceIdOffset = profile.nextAppearanceId(networkId)
             val migratedAccounts = olympiaAccounts.mapIndexed { index, olympiaAccount ->
                 val babylonAddress = Address.virtualAccountAddressFromOlympiaAddress(

--- a/profile/src/main/java/rdx/works/profile/domain/account/SwitchNetworkUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/account/SwitchNetworkUseCase.kt
@@ -24,11 +24,10 @@ class SwitchNetworkUseCase @Inject constructor(
         return withContext(defaultDispatcher) {
             val profile = profileRepository.profile.first()
             val networkIdToSwitch = if (networkId == -1) {
-                profile.currentNetwork?.networkID
+                profile.currentNetwork.networkID
             } else {
                 networkId
             }
-            if (networkIdToSwitch == null) return@withContext Radix.Gateway.default.network.networkId()
             val gateway = Radix.Gateway(
                 url = networkUrl,
                 network = Radix.Network.allKnownNetworks().first { network ->


### PR DESCRIPTION
## Description
This PR makes the extension function `currentNetwork` **not nullable and defaults it to default network** like we already do in all the places that the current network returns null


## How to test
Create accounts and switch networks.

## PR submission checklist
- [x] I have created accounts and switching networks
- [x] I have executed transactions
- [x] I have deleted the wallet and created new one
