### PR TITLE
Allow click on fungibles & NFTs from dApp details sheets

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -449,6 +449,12 @@ fun NavigationHost(
             }
         )
         dAppDetailsDialog(
+            onFungibleClick = {
+                navController.fungibleAssetDialog(resourceAddress = it.resourceAddress)
+            },
+            onNonFungibleClick = {
+                navController.nonFungibleAssetDialog(resourceAddress = it.resourceAddress)
+            },
             onDismiss = {
                 navController.popBackStack()
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/dapp/DAppDetailsDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/dapp/DAppDetailsDialog.kt
@@ -154,7 +154,7 @@ private fun DAppDetailsDialogContent(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(RadixTheme.dimensions.paddingDefault),
-                            text = stringResource(id = R.string.authorizedDapps_dAppDetails_tokens),
+                            text = stringResource(id = R.string.authorizedDapps_dAppDetails_nfts),
                             style = RadixTheme.typography.body1Regular,
                             color = RadixTheme.colors.gray2,
                             textAlign = TextAlign.Start

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/dapp/DAppDetailsDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/dapp/DAppDetailsDialog.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.settings.authorizeddapps.dappdetail.DAppWebsiteAddressRow
 import com.babylon.wallet.android.presentation.settings.authorizeddapps.dappdetail.DappDefinitionAddressRow
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
@@ -39,12 +40,16 @@ import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
 @Composable
 fun DAppDetailsDialog(
     viewModel: DAppDetailsDialogViewModel,
+    onFungibleClick: (Resource.FungibleResource) -> Unit,
+    onNonFungibleClick: (Resource.NonFungibleResource) -> Unit,
     onDismiss: () -> Unit
 ) {
     val state by viewModel.state.collectAsState()
     DAppDetailsDialogContent(
         state = state,
         onMessageShown = viewModel::onMessageShown,
+        onFungibleClick = onFungibleClick,
+        onNonFungibleClick = onNonFungibleClick,
         onDismiss = onDismiss
     )
 }
@@ -53,6 +58,8 @@ fun DAppDetailsDialog(
 private fun DAppDetailsDialogContent(
     modifier: Modifier = Modifier,
     state: DAppDetailsDialogViewModel.State,
+    onFungibleClick: (Resource.FungibleResource) -> Unit,
+    onNonFungibleClick: (Resource.NonFungibleResource) -> Unit,
     onMessageShown: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -142,7 +149,8 @@ private fun DAppDetailsDialogContent(
                     GrayBackgroundWrapper {
                         FungibleCard(
                             fungible = resource,
-                            showChevron = false
+                            showChevron = false,
+                            onClick = { onFungibleClick(resource) }
                         )
                         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                     }
@@ -165,7 +173,8 @@ private fun DAppDetailsDialogContent(
                     GrayBackgroundWrapper {
                         NonFungibleCard(
                             nonFungible = resource,
-                            showChevron = false
+                            showChevron = false,
+                            onClick = { onNonFungibleClick(resource) }
                         )
                         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/dapp/DAppDetailsDialogNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/dapp/DAppDetailsDialogNav.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.dialog
 import androidx.navigation.navArgument
+import com.babylon.wallet.android.domain.model.resources.Resource
 
 private const val ROUTE = "dApp_details_dialog"
 private const val ARG_DAPP_DEFINITION_ADDRESS = "dApp_definition_address"
@@ -28,6 +29,8 @@ internal class DAppDetailsDialogArgs(
 }
 
 fun NavGraphBuilder.dAppDetailsDialog(
+    onFungibleClick: (Resource.FungibleResource) -> Unit,
+    onNonFungibleClick: (Resource.NonFungibleResource) -> Unit,
     onDismiss: () -> Unit
 ) {
     dialog(
@@ -41,6 +44,8 @@ fun NavGraphBuilder.dAppDetailsDialog(
     ) {
         DAppDetailsDialog(
             viewModel = hiltViewModel(),
+            onFungibleClick = onFungibleClick,
+            onNonFungibleClick = onNonFungibleClick,
             onDismiss = onDismiss
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/FungibleCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/FungibleCard.kt
@@ -1,6 +1,7 @@
 package com.babylon.wallet.android.presentation.ui.composables.card
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,7 +29,8 @@ fun FungibleCard(
     fungible: Resource.FungibleResource,
     modifier: Modifier = Modifier,
     showChevron: Boolean = true,
-    elevation: Dp = 8.dp
+    elevation: Dp = 8.dp,
+    onClick: (() -> Unit)? = null
 ) {
     Row(
         modifier = modifier
@@ -36,6 +38,9 @@ fun FungibleCard(
             .clip(RadixTheme.shapes.roundedRectMedium)
             .fillMaxWidth()
             .background(RadixTheme.colors.white, shape = RadixTheme.shapes.roundedRectMedium)
+            .clickable(enabled = onClick != null) {
+                onClick?.invoke()
+            }
             .padding(
                 horizontal = RadixTheme.dimensions.paddingLarge,
                 vertical = RadixTheme.dimensions.paddingDefault

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/NonFungibleCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/NonFungibleCard.kt
@@ -1,6 +1,7 @@
 package com.babylon.wallet.android.presentation.ui.composables.card
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,7 +29,8 @@ fun NonFungibleCard(
     nonFungible: Resource.NonFungibleResource,
     modifier: Modifier = Modifier,
     showChevron: Boolean = true,
-    elevation: Dp = 8.dp
+    elevation: Dp = 8.dp,
+    onClick: (() -> Unit)? = null,
 ) {
     Row(
         modifier = modifier
@@ -36,6 +38,9 @@ fun NonFungibleCard(
             .clip(RadixTheme.shapes.roundedRectMedium)
             .fillMaxWidth()
             .background(RadixTheme.colors.white, shape = RadixTheme.shapes.roundedRectMedium)
+            .clickable(enabled = onClick != null) {
+                onClick?.invoke()
+            }
             .padding(
                 horizontal = RadixTheme.dimensions.paddingLarge,
                 vertical = RadixTheme.dimensions.paddingDefault


### PR DESCRIPTION
## Description
DAppDetailsDialog is now able to click on the associated fungibles and non fungibles. Also the text changed to associated NFTs for the non fungibles section. 

## How to test

1. Better use gumball club to do a transaction.
2. Click on the Using dapps section 
3. Then click on a fungible or non fungible associated with gumball club

## Video
[dappdetails.webm](https://github.com/radixdlt/babylon-wallet-android/assets/125959264/1ad7b79b-8d80-402b-a4ba-dc3dd6eba71a)

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
