### PR TITLE
Fix infinite loading in staking tab

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/state/StateRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/state/StateRepository.kt
@@ -178,7 +178,7 @@ class StateRepositoryImpl @Inject constructor(
 
                 result = result.map { item ->
                     item.copy(
-                        liquidStakeUnit = if (item.liquidStakeUnit != null && item.liquidStakeUnit.fungibleResource.isDetailsAvailable.not()) {
+                        liquidStakeUnit = if (item.liquidStakeUnit != null && !item.liquidStakeUnit.fungibleResource.isDetailsAvailable) {
                             val newLsu = lsuEntities[item.liquidStakeUnit.resourceAddress]?.toResource(
                                 item.liquidStakeUnit.fungibleResource.ownedAmount
                             ) as? Resource.FungibleResource

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
@@ -130,8 +130,8 @@ data class ValidatorWithStakes(
 
     val isDetailsAvailable: Boolean
         get() = validatorDetail.totalXrdStake != null &&
-                (liquidStakeUnit == null || liquidStakeUnit.fungibleResource.isDetailsAvailable) &&
-                (stakeClaimNft == null || stakeClaimNft.nonFungibleResource.amount.toInt() == stakeClaimNft.nonFungibleResource.items.size)
+            (liquidStakeUnit == null || liquidStakeUnit.fungibleResource.isDetailsAvailable) &&
+            (stakeClaimNft == null || stakeClaimNft.nonFungibleResource.amount.toInt() == stakeClaimNft.nonFungibleResource.items.size)
 
     val hasLSU: Boolean
         get() = liquidStakeUnit != null && (liquidStakeUnit.fungibleResource.ownedAmount ?: BigDecimal.ZERO) > BigDecimal.ZERO

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AccountWithAssets.kt
@@ -129,8 +129,9 @@ data class ValidatorWithStakes(
 ) {
 
     val isDetailsAvailable: Boolean
-        get() = validatorDetail.totalXrdStake != null && liquidStakeUnit != null && liquidStakeUnit.fungibleResource.isDetailsAvailable &&
-            (stakeClaimNft == null || stakeClaimNft.nonFungibleResource.amount.toInt() == stakeClaimNft.nonFungibleResource.items.size)
+        get() = validatorDetail.totalXrdStake != null &&
+                (liquidStakeUnit == null || liquidStakeUnit.fungibleResource.isDetailsAvailable) &&
+                (stakeClaimNft == null || stakeClaimNft.nonFungibleResource.amount.toInt() == stakeClaimNft.nonFungibleResource.items.size)
 
     val hasLSU: Boolean
         get() = liquidStakeUnit != null && (liquidStakeUnit.fungibleResource.ownedAmount ?: BigDecimal.ZERO) > BigDecimal.ZERO

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
@@ -497,7 +497,6 @@ private fun ValidatorHeader(
                 }
             }
 
-
             Text(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
@@ -30,7 +30,6 @@ import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixTextButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.assets.Assets
-import com.babylon.wallet.android.domain.model.assets.ValidatorDetail
 import com.babylon.wallet.android.domain.model.assets.ValidatorWithStakes
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.model.resources.XrdResource
@@ -154,9 +153,11 @@ private fun StakingSummary(
                 .padding(horizontal = RadixTheme.dimensions.paddingLarge)
                 .clickable(enabled = summary?.hasReadyToClaimValue == true && action is AssetsViewAction.Click) {
                     if (action is AssetsViewAction.Click) {
-                        val claims = assets.ownedValidatorsWithStakes.filter {
-                            it.hasClaims
-                        }.mapNotNull { it.stakeClaimNft }
+                        val claims = assets.ownedValidatorsWithStakes
+                            .filter {
+                                it.hasClaims
+                            }
+                            .mapNotNull { it.stakeClaimNft }
 
                         action.onClaimClick(claims)
                     }
@@ -277,8 +278,7 @@ fun ValidatorDetails(
                         action.onCollectionClick(validatorWithStakes.validatorDetail.address)
                     }
                     .padding(RadixTheme.dimensions.paddingLarge),
-                validator = validatorWithStakes.validatorDetail,
-                stakedAmount = validatorWithStakes.stakeValue()
+                validatorWithStakes = validatorWithStakes
             )
         }
 
@@ -468,8 +468,7 @@ private fun StakeClaims(
 @Composable
 private fun ValidatorHeader(
     modifier: Modifier = Modifier,
-    validator: ValidatorDetail,
-    stakedAmount: BigDecimal?
+    validatorWithStakes: ValidatorWithStakes
 ) {
     Row(
         modifier = modifier,
@@ -478,17 +477,26 @@ private fun ValidatorHeader(
     ) {
         Thumbnail.Validator(
             modifier = Modifier.size(44.dp),
-            validator = validator
+            validator = validatorWithStakes.validatorDetail
         )
         Column(
             verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
         ) {
             Text(
-                text = validator.name,
+                text = validatorWithStakes.validatorDetail.name,
                 style = RadixTheme.typography.secondaryHeader,
                 color = RadixTheme.colors.gray1,
                 maxLines = 1
             )
+
+            val stakedAmount = remember(validatorWithStakes) {
+                if (validatorWithStakes.liquidStakeUnit != null) {
+                    validatorWithStakes.stakeValue()
+                } else {
+                    BigDecimal.ZERO
+                }
+            }
+
 
             Text(
                 modifier = Modifier


### PR DESCRIPTION
## Description
When an account has only stake claims, the summary and the validators where showing only the shimmering effect, looking like the stake details were never fetched. This is now fixed.

## How to test
You need an account with only a claim as an asset an no other stakes. You can achieve that by
1. going to an account that has staking and claims and transfer the claim to another account which has no other staking info.
2. Then you will see the bug (look at the video)

## Video
[Bug](https://github.com/radixdlt/babylon-wallet-android/assets/125959264/ed6c8d0b-3755-4540-aa24-64086cb5c54e)

[Fix](https://github.com/radixdlt/babylon-wallet-android/assets/125959264/6a7fd177-8492-4d36-aba9-40e4fc8832a9)


## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
