### PR TITLE
ABW-2842 - Screen aligned with the Zeplin design.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
@@ -52,15 +52,17 @@ fun CommonTransferContent(
             Column(
                 modifier = Modifier
                     .applyIf(condition = state.showDottedLine, modifier = Modifier.strokeLine())
-                    .padding(top = RadixTheme.dimensions.paddingXLarge)
+                    .padding(top = RadixTheme.dimensions.paddingLarge)
             ) {
                 middleSection()
 
                 DepositAccountContent(
-                    modifier = Modifier.padding(
+                    modifier = Modifier
+                        .padding(
                         start = RadixTheme.dimensions.paddingDefault,
                         end = RadixTheme.dimensions.paddingDefault
-                    ),
+                    )
+                        .padding(top = RadixTheme.dimensions.paddingLarge),
                     to = previewType.to.toPersistentList(),
                     promptForGuarantees = onPromptForGuarantees,
                     onFungibleResourceClick = { fungibleResource, isNewlyCreated ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
@@ -59,9 +59,9 @@ fun CommonTransferContent(
                 DepositAccountContent(
                     modifier = Modifier
                         .padding(
-                        start = RadixTheme.dimensions.paddingDefault,
-                        end = RadixTheme.dimensions.paddingDefault
-                    )
+                            start = RadixTheme.dimensions.paddingDefault,
+                            end = RadixTheme.dimensions.paddingDefault
+                        )
                         .padding(top = RadixTheme.dimensions.paddingLarge),
                     to = previewType.to.toPersistentList(),
                     promptForGuarantees = onPromptForGuarantees,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ConnectedDAppsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ConnectedDAppsContent.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -101,6 +102,7 @@ fun ConnectedDAppsContent(
                 modifier = Modifier
                     .padding(horizontal = RadixTheme.dimensions.paddingDefault)
                     .fillMaxWidth()
+                    .shadow(6.dp, RadixTheme.shapes.roundedRectDefault)
                     .background(RadixTheme.colors.defaultBackground, RadixTheme.shapes.roundedRectMedium),
                 horizontalAlignment = Alignment.End
             ) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ConnectedDAppsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ConnectedDAppsContent.kt
@@ -53,10 +53,7 @@ fun ConnectedDAppsContent(
 
     var expanded by rememberSaveable { mutableStateOf(true) }
 
-    Column(
-        modifier = Modifier
-            .padding(bottom = RadixTheme.dimensions.paddingXLarge)
-    ) {
+    Column {
         Box(
             modifier = modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolsContent.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -112,6 +113,7 @@ fun PoolsContent(
             modifier = Modifier
                 .padding(horizontal = RadixTheme.dimensions.paddingDefault)
                 .fillMaxWidth()
+                .shadow(6.dp, RadixTheme.shapes.roundedRectDefault)
         ) {
             associatedDApps.forEach { dApp ->
                 InvolvedComponentDetails(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolsContent.kt
@@ -54,7 +54,8 @@ fun PoolsContent(
 ) {
     var expanded by rememberSaveable { mutableStateOf(true) }
     Box(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().
+        padding(bottom = RadixTheme.dimensions.paddingSmall),
         contentAlignment = Alignment.CenterStart
     ) {
         Row(
@@ -74,13 +75,12 @@ fun PoolsContent(
             )
             Row(
                 Modifier.weight(1f),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingMedium)
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
                     modifier = Modifier.weight(1f, false),
                     maxLines = 2,
-                    text = text,
+                    text = text.uppercase(),
                     style = RadixTheme.typography.body1Link,
                     color = RadixTheme.colors.gray2,
                     overflow = TextOverflow.Ellipsis,
@@ -95,11 +95,6 @@ fun PoolsContent(
                     tint = RadixTheme.colors.gray2,
                     contentDescription = "arrow"
                 )
-            }
-            if (expanded) {
-                StrokeLine(modifier = Modifier.padding(end = RadixTheme.dimensions.paddingLarge), height = 60.dp)
-            } else {
-                Spacer(modifier = Modifier.height(60.dp))
             }
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolsContent.kt
@@ -54,8 +54,8 @@ fun PoolsContent(
 ) {
     var expanded by rememberSaveable { mutableStateOf(true) }
     Box(
-        modifier = modifier.fillMaxWidth().
-        padding(bottom = RadixTheme.dimensions.paddingSmall),
+        modifier = modifier.fillMaxWidth()
+            .padding(bottom = RadixTheme.dimensions.paddingSmall),
         contentAlignment = Alignment.CenterStart
     ) {
         Row(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ValidatorsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ValidatorsContent.kt
@@ -105,7 +105,6 @@ fun ValidatorsContent(
         Column(
             modifier = Modifier
                 .padding(horizontal = RadixTheme.dimensions.paddingDefault)
-                .padding(bottom = RadixTheme.dimensions.paddingXLarge)
                 .fillMaxWidth()
                 .background(RadixTheme.colors.gray5)
         ) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ValidatorsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/ValidatorsContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -114,6 +115,7 @@ fun ValidatorsContent(
                     validator = validator,
                     modifier = Modifier
                         .fillMaxWidth()
+                        .shadow(6.dp, RadixTheme.shapes.roundedRectDefault)
                         .background(RadixTheme.colors.defaultBackground, RadixTheme.shapes.roundedRectMedium)
                         .padding(RadixTheme.dimensions.paddingDefault)
                 )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ValidatorDetailsItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ValidatorDetailsItem.kt
@@ -1,6 +1,7 @@
 package com.babylon.wallet.android.presentation.ui.composables
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
@@ -23,11 +24,19 @@ fun ValidatorDetailsItem(validator: ValidatorDetail, modifier: Modifier = Modifi
             modifier = Modifier.size(iconSize),
             validator = validator
         )
-        Text(
-            validator.name,
-            style = RadixTheme.typography.body1Header,
-            color = RadixTheme.colors.gray1,
-            maxLines = 1
-        )
+        Column {
+            Text(
+                validator.name,
+                style = RadixTheme.typography.body1Header,
+                color = RadixTheme.colors.gray1,
+                maxLines = 1
+            )
+
+            ActionableAddressView(
+                address = validator.address,
+                textStyle = RadixTheme.typography.body2HighImportance,
+                textColor = RadixTheme.colors.gray2
+            )
+        }
     }
 }


### PR DESCRIPTION
## Description
Transaction review look aligned with Zeplin regarding Pools/ Stakes and ConnectedDApps container.

## How to test

-  Trigger transfer showing Pools and compare with Zeplin.

## Screenshot

Before: 
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/65dc0bd8-5657-4db8-a270-f8af0e7a3477" width="300">

After:
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/ebff4877-499b-4bd5-b153-6b3f033c0200" width="300">

## PR submission checklist
- [x] I have generated transaction preview containing pools section and verified its in line with Zeplin.
