### PR TITLE
ABW-2732 - Increase animation threshold which changes the progress for shorter contents.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
@@ -54,6 +54,13 @@ fun TransactionPreviewHeader(
         is PreviewType.Transfer -> stringResource(R.string.transactionReview_transferTitle)
         else -> stringResource(R.string.transactionReview_title)
     }
+    // TODO improve this at later time.
+    // AnimationRangePx is the threshold which scrollState.value hits and then transition of the motion layout starts.
+    // When its relatively low i.e. 40.dp we start transition early and if content is large enough scroll state continue
+    // with its scroll value.
+    // When content is relatively small we might start topbar transition too early which makes scroll state to reset its
+    // scroll.value which is causing the flickering.
+    // That is why for smaller content, we increase animation threshold value from 40.do to 200.dp
     val animationValue = remember(scrollState.maxValue) {
         if (scrollState.maxValue >= 200) {
             40.dp

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -53,12 +54,27 @@ fun TransactionPreviewHeader(
         is PreviewType.Transfer -> stringResource(R.string.transactionReview_transferTitle)
         else -> stringResource(R.string.transactionReview_title)
     }
-    val animationRangePx = with(LocalDensity.current) { 40.dp.toPx() }
-    val progress by remember {
-        derivedStateOf {
-            (scrollState.value / animationRangePx).coerceIn(0f, 1f)
+    val animationValue = remember(scrollState.maxValue) {
+        if (scrollState.maxValue >= 200) {
+            40.dp
+        } else {
+            200.dp
         }
     }
+
+    val animationRangePx = with(LocalDensity.current) {
+        animationValue.toPx()
+    }
+    val progress by remember(scrollState.value) {
+        if (scrollState.maxValue != Int.MAX_VALUE) {
+            derivedStateOf {
+                (scrollState.value / animationRangePx).coerceIn(0f, 1f)
+            }
+        } else {
+            mutableStateOf(0f)
+        }
+    }
+
     MotionLayout(
         modifier = modifier
             .statusBarsPadding()


### PR DESCRIPTION
## Description
This solution is a hack but didn't want to spend more time on this. 
It fixes the problem of scroll flickering which sometimes makes impossible to reach Sign Transaction slide button.

Im sure there must be more elegant solution but didn't find it in this time frame.


To describe when exactly the problem exists:
For Transaction Review screens that hold longer content was fine.
The problem occurred for content short enough to perform motion layout animation.

So depending on initial ScrollState.maxValue I set larger or shorter animation threshold (called animationRange in the code)

## How to test.

Please trigger some transaction as shown in below videos.

## Video
Before:

https://github.com/radixdlt/babylon-wallet-android/assets/108684750/a6720657-6627-4dd8-86bd-855447ef9d19

https://github.com/radixdlt/babylon-wallet-android/assets/108684750/24c4266e-ad94-436e-9206-1feb2d4bb352


After:

https://github.com/radixdlt/babylon-wallet-android/assets/108684750/eaf3cab6-f6a5-47c3-a4e6-293f1b630a82

https://github.com/radixdlt/babylon-wallet-android/assets/108684750/b2c4c4e9-da64-4840-a6c7-e9d1c49cf2ec

https://github.com/radixdlt/babylon-wallet-android/assets/108684750/46c545c8-2de8-49b6-9d5f-a446f0eb0233


## PR submission checklist
- [x] I have tested transaction reviews scrolling and verified that flicker issue is fixed.
