### PR TITLE
Dashboard link bugs

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
@@ -53,7 +53,8 @@ data class ActionableAddress(
             ACCOUNT(HRP.ACCOUNT),
             VALIDATOR(HRP.VALIDATOR),
             TRANSACTION(HRP.TRANSACTION),
-            COMPONENT(HRP.COMPONENT);
+            COMPONENT(HRP.COMPONENT),
+            POOL(HRP.POOL);
 
             companion object {
                 private object HRP {
@@ -62,6 +63,7 @@ data class ActionableAddress(
                     const val PACKAGE = "package"
                     const val VALIDATOR = "validator"
                     const val COMPONENT = "component"
+                    const val POOL = "pool"
                     const val TRANSACTION = "txid"
                 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/model/ActionableAddress.kt
@@ -8,7 +8,8 @@ import rdx.works.profile.derivation.model.NetworkId
 
 data class ActionableAddress(
     val address: String,
-    val truncateAddress: Boolean = true
+    val truncateAddress: Boolean = true,
+    val isVisitableInDashboard: Boolean = true
 ) {
 
     val type: Type? = Type.from(address)
@@ -25,6 +26,8 @@ data class ActionableAddress(
     }
 
     fun toDashboardUrl(networkId: NetworkId): String? {
+        if (!isVisitableInDashboard) return null
+
         val addressUrlEncoded = address.encodeUtf8()
         val suffix = when (type) {
             is Type.LocalId -> return null

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/fungible/FungibleDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/fungible/FungibleDialogContent.kt
@@ -98,7 +98,8 @@ fun FungibleDialogContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = RadixTheme.dimensions.paddingSmall),
-            address = resourceAddress
+            address = resourceAddress,
+            isNewlyCreatedEntity = isNewlyCreated
         )
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialogContent.kt
@@ -115,6 +115,7 @@ fun NonFungibleAssetDialogContent(
                     ActionableAddressView(
                         modifier = Modifier.padding(start = RadixTheme.dimensions.paddingDefault),
                         address = item.globalAddress,
+                        visitableInDashboard = !isNewlyCreated,
                         textStyle = RadixTheme.typography.body1HighImportance,
                         textColor = RadixTheme.colors.gray1
                     )
@@ -208,7 +209,8 @@ fun NonFungibleAssetDialogContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = RadixTheme.dimensions.paddingXLarge),
-                address = resourceAddress
+                address = resourceAddress,
+                isNewlyCreatedEntity = isNewlyCreated
             )
             if (!asset?.resource?.name.isNullOrBlank() && localId != null) {
                 Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ActionableAddressView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ActionableAddressView.kt
@@ -69,11 +69,18 @@ fun ActionableAddressView(
     address: String,
     modifier: Modifier = Modifier,
     truncateAddress: Boolean = true,
+    visitableInDashboard: Boolean = true,
     textStyle: TextStyle = LocalTextStyle.current,
     textColor: Color = Color.Unspecified,
     iconColor: Color = textColor
 ) {
-    val actionableAddress = resolveAddress(address = address, truncateAddress = truncateAddress)
+    val actionableAddress = remember(address, truncateAddress, visitableInDashboard) {
+        ActionableAddress(
+            address = address,
+            truncateAddress = truncateAddress,
+            isVisitableInDashboard = visitableInDashboard
+        )
+    }
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -302,12 +309,6 @@ fun ActionableAddressView(
         }
     }
 }
-
-@Composable
-private fun resolveAddress(
-    address: String,
-    truncateAddress: Boolean
-): ActionableAddress = remember(address) { ActionableAddress(address, truncateAddress) }
 
 private data class PopupActions(
     val primary: PopupActionItem,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/AddressRow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/AddressRow.kt
@@ -15,7 +15,8 @@ import com.babylon.wallet.android.presentation.ui.composables.ActionableAddressV
 fun AddressRow(
     modifier: Modifier = Modifier,
     label: String = stringResource(id = R.string.assetDetails_resourceAddress),
-    address: String
+    address: String,
+    isNewlyCreatedEntity: Boolean = false
 ) {
     Row(
         modifier,
@@ -30,6 +31,7 @@ fun AddressRow(
 
         ActionableAddressView(
             address = address,
+            visitableInDashboard = !isNewlyCreatedEntity,
             textStyle = RadixTheme.typography.body1HighImportance,
             textColor = RadixTheme.colors.gray1,
             iconColor = RadixTheme.colors.gray2


### PR DESCRIPTION
## Description
1. Links to pool addresses resolve to the correct page
2. Resource addresses and local ids for newly created entities do not show the `View in Radix Dashboard` action.

## How to test

1. Do a pool contribution or redemption. Click on the pools sheet and visit the dashboard for a pool address
3. Create a token or an NFT and long click on the resource address or also the local id for the NFT. All should not show the View in Radix Dashboard action.

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
