### PR TITLE
Show Instant as date in NFT data

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/StateNonFungibleDetailsResponseItemExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/StateNonFungibleDetailsResponseItemExtensions.kt
@@ -30,6 +30,10 @@ import com.babylon.wallet.android.domain.model.resources.metadata.MetadataType
 import com.babylon.wallet.android.utils.isValidUrl
 import com.babylon.wallet.android.utils.toAddressOrNull
 
+private enum class SborTypeName(val code: String) {
+    INSTANT("Instant")
+}
+
 // https://docs.radixdlt.com/v1/docs/metadata-for-wallet-display#nonfungibles
 private val NFTExplicitMetadataKeys = listOf(
     ExplicitMetadataKey.NAME.key,
@@ -98,11 +102,20 @@ private fun ProgrammaticScryptoSborValue.toMetadata(isCollection: Boolean = fals
             valueType = MetadataType.Integer(signed = true, size = MetadataType.Integer.Size.INT)
         )
 
-        is ProgrammaticScryptoSborValueI64 -> Metadata.Primitive(
-            key = key,
-            value = sborValue.value,
-            valueType = MetadataType.Integer(signed = true, size = MetadataType.Integer.Size.LONG)
-        )
+        is ProgrammaticScryptoSborValueI64 ->
+            if (sborValue.typeName == SborTypeName.INSTANT.code && sborValue.value.toLongOrNull() != null) {
+                Metadata.Primitive(
+                    key = key,
+                    value = sborValue.value,
+                    valueType = MetadataType.Instant
+                )
+            } else {
+                Metadata.Primitive(
+                    key = key,
+                    value = sborValue.value,
+                    valueType = MetadataType.Integer(signed = true, size = MetadataType.Integer.Size.LONG)
+                )
+            }
 
         is ProgrammaticScryptoSborValueI128 -> Metadata.Primitive(
             key = key,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
@@ -82,9 +82,7 @@ fun Metadata.KeyView(
 ) {
     Text(
         modifier = modifier.padding(end = RadixTheme.dimensions.paddingMedium),
-        text = key.replaceFirstChar {
-            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
-        },
+        text = key,
         style = RadixTheme.typography.body1Regular,
         color = RadixTheme.colors.gray2,
         textAlign = TextAlign.Start


### PR DESCRIPTION
## Description
IN this PR we convert the epoch date of an instant NFT data entry to a human readable date.

## How to test
You either need a NFT with instant data attached to it. If you don't own one you can attach this code temporarily for testing in `NFTEntity L24`:

```
metadata = metadata?.metadata.orEmpty().toMutableList().apply {
            add(
                Metadata.Primitive(
                    key = "maturity_date",
                    value = "1705965360",
                    valueType = com.babylon.wallet.android.domain.model.resources.metadata.MetadataType.Instant
                )
            )
        }
```
This will result in every NFT saved in your wallet to have an entry like this 👇 
## Screenshot
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/d14eebda-9451-4b45-b50d-41c3577499fb" width="300">


## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
