### PR TITLE
ABW-2721 - Warning shown on Non conforming transaction before user can continue with signing.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -114,7 +114,8 @@ fun TransactionReviewScreen(
         onTipPercentageChanged = viewModel::onTipPercentageChanged,
         onViewDefaultModeClick = viewModel::onViewDefaultModeClick,
         onViewAdvancedModeClick = viewModel::onViewAdvancedModeClick,
-        dismissTransactionErrorDialog = viewModel::dismissTransactionErrorDialog
+        dismissTransactionErrorDialog = viewModel::dismissTransactionErrorDialog,
+        onAcknowledgeRawTransactionWarning = viewModel::onAcknowledgeRawTransactionWarning
     )
 
     state.interactionState?.let {
@@ -171,7 +172,8 @@ private fun TransactionPreviewContent(
     onTipPercentageChanged: (String) -> Unit,
     onViewDefaultModeClick: () -> Unit,
     onViewAdvancedModeClick: () -> Unit,
-    dismissTransactionErrorDialog: () -> Unit
+    dismissTransactionErrorDialog: () -> Unit,
+    onAcknowledgeRawTransactionWarning: () -> Unit
 ) {
     val modalBottomSheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true
@@ -266,6 +268,22 @@ private fun TransactionPreviewContent(
                             onSwipeComplete = onApproveTransaction
                         )
                     }
+                }
+
+                if (state.showRawTransactionWarning) {
+                    BasicPromptAlertDialog(
+                        finish = { acknowledged ->
+                            if (acknowledged) {
+                                onAcknowledgeRawTransactionWarning()
+                            }
+                        },
+                        titleText = "This is a complex transaction that cannot be summarized - the raw transaction " +
+                            "manifest will be shown. Do not submit unless you understand the contents.", // Crowdin
+                        confirmText = stringResource(
+                            id = R.string.common_continue
+                        ),
+                        dismissText = null
+                    )
                 }
 
                 AnimatedVisibility(
@@ -489,7 +507,8 @@ fun TransactionPreviewContentPreview() {
             onTipPercentageChanged = {},
             onViewDefaultModeClick = {},
             onViewAdvancedModeClick = {},
-            dismissTransactionErrorDialog = {}
+            dismissTransactionErrorDialog = {},
+            onAcknowledgeRawTransactionWarning = {}
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -229,6 +229,10 @@ class TransactionReviewViewModel @Inject constructor(
         _state.update { it.copy(error = null) }
     }
 
+    fun onAcknowledgeRawTransactionWarning() {
+        _state.update { it.copy(showRawTransactionWarning = false) }
+    }
+
     sealed interface Event : OneOffEvent {
         data class OnFungibleClick(
             val resource: FungibleResource,
@@ -250,6 +254,7 @@ class TransactionReviewViewModel @Inject constructor(
         val isNetworkFeeLoading: Boolean,
         val isSubmitting: Boolean = false,
         val isRawManifestVisible: Boolean = false,
+        val showRawTransactionWarning: Boolean = false,
         val previewType: PreviewType,
         val transactionFees: TransactionFees = TransactionFees(),
         val feePayerSearchResult: FeePayerSearchResult? = null,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -115,6 +115,7 @@ class TransactionAnalysisDelegate @Inject constructor(
         _state.update {
             it.copy(
                 isRawManifestVisible = previewType == PreviewType.NonConforming,
+                showRawTransactionWarning = previewType == PreviewType.NonConforming,
                 isLoading = false,
                 previewType = previewType,
                 defaultSignersCount = notaryAndSigners.signers.count()


### PR DESCRIPTION
## Description
Warning is shown for Non Conforming transactions before user can continue with signing transaction.


## How to test

1. Trigger some kind of Non Conforming transaction
2. Observe warning dialog with a Continue button that make dialog gone and user is able to continue with signing.

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/da04f44b-25ba-44a5-9358-3070bd637aa2" width="300">

## PR submission checklist
- [x] I have tested Non Conforming transfer and verified that warning is shown.
