### PR TITLE
ABW-2867 - GIF/SVG/WEBP support added.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
@@ -162,7 +162,7 @@ object Thumbnail {
                 ImageRequest.Builder(context)
                     .data(imageType.cloudFlareUri)
                     .error(R.drawable.ic_broken_image)
-                    .applyAllSupportedImageDecoders()
+                    .applyCorrectDecoderBasedOnMimeType()
                     // Needed for cloudflare
                     .addHeader("accept", "text/html")
                     .build()
@@ -359,7 +359,7 @@ object Thumbnail {
                         error(errorDrawable)
                     }
                 }
-                .applyAllSupportedImageDecoders()
+                .applyCorrectDecoderBasedOnMimeType()
                 // Needed for cloudflare
                 .addHeader("accept", "text/html")
                 .build()
@@ -445,7 +445,7 @@ enum class ThumbnailRequestSize(val size: Int) {
     }
 }
 
-private fun ImageRequest.Builder.applyAllSupportedImageDecoders() = apply {
+private fun ImageRequest.Builder.applyCorrectDecoderBasedOnMimeType() = apply {
     this.decoderFactory { result, options, _ ->
         if (result.mimeType == "image/svg+xml" || DecodeUtils.isSvg(result.source.source())) {
             SvgDecoder(result.source, options)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
@@ -444,15 +444,18 @@ enum class ThumbnailRequestSize(val size: Int) {
     }
 }
 
+@Suppress("MagicNumber")
 private fun ImageRequest.Builder.applyAllSupportedImageDecoders() = apply {
     this.decoderFactory { result, options, _ ->
         if (result.mimeType == "image/svg+xml" || DecodeUtils.isSvg(result.source.source())) {
             SvgDecoder(result.source, options)
         } else if (DecodeUtils.isGif(result.source.source())) {
             GifDecoder(result.source, options)
-        } else if (Build.VERSION.SDK_INT >= 28 && (DecodeUtils.isAnimatedWebP(result.source.source()) || DecodeUtils.isAnimatedHeif(
-                result.source.source()
-            ))
+        } else if (Build.VERSION.SDK_INT >= 28 && (
+                DecodeUtils.isAnimatedWebP(result.source.source()) || DecodeUtils.isAnimatedHeif(
+                    result.source.source()
+                )
+                )
         ) {
             ImageDecoderDecoder(result.source, options)
         } else {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
 import coil.compose.SubcomposeAsyncImage
+import coil.decode.BitmapFactoryDecoder
 import coil.decode.DecodeUtils
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
@@ -444,14 +445,13 @@ enum class ThumbnailRequestSize(val size: Int) {
     }
 }
 
-@Suppress("MagicNumber")
 private fun ImageRequest.Builder.applyAllSupportedImageDecoders() = apply {
     this.decoderFactory { result, options, _ ->
         if (result.mimeType == "image/svg+xml" || DecodeUtils.isSvg(result.source.source())) {
             SvgDecoder(result.source, options)
         } else if (DecodeUtils.isGif(result.source.source())) {
             GifDecoder(result.source, options)
-        } else if (Build.VERSION.SDK_INT >= 28 && (
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && (
                 DecodeUtils.isAnimatedWebP(result.source.source()) || DecodeUtils.isAnimatedHeif(
                     result.source.source()
                 )
@@ -459,7 +459,7 @@ private fun ImageRequest.Builder.applyAllSupportedImageDecoders() = apply {
         ) {
             ImageDecoderDecoder(result.source, options)
         } else {
-            null
+            BitmapFactoryDecoder(result.source, options)
         }
     }
 }


### PR DESCRIPTION
## Description
This PR fixes GIF/SVG and WEB (incl animated) image support.


## How to test

1. Ideally create NFT with such an image, but you can go directly to Thumbnail.kt L155 to replace the image with any you prefer. Here are some examples:
https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif
https://upload.wikimedia.org/wikipedia/commons/d/d7/Android_robot.svg
https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/410.svg
https://www.gstatic.com/webp/gallery/1.webp
https://res.cloudinary.com/demo/image/upload/fl_awebp/bored_animation.webp

Note that animated WebP are not currently working because of image service not supporting them. You can verify it by supporting url without image service and see if its works.

## Video

https://github.com/radixdlt/babylon-wallet-android/assets/108684750/658a881f-b63d-4f21-abe7-4fbe893f0f01

## PR submission checklist
- [x] I have tested SVG, GIF and WEBP images and they are displayed correctly.
