### PR TITLE
[ABW-2754] Show add link connector screen only when no link connectors available and connector status indicator

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/LinkConnectionStatusObserver.kt
+++ b/app/src/main/java/com/babylon/wallet/android/LinkConnectionStatusObserver.kt
@@ -33,7 +33,7 @@ class LinkConnectionStatusObserver @Inject constructor(
         .peerConnectionStatus
         .map { mapOfPeerConnectionStatus ->
             LinkConnectionsStatus(
-                peerConnectionState = mapOfPeerConnectionStatus.values.toPersistentList()
+                peerConnectionStatus = mapOfPeerConnectionStatus.values.toPersistentList()
             )
         }
         .stateIn(
@@ -43,10 +43,10 @@ class LinkConnectionStatusObserver @Inject constructor(
         )
 
     data class LinkConnectionsStatus(
-        private val peerConnectionState: ImmutableList<PeerConnectionStatus> = persistentListOf()
+        private val peerConnectionStatus: ImmutableList<PeerConnectionStatus> = persistentListOf()
     ) {
 
-        fun currentStatus() = peerConnectionState
+        fun currentStatus() = peerConnectionStatus
             .map { state ->
                 when (state) {
                     PeerConnectionStatus.OPEN -> {

--- a/app/src/main/java/com/babylon/wallet/android/LinkConnectionStatusObserver.kt
+++ b/app/src/main/java/com/babylon/wallet/android/LinkConnectionStatusObserver.kt
@@ -1,0 +1,66 @@
+package com.babylon.wallet.android
+
+import androidx.compose.ui.graphics.Color
+import com.babylon.wallet.android.di.coroutines.ApplicationScope
+import com.babylon.wallet.android.utils.Constants
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import rdx.works.core.preferences.PreferencesManager
+import rdx.works.peerdroid.data.PeerdroidConnector
+import rdx.works.peerdroid.domain.PeerConnectionStatus
+import javax.inject.Inject
+
+class LinkConnectionStatusObserver @Inject constructor(
+    peerdroidConnector: PeerdroidConnector,
+    preferencesManager: PreferencesManager,
+    @ApplicationScope private val applicationScope: CoroutineScope
+) {
+
+    val isEnabled = preferencesManager
+        .isLinkConnectionStatusIndicatorEnabled
+        .stateIn(
+            scope = applicationScope,
+            started = SharingStarted.WhileSubscribed(Constants.VM_STOP_TIMEOUT_MS),
+            initialValue = true
+        )
+
+    val currentStatus = peerdroidConnector
+        .peerConnectionStatus
+        .map { mapOfPeerConnectionStatus ->
+            LinkConnectionsStatus(
+                peerConnectionState = mapOfPeerConnectionStatus.values.toPersistentList()
+            )
+        }
+        .stateIn(
+            scope = applicationScope,
+            started = SharingStarted.WhileSubscribed(Constants.VM_STOP_TIMEOUT_MS),
+            initialValue = LinkConnectionsStatus()
+        )
+
+    data class LinkConnectionsStatus(
+        private val peerConnectionState: ImmutableList<PeerConnectionStatus> = persistentListOf()
+    ) {
+
+        fun currentStatus() = peerConnectionState
+            .map { state ->
+                when (state) {
+                    PeerConnectionStatus.OPEN -> {
+                        Color.Green
+                    }
+
+                    PeerConnectionStatus.CLOSED -> {
+                        Color.Red
+                    }
+
+                    PeerConnectionStatus.CONNECTING -> {
+                        Color.Yellow
+                    }
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
@@ -18,7 +18,8 @@ import javax.inject.Inject
 
 interface LedgerMessenger {
 
-    val isConnected: Flow<Boolean>
+    val isAnyLinkedConnectorConnected: Flow<Boolean>
+
     suspend fun sendDeviceInfoRequest(interactionId: String): Result<MessageFromDataChannel.LedgerResponse.GetDeviceInfoResponse>
 
     suspend fun signTransactionRequest(
@@ -55,7 +56,7 @@ class LedgerMessengerImpl @Inject constructor(
     private val peerdroidClient: PeerdroidClient,
 ) : LedgerMessenger {
 
-    override val isConnected: Flow<Boolean>
+    override val isAnyLinkedConnectorConnected: Flow<Boolean>
         get() = peerdroidClient.hasAtLeastOneConnection
 
     override suspend fun sendDeviceInfoRequest(interactionId: String): Result<MessageFromDataChannel.LedgerResponse.GetDeviceInfoResponse> {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/ChooseLedgerScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/withledger/ChooseLedgerScreen.kt
@@ -102,7 +102,7 @@ fun ChooseLedgerScreen(
                         context.biometricAuthenticateSuspend()
                     })
                 },
-                linkingToConnector = state.linkingToConnector
+                linkingToConnector = state.isAddingLinkConnector
             )
         }
 
@@ -126,7 +126,7 @@ fun ChooseLedgerScreen(
                 isNewConnectorContinueButtonEnabled = addLinkConnectorState.isContinueButtonEnabled,
                 onNewConnectorContinueClick = {
                     addLinkConnectorViewModel.onContinueClick()
-                    viewModel.onNewConnectorAdded(showContent.addDeviceAfterLinking)
+                    viewModel.onNewLinkConnectorAdded(showContent.addDeviceAfterLinking)
                 },
                 onNewConnectorCloseClick = {
                     addLinkConnectorViewModel.onCloseClick()
@@ -161,7 +161,7 @@ fun ChooseLedgerScreen(
                     viewModel.onCloseClick()
                 },
                 onMessageShown = addLedgerDeviceViewModel::onMessageShown,
-                isLinkConnectionEstablished = addLedgerDeviceState.isLinkConnectionEstablished && state.linkingToConnector.not()
+                isLinkedConnectorEstablished = addLedgerDeviceState.isAnyLinkedConnectorConnected && state.isAddingLinkConnector.not()
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsItem.kt
@@ -108,10 +108,13 @@ sealed interface SettingsItem {
     sealed interface DebugSettingsItem {
         data object InspectProfile : DebugSettingsItem
 
+        data object LinkConnectionStatusIndicator : DebugSettingsItem
+
         @StringRes
         fun descriptionRes(): Int {
             return when (this) {
                 InspectProfile -> R.string.settings_debugSettings_inspectProfile
+                LinkConnectionStatusIndicator -> R.string.linkedConnectors_title
             }
         }
 
@@ -119,12 +122,14 @@ sealed interface SettingsItem {
         fun getIcon(): Int? { // add rest of icons
             return when (this) {
                 InspectProfile -> com.babylon.wallet.android.designsystem.R.drawable.ic_personas
+                LinkConnectionStatusIndicator -> com.babylon.wallet.android.designsystem.R.drawable.ic_desktop_connection
             }
         }
 
         companion object {
             fun values() = setOf(
-                InspectProfile
+                InspectProfile,
+                LinkConnectionStatusIndicator
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -419,7 +419,7 @@ private fun ImportLegacyWalletContent(
                 onClose = onCloseSettings,
                 waitingForLedgerResponse = waitingForLedgerResponse,
                 onBackClick = onCloseSettings,
-                isLinkConnectionEstablished = true
+                isLinkedConnectorEstablished = true
 
             )
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletViewModel.kt
@@ -91,11 +91,6 @@ class ImportLegacyWalletViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            ledgerMessenger.isConnected.collect { connected ->
-                _state.update { it.copy(isLinkConnectionEstablished = connected) }
-            }
-        }
-        viewModelScope.launch {
             useLedgerDelegate.state.collect { delegateState ->
                 _state.update { uiState ->
                     val state = delegateState.addLedgerSheetState
@@ -446,15 +441,11 @@ class ImportLegacyWalletViewModel @Inject constructor(
 
     fun onContinueWithLedgerClick() {
         viewModelScope.launch {
-            if (getProfileUseCase.p2pLinks.first().isNotEmpty()) {
-                if (state.value.isLinkConnectionEstablished.not()) {
-                    _state.update {
-                        it.copy(shouldShowAddLinkConnectorScreen = true)
-                    }
-                } else {
-                    useLedgerDelegate.onSendAddLedgerRequest()
-                }
-            } else if (getProfileUseCase.p2pLinks.first().isEmpty()) {
+            val hasAtLeastOneLinkedConnector = getProfileUseCase.p2pLinks.first().isNotEmpty()
+
+            if (hasAtLeastOneLinkedConnector) {
+                useLedgerDelegate.onSendAddLedgerRequest()
+            } else if (hasAtLeastOneLinkedConnector.not()) {
                 _state.update {
                     it.copy(shouldShowAddLinkConnectorScreen = true)
                 }
@@ -522,8 +513,7 @@ data class ImportLegacyWalletUiState(
     val seedPhraseInputState: SeedPhraseInputDelegate.State = SeedPhraseInputDelegate.State(),
     val shouldShowAddLinkConnectorScreen: Boolean = false,
     val shouldShowAddLedgerDeviceScreen: Boolean = false,
-    var existingOlympiaFactorSourceId: FactorSourceID.FromHash? = null,
-    val isLinkConnectionEstablished: Boolean = false,
+    var existingOlympiaFactorSourceId: FactorSourceID.FromHash? = null
 ) : UiState {
 
     fun mnemonicWithPassphrase(): MnemonicWithPassphrase {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/AddLedgerDeviceViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/AddLedgerDeviceViewModel.kt
@@ -86,8 +86,8 @@ class AddLedgerDeviceViewModel @Inject constructor(
 
     private fun observeLinkConnectionStatus() {
         viewModelScope.launch {
-            ledgerMessenger.isConnected.collect { connected ->
-                _state.update { it.copy(isLinkConnectionEstablished = connected) }
+            ledgerMessenger.isAnyLinkedConnectorConnected.collect { isConnected ->
+                _state.update { it.copy(isAnyLinkedConnectorConnected = isConnected) }
             }
         }
     }
@@ -101,7 +101,7 @@ class AddLedgerDeviceViewModel @Inject constructor(
 
     fun initState() {
         _state.update { current ->
-            AddLedgerDeviceUiState.init.copy(isLinkConnectionEstablished = current.isLinkConnectionEstablished)
+            AddLedgerDeviceUiState.init.copy(isAnyLinkedConnectorConnected = current.isAnyLinkedConnectorConnected)
         }
     }
 
@@ -136,7 +136,7 @@ data class AddLedgerDeviceUiState(
     val showContent: ShowContent,
     val newConnectedLedgerDevice: LedgerDeviceUiModel?,
     val uiMessage: UiMessage?,
-    val isLinkConnectionEstablished: Boolean = false
+    val isAnyLinkedConnectorConnected: Boolean = false
 ) : UiState {
 
     enum class ShowContent {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
@@ -95,7 +95,7 @@ fun LedgerHardwareWalletsScreen(
                     ledgerDevices = state.ledgerDevices,
                     onAddLedgerDeviceClick = viewModel::onAddLedgerDeviceClick,
                     onBackClick = onBackClick,
-                    linkingToConnector = state.isAddLedgerButtonEnabled
+                    isNewLinkedConnectorConnected = state.isNewLinkedConnectorConnected
                 )
             }
 
@@ -122,7 +122,7 @@ fun LedgerHardwareWalletsScreen(
                         addLedgerDeviceViewModel.initState()
                         viewModel.onCloseClick()
                     },
-                    isLinkConnectionEstablished = addLedgerDeviceState.isLinkConnectionEstablished
+                    isLinkedConnectorEstablished = addLedgerDeviceState.isAnyLinkedConnectorConnected
                 )
             }
 
@@ -163,7 +163,7 @@ private fun LedgerHardwareWalletsContent(
     ledgerDevices: ImmutableList<LedgerHardwareWalletFactorSource>,
     onAddLedgerDeviceClick: () -> Unit,
     onBackClick: () -> Unit,
-    linkingToConnector: Boolean,
+    isNewLinkedConnectorConnected: Boolean,
 ) {
     BackHandler(onBack = onBackClick)
 
@@ -183,7 +183,7 @@ private fun LedgerHardwareWalletsContent(
                 modifier = Modifier.fillMaxWidth(),
                 ledgerFactorSources = ledgerDevices,
                 onAddLedgerDeviceClick = onAddLedgerDeviceClick,
-                linkingToConnector = linkingToConnector
+                isNewLinkedConnectorConnected = isNewLinkedConnectorConnected
             )
         }
     }
@@ -194,7 +194,7 @@ private fun LedgerDeviceDetails(
     modifier: Modifier = Modifier,
     ledgerFactorSources: ImmutableList<LedgerHardwareWalletFactorSource>,
     onAddLedgerDeviceClick: () -> Unit,
-    linkingToConnector: Boolean
+    isNewLinkedConnectorConnected: Boolean
 ) {
     Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
@@ -212,7 +212,7 @@ private fun LedgerDeviceDetails(
                     .fillMaxWidth(),
                 ledgerDevices = ledgerFactorSources,
                 onAddLedgerDeviceClick = onAddLedgerDeviceClick,
-                linkingToConnector = linkingToConnector
+                isNewLinkedConnectorConnected = isNewLinkedConnectorConnected
             )
         } else {
             Text(
@@ -234,7 +234,8 @@ private fun LedgerDeviceDetails(
                 modifier = Modifier
                     .fillMaxWidth(0.7f)
                     .imePadding(),
-                enabled = linkingToConnector.not(),
+                isLoading = isNewLinkedConnectorConnected.not(),
+                enabled = isNewLinkedConnectorConnected,
                 throttleClicks = true
             )
         }
@@ -246,7 +247,7 @@ private fun LedgerDevicesListContent(
     modifier: Modifier = Modifier,
     ledgerDevices: ImmutableList<LedgerHardwareWalletFactorSource>,
     onAddLedgerDeviceClick: () -> Unit,
-    linkingToConnector: Boolean
+    isNewLinkedConnectorConnected: Boolean
 ) {
     LazyColumn(
         modifier,
@@ -280,7 +281,8 @@ private fun LedgerDevicesListContent(
                 text = stringResource(id = R.string.ledgerHardwareDevices_addNewLedger),
                 onClick = onAddLedgerDeviceClick,
                 throttleClicks = true,
-                enabled = linkingToConnector.not()
+                isLoading = isNewLinkedConnectorConnected.not(),
+                enabled = isNewLinkedConnectorConnected
             )
         }
     }
@@ -294,7 +296,7 @@ fun LedgerHardwareWalletsScreenEmptyPreview() {
             ledgerDevices = persistentListOf(),
             onAddLedgerDeviceClick = {},
             onBackClick = {},
-            linkingToConnector = true
+            isNewLinkedConnectorConnected = true
         )
     }
 }
@@ -307,7 +309,7 @@ fun LedgerHardwareWalletsScreenPreview() {
             ledgerDevices = SampleDataProvider().ledgerFactorSourcesSample.toPersistentList(),
             onAddLedgerDeviceClick = {},
             onBackClick = {},
-            linkingToConnector = true
+            isNewLinkedConnectorConnected = true
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/appsettings/AppSettingsNav.kt
@@ -2,7 +2,6 @@ package com.babylon.wallet.android.presentation.settings.appsettings
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -43,7 +42,6 @@ fun NavGraphBuilder.appSettingsNavGraph(
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.appSettingsScreen(
     navController: NavController
 ) {
@@ -87,7 +85,6 @@ fun NavGraphBuilder.appSettingsScreen(
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 private fun NavGraphBuilder.settingsGateway(navController: NavController) {
     composable(
         route = Screen.SettingsEditGatewayApiDestination.route,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/debug/DebugSettingsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/debug/DebugSettingsNav.kt
@@ -2,10 +2,12 @@ package com.babylon.wallet.android.presentation.settings.debug
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.babylon.wallet.android.presentation.settings.SettingsItem
 import com.babylon.wallet.android.presentation.settings.SettingsItem.DebugSettingsItem.InspectProfile
 import com.babylon.wallet.android.presentation.settings.debug.profile.inspectProfile
 
@@ -41,12 +43,14 @@ fun NavGraphBuilder.debugSettings(
             }
         ) {
             DebugSettingsScreen(
+                viewModel = hiltViewModel(),
                 onBackClick = {
                     navController.popBackStack()
                 },
                 onItemClick = { item ->
                     when (item) {
                         InspectProfile -> navController.inspectProfile()
+                        SettingsItem.DebugSettingsItem.LinkConnectionStatusIndicator -> {}
                     }
                 }
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/debug/DebugSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/debug/DebugSettingsScreen.kt
@@ -3,27 +3,34 @@ package com.babylon.wallet.android.presentation.settings.debug
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.settings.SettingsItem
 import com.babylon.wallet.android.presentation.ui.composables.DefaultSettingsItem
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
+import com.babylon.wallet.android.presentation.ui.composables.SwitchSettingsItem
 
 @Composable
 fun DebugSettingsScreen(
     modifier: Modifier = Modifier,
+    viewModel: DebugSettingsViewModel,
     onBackClick: () -> Unit,
     onItemClick: (SettingsItem.DebugSettingsItem) -> Unit
 ) {
+    val linkConnectionStatusIndicatorState by viewModel.linkConnectionStatusIndicatorState.collectAsStateWithLifecycle()
+
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -41,16 +48,32 @@ fun DebugSettingsScreen(
         ) {
             HorizontalDivider(color = RadixTheme.colors.gray5)
             LazyColumn(modifier = Modifier.fillMaxSize()) {
-                SettingsItem.DebugSettingsItem.values().forEachIndexed { index, appSettingsItem ->
+                SettingsItem.DebugSettingsItem.values().forEach { debugSettingsItem ->
                     item {
-                        DefaultSettingsItem(
-                            title = stringResource(id = appSettingsItem.descriptionRes()),
-                            icon = appSettingsItem.getIcon(),
-                            onClick = {
-                                onItemClick(appSettingsItem)
+                        when (debugSettingsItem) {
+                            SettingsItem.DebugSettingsItem.InspectProfile -> {
+                                DefaultSettingsItem(
+                                    title = stringResource(id = debugSettingsItem.descriptionRes()),
+                                    icon = debugSettingsItem.getIcon(),
+                                    onClick = {
+                                        onItemClick(debugSettingsItem)
+                                    }
+                                )
+                                HorizontalDivider(color = RadixTheme.colors.gray5)
                             }
-                        )
-                        HorizontalDivider(color = RadixTheme.colors.gray5)
+                            SettingsItem.DebugSettingsItem.LinkConnectionStatusIndicator -> {
+                                SwitchSettingsItem(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(all = RadixTheme.dimensions.paddingDefault),
+                                    titleRes = debugSettingsItem.descriptionRes(),
+                                    iconResource = debugSettingsItem.getIcon(),
+                                    checked = linkConnectionStatusIndicatorState.isEnabled,
+                                    onCheckedChange = viewModel::onLinkConnectionStatusIndicatorToggled
+                                )
+                                HorizontalDivider(color = RadixTheme.colors.gray5)
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/debug/DebugSettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/debug/DebugSettingsViewModel.kt
@@ -1,0 +1,37 @@
+package com.babylon.wallet.android.presentation.settings.debug
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.babylon.wallet.android.utils.Constants
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import rdx.works.core.preferences.PreferencesManager
+import javax.inject.Inject
+
+@HiltViewModel
+class DebugSettingsViewModel @Inject constructor(
+    private val preferencesManager: PreferencesManager
+) : ViewModel() {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val linkConnectionStatusIndicatorState = preferencesManager
+        .isLinkConnectionStatusIndicatorEnabled
+        .mapLatest { isEnabled ->
+            LinkConnectionStatusIndicator(isEnabled = isEnabled)
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(Constants.VM_STOP_TIMEOUT_MS),
+            initialValue = LinkConnectionStatusIndicator(isEnabled = true)
+        )
+
+    fun onLinkConnectionStatusIndicatorToggled(isEnabled: Boolean) = viewModelScope.launch {
+        preferencesManager.setLinkConnectionStatusIndicator(isEnabled = isEnabled)
+    }
+
+    data class LinkConnectionStatusIndicator(val isEnabled: Boolean)
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
@@ -54,7 +54,7 @@ fun AddLedgerDeviceScreen(
     onClose: () -> Unit,
     waitingForLedgerResponse: Boolean,
     onBackClick: () -> Unit,
-    isLinkConnectionEstablished: Boolean
+    isLinkedConnectorEstablished: Boolean
 ) {
     BackHandler(onBack = onBackClick)
 
@@ -140,8 +140,8 @@ fun AddLedgerDeviceScreen(
                                 modifier = Modifier.fillMaxWidth(),
                                 onClick = onSendAddLedgerRequestClick,
                                 text = stringResource(id = com.babylon.wallet.android.R.string.addLedgerDevice_addDevice_continue),
-                                enabled = isLinkConnectionEstablished,
-                                isLoading = !isLinkConnectionEstablished
+                                enabled = isLinkedConnectorEstablished,
+                                isLoading = isLinkedConnectorEstablished.not()
                             )
                         }
 
@@ -230,7 +230,7 @@ fun AddLedgerDeviceScreenPreview() {
             onClose = {},
             waitingForLedgerResponse = false,
             onBackClick = {},
-            isLinkConnectionEstablished = true
+            isLinkedConnectorEstablished = true
         )
     }
 }
@@ -251,7 +251,7 @@ fun AddLedgerDeviceContentPreview3() {
             onClose = {},
             waitingForLedgerResponse = false,
             onBackClick = {},
-            isLinkConnectionEstablished = true
+            isLinkedConnectorEstablished = true
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DevelopmentPreviewWrapper.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DevelopmentPreviewWrapper.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.babylon.wallet.android.LinkConnectionStatusObserver.LinkConnectionsStatus
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
@@ -48,11 +47,17 @@ fun DevelopmentPreviewWrapper(
     Box(modifier = modifier) {
         var bannerHeight by remember { mutableStateOf(0.dp) }
         CompositionLocalProvider(LocalDevBannerState provides devBannerState) {
-            content(if (devBannerState.isVisible) PaddingValues(top = bannerHeight) else PaddingValues())
+            content(
+                if (devBannerState.isVisible || linkConnectionsStatus != null) {
+                    PaddingValues(top = bannerHeight)
+                } else {
+                    PaddingValues()
+                }
+            )
         }
 
-        if (devBannerState.isVisible && linkConnectionsStatus != null) {
-            val density = LocalDensity.current
+        val density = LocalDensity.current
+        if (devBannerState.isVisible) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -64,42 +69,48 @@ fun DevelopmentPreviewWrapper(
                     .padding(RadixTheme.dimensions.paddingXSmall)
             ) {
                 Text(
+                    modifier = Modifier.fillMaxWidth(),
                     text = stringResource(R.string.common_developerDisclaimerText),
                     style = RadixTheme.typography.body2HighImportance,
-                    fontSize = 12.sp,
                     color = Color.Black,
                     textAlign = TextAlign.Center,
                 )
-                LazyRow(
-                    modifier = Modifier,
-                    horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
-                ) {
-                    items(items = linkConnectionsStatus.currentStatus()) { color ->
-                        Canvas(
-                            modifier = Modifier.size(12.dp),
-                            onDraw = {
-                                drawCircle(color = color)
-                            }
-                        )
+
+                if (linkConnectionsStatus != null) {
+                    LazyRow(
+                        modifier = Modifier,
+                        horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
+                    ) {
+                        items(items = linkConnectionsStatus.currentStatus()) { color ->
+                            Canvas(
+                                modifier = Modifier.size(12.dp),
+                                onDraw = {
+                                    drawCircle(color = color)
+                                }
+                            )
+                        }
                     }
                 }
             }
-        } else if (devBannerState.isVisible) {
-            val density = LocalDensity.current
-            Text(
+        } else if (linkConnectionsStatus != null) {
+            LazyRow(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .background(RadixTheme.colors.orange2)
                     .statusBarsPadding()
                     .onGloballyPositioned { coordinates ->
                         bannerHeight = with(density) { coordinates.size.height.toDp() }
                     }
-                    .padding(RadixTheme.dimensions.paddingSmall),
-                text = stringResource(R.string.common_developerDisclaimerText),
-                style = RadixTheme.typography.body2HighImportance,
-                color = Color.Black,
-                textAlign = TextAlign.Center,
-            )
+                    .padding(RadixTheme.dimensions.paddingXSmall),
+                horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
+            ) {
+                items(items = linkConnectionsStatus.currentStatus()) { color ->
+                    Canvas(
+                        modifier = Modifier.size(12.dp),
+                        onDraw = {
+                            drawCircle(color = color)
+                        }
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/AddLedgerDeviceViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/AddLedgerDeviceViewModelTest.kt
@@ -41,7 +41,7 @@ class AddLedgerDeviceViewModelTest : StateViewModelTest<AddLedgerDeviceViewModel
 
     @Before
     fun setup() {
-        coEvery { ledgerMessengerMock.isConnected } returns flowOf(true)
+        coEvery { ledgerMessengerMock.isAnyLinkedConnectorConnected } returns flowOf(true)
     }
 
     @Test

--- a/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/ChooseLedgerViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/createaccount/withledger/ChooseLedgerViewModelTest.kt
@@ -66,7 +66,7 @@ internal class ChooseLedgerViewModelTest : StateViewModelTest<ChooseLedgerViewMo
     @Before
     override fun setUp() {
         super.setUp()
-        coEvery { ledgerMessenger.isConnected } returns flowOf(true)
+        coEvery { ledgerMessenger.isAnyLinkedConnectorConnected } returns flowOf(true)
         coEvery { eventBus.sendEvent(any()) } just Runs
         coEvery { getProfileUseCase() } returns flowOf(profile())
         every { savedStateHandle.get<Int>(ARG_NETWORK_ID) } returns Radix.Gateway.mainnet.network.id

--- a/core/src/main/java/rdx/works/core/preferences/PreferencesManager.kt
+++ b/core/src/main/java/rdx/works/core/preferences/PreferencesManager.kt
@@ -134,7 +134,7 @@ class PreferencesManager @Inject constructor(
 
     val isLinkConnectionStatusIndicatorEnabled: Flow<Boolean> = dataStore.data
         .map { preferences ->
-            preferences[KEY_LINK_CONNECTION_STATUS_INDICATOR] ?: true
+            preferences[KEY_LINK_CONNECTION_STATUS_INDICATOR] ?: false
         }
 
     suspend fun setLinkConnectionStatusIndicator(isEnabled: Boolean) {

--- a/core/src/main/java/rdx/works/core/preferences/PreferencesManager.kt
+++ b/core/src/main/java/rdx/works/core/preferences/PreferencesManager.kt
@@ -132,6 +132,17 @@ class PreferencesManager @Inject constructor(
         }
     }
 
+    val isLinkConnectionStatusIndicatorEnabled: Flow<Boolean> = dataStore.data
+        .map { preferences ->
+            preferences[KEY_LINK_CONNECTION_STATUS_INDICATOR] ?: true
+        }
+
+    suspend fun setLinkConnectionStatusIndicator(isEnabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[KEY_LINK_CONNECTION_STATUS_INDICATOR] = isEnabled
+        }
+    }
+
     suspend fun clear() = dataStore.edit { it.clear() }
 
     companion object {
@@ -144,5 +155,6 @@ class PreferencesManager @Inject constructor(
         private val KEY_IMPORT_OLYMPIA_WALLET_SETTING_DISMISSED =
             booleanPreferencesKey("import_olympia_wallet_setting_dismissed")
         private val KEY_DEVICE_ROOTED_DIALOG_SHOWN = booleanPreferencesKey("device_rooted_dialog_shown")
+        private val KEY_LINK_CONNECTION_STATUS_INDICATOR = booleanPreferencesKey("link_connection_status_indicator")
     }
 }

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
@@ -159,7 +159,7 @@ internal class PeerdroidConnectorImpl(
                 dataChannelHolder.dataChannel.close()
             }
             mapOfDataChannels.values.removeAll(dataChannelsForTermination.toSet())
-            updateMapOfPeerConnectionState(connectionId = connectionId, isOpen = false, isDeleted = true)
+            updatePeerConnectionStatus(connectionId = connectionId, isOpen = false, isDeleted = true)
             Timber.d("⚙️ \uD83D\uDDD1️ link connection with connectionId: ${connectionId.id} deleted ✅")
         }
     }
@@ -313,7 +313,7 @@ internal class PeerdroidConnectorImpl(
             .onEach { event ->
                 when (event) {
                     is PeerConnectionEvent.RenegotiationNeeded -> {
-                        updateMapOfPeerConnectionState(connectionId = connectionId, isConnecting = true)
+                        updatePeerConnectionStatus(connectionId = connectionId, isConnecting = true)
                         Timber.d("⚙️ ⚡ renegotiation needed for remote client: $remoteClientHolder \uD83C\uDD97")
                         renegotiationDeferred.complete(Unit)
                     }
@@ -343,7 +343,7 @@ internal class PeerdroidConnectorImpl(
                             dataChannel = dataChannel
                         )
                         isAnyChannelConnected.tryEmit(mapOfDataChannels.values.isNotEmpty())
-                        updateMapOfPeerConnectionState(connectionId = connectionId, isConnecting = false, isOpen = true)
+                        updatePeerConnectionStatus(connectionId = connectionId, isConnecting = false, isOpen = true)
                         Timber.d("⚙️ ℹ️ current count of data channels: ${mapOfDataChannels.size}")
                     }
 
@@ -351,7 +351,7 @@ internal class PeerdroidConnectorImpl(
                         Timber.d("⚙️ ⚡ peer connection disconnected for remote client: $remoteClientHolder \uD83D\uDD34")
                         terminatePeerConnectionAndDataChannel(remoteClientHolder, connectionId)
                         isAnyChannelConnected.tryEmit(mapOfDataChannels.values.isNotEmpty())
-                        updateMapOfPeerConnectionState(connectionId = connectionId, isConnecting = false, isOpen = false)
+                        updatePeerConnectionStatus(connectionId = connectionId, isConnecting = false, isOpen = false)
                     }
 
                     is PeerConnectionEvent.Failed -> {
@@ -489,7 +489,7 @@ internal class PeerdroidConnectorImpl(
         }
     }
 
-    private fun updateMapOfPeerConnectionState(
+    private fun updatePeerConnectionStatus(
         connectionId: ConnectionIdHolder,
         isConnecting: Boolean = false,
         isOpen: Boolean = false,

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
@@ -47,6 +47,7 @@ import rdx.works.peerdroid.domain.ConnectionIdHolder
 import rdx.works.peerdroid.domain.DataChannelHolder
 import rdx.works.peerdroid.domain.DataChannelWrapperEvent
 import rdx.works.peerdroid.domain.PeerConnectionHolder
+import rdx.works.peerdroid.domain.PeerConnectionStatus
 import rdx.works.peerdroid.domain.RemoteClientHolder
 import rdx.works.peerdroid.domain.WebSocketHolder
 import timber.log.Timber
@@ -55,6 +56,8 @@ import java.util.concurrent.ConcurrentHashMap
 interface PeerdroidConnector {
 
     val anyChannelConnected: Flow<Boolean>
+
+    val peerConnectionStatus: Flow<Map<String, PeerConnectionStatus>>
 
     suspend fun connectToConnectorExtension(encryptionKey: ByteArray): Result<Unit>
 
@@ -92,12 +95,17 @@ internal class PeerdroidConnectorImpl(
 
     private val isAnyChannelConnected = MutableStateFlow(false)
 
+    private val _peerConnectionStatus = MutableStateFlow(emptyMap<String, PeerConnectionStatus>())
+
     init {
         Timber.d("⚙️ init PeerdroidConnector")
     }
 
     override val anyChannelConnected: Flow<Boolean>
         get() = isAnyChannelConnected.asSharedFlow()
+
+    override val peerConnectionStatus: Flow<Map<String, PeerConnectionStatus>>
+        get() = _peerConnectionStatus
 
     override suspend fun connectToConnectorExtension(encryptionKey: ByteArray): Result<Unit> {
         val connectionId = encryptionKey.blake2Hash().toHexString()
@@ -151,6 +159,7 @@ internal class PeerdroidConnectorImpl(
                 dataChannelHolder.dataChannel.close()
             }
             mapOfDataChannels.values.removeAll(dataChannelsForTermination.toSet())
+            updateMapOfPeerConnectionState(connectionId = connectionId, isOpen = false, isDeleted = true)
             Timber.d("⚙️ \uD83D\uDDD1️ link connection with connectionId: ${connectionId.id} deleted ✅")
         }
     }
@@ -304,6 +313,7 @@ internal class PeerdroidConnectorImpl(
             .onEach { event ->
                 when (event) {
                     is PeerConnectionEvent.RenegotiationNeeded -> {
+                        updateMapOfPeerConnectionState(connectionId = connectionId, isConnecting = true)
                         Timber.d("⚙️ ⚡ renegotiation needed for remote client: $remoteClientHolder \uD83C\uDD97")
                         renegotiationDeferred.complete(Unit)
                     }
@@ -333,6 +343,7 @@ internal class PeerdroidConnectorImpl(
                             dataChannel = dataChannel
                         )
                         isAnyChannelConnected.tryEmit(mapOfDataChannels.values.isNotEmpty())
+                        updateMapOfPeerConnectionState(connectionId = connectionId, isConnecting = false, isOpen = true)
                         Timber.d("⚙️ ℹ️ current count of data channels: ${mapOfDataChannels.size}")
                     }
 
@@ -340,6 +351,7 @@ internal class PeerdroidConnectorImpl(
                         Timber.d("⚙️ ⚡ peer connection disconnected for remote client: $remoteClientHolder \uD83D\uDD34")
                         terminatePeerConnectionAndDataChannel(remoteClientHolder, connectionId)
                         isAnyChannelConnected.tryEmit(mapOfDataChannels.values.isNotEmpty())
+                        updateMapOfPeerConnectionState(connectionId = connectionId, isConnecting = false, isOpen = false)
                     }
 
                     is PeerConnectionEvent.Failed -> {
@@ -475,5 +487,27 @@ internal class PeerdroidConnectorImpl(
                 iceCandidateData = iceCandidateData
             )
         }
+    }
+
+    private fun updateMapOfPeerConnectionState(
+        connectionId: ConnectionIdHolder,
+        isConnecting: Boolean = false,
+        isOpen: Boolean = false,
+        isDeleted: Boolean = false
+    ) {
+        val mapOfPeerConnectionStatus = _peerConnectionStatus.value.toMutableMap()
+        mapOfPeerConnectionStatus[connectionId.id] = if (isConnecting) {
+            PeerConnectionStatus.CONNECTING
+        } else {
+            if (isOpen) {
+                PeerConnectionStatus.OPEN
+            } else {
+                PeerConnectionStatus.CLOSED
+            }
+        }
+        if (isDeleted) {
+            mapOfPeerConnectionStatus.remove(connectionId.id)
+        }
+        _peerConnectionStatus.tryEmit(mapOfPeerConnectionStatus)
     }
 }

--- a/peerdroid/src/main/java/rdx/works/peerdroid/domain/PeerConnectionStatus.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/domain/PeerConnectionStatus.kt
@@ -1,0 +1,6 @@
+package rdx.works.peerdroid.domain
+
+// it indicates the PeerConnection state that can be used as a simple indicator in the UI
+enum class PeerConnectionStatus {
+    OPEN, CLOSED, CONNECTING
+}


### PR DESCRIPTION
## Description
This PR 
- fixes when showing the add new link connector screen. Specifically, wallet shows that screen only when no link connectors configured in settings. We do not check if the linked connectors are connected any more.
- added a loading spinner in the "add ledger device" button while user is linking a new connector

### For dev and alpha builds only:
Added a peer connection status indicator (not data channel status!) which is shown as a dot at the top of the system's bar.
- indicator turns **red** as long as the peer connection is in **disconnected** state
- indicator turns **yellow** as long as the peer connection is in **connecting** state
- indicator turns **green** as long as the peer connection is in **connected** state


## How to test

1. Add a new link connector
2. Forget link connection from the CE of the browser, but do not delete it from the wallet settings
3. Navigate to Ledger Hardware Wallets screen and click on "Add Ledger Device"
=> it should show the "Add Ledger Device" screen

now continue with:
1. Delete the linked connector from settings
2. Navigate again back to Ledger Hardware Wallets screen and click on "Add Ledger Device"
=> it should show the add new link connector screen


## Video

https://github.com/radixdlt/babylon-wallet-android/assets/118305718/e044a0c4-726b-4384-a948-74df88e3eb16


## PR submission checklist
- [x] I have tested all the paths where ledger and linked connector are involved
