### PR TITLE
Add downloaded parameter to radix banner link

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/utils/Constants.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/Constants.kt
@@ -5,7 +5,7 @@ object Constants {
     const val DELAY_300_MS = 300L
     const val ACCOUNT_NAME_MAX_LENGTH = 30
     const val USE_CURRENT_NETWORK = -1
-    const val RADIX_START_PAGE_URL = "https://wallet.radixdlt.com/"
+    const val RADIX_START_PAGE_URL = "https://wallet.radixdlt.com/?wallet=downloaded"
     const val DEFAULT_ACCOUNT_NAME = "Unnamed"
     const val MAX_ITEMS_PER_ENTITY_DETAILS_REQUEST = 20
 }


### PR DESCRIPTION
## Description
Just a minor change to the URL 
from: `https://wallet.radixdlt.com/`
to: `https://wallet.radixdlt.com/?wallet=downloaded`
