### PR TITLE
ABW-2734 - Blind singing error dialog shown.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -207,7 +207,7 @@ fun RadixWalletException.LedgerCommunicationException.toUserFriendlyMessage(cont
             } // TODO consider different copy
             is RadixWalletException.LedgerCommunicationException.FailedToSignTransaction -> when (this.reason) {
                 LedgerErrorCode.Generic -> R.string.common_somethingWentWrong
-                LedgerErrorCode.BlindSigningNotEnabledButRequired -> R.string.error_transactionFailure_blindSigningNotEnabledButRequired
+                LedgerErrorCode.BlindSigningNotEnabledButRequired -> R.string.ledgerHardwareDevices_couldNotSign_message
                 LedgerErrorCode.UserRejectedSigningOfTransaction -> R.string.error_transactionFailure_rejected
             }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -467,7 +467,7 @@ data class TransactionErrorMessage(
         get() = isNoMnemonicErrorVisible ||
             error is RadixWalletException.PrepareTransactionException.ReceivingAccountDoesNotAllowDeposits ||
             error is RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities ||
-                error is RadixWalletException.LedgerCommunicationException.FailedToSignTransaction
+            error is RadixWalletException.LedgerCommunicationException.FailedToSignTransaction
 
     val uiMessage: UiMessage = UiMessage.ErrorMessage(error)
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -466,7 +466,8 @@ data class TransactionErrorMessage(
     val isTerminalError: Boolean
         get() = isNoMnemonicErrorVisible ||
             error is RadixWalletException.PrepareTransactionException.ReceivingAccountDoesNotAllowDeposits ||
-            error is RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities
+            error is RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities ||
+                error is RadixWalletException.LedgerCommunicationException.FailedToSignTransaction
 
     val uiMessage: UiMessage = UiMessage.ErrorMessage(error)
 
@@ -474,6 +475,8 @@ data class TransactionErrorMessage(
     fun getTitle(): String {
         return if (isNoMnemonicErrorVisible) {
             stringResource(id = R.string.transactionReview_noMnemonicError_title)
+        } else if (error is RadixWalletException.LedgerCommunicationException.FailedToSignTransaction) {
+            stringResource(id = R.string.ledgerHardwareDevices_couldNotSign_title)
         } else {
             stringResource(id = R.string.common_errorAlertTitle)
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
@@ -205,7 +205,10 @@ class TransactionSubmitDelegate @Inject constructor(
                     is RadixWalletException.LedgerCommunicationException -> {
                         logNonFatalException(radixWalletException)
                         _state.update {
-                            it.copy(isSubmitting = false)
+                            it.copy(
+                                isSubmitting = false,
+                                error = TransactionErrorMessage(radixWalletException)
+                            )
                         }
                         approvalJob = null
                         return


### PR DESCRIPTION
## Description
Ledger transaction with blind signing disabled end up with proper error dialog. 

## How to test

1. Make sure that blind singing is disabled on your ledger app.
2. Trigger some ledger transaction (for example create token from ledger account)
3. Verify that error is shown when signing fails due to blind singing disabled (see video)

## Video
https://github.com/radixdlt/babylon-wallet-android/assets/108684750/8546dd30-fe23-49fb-b433-d9691cdc09b5

## PR submission checklist
- [x] I have tested ledger involved transaction with blind signing disabled and verified that error is shown
