### PR TITLE
ABW-2899 - Icon added to deposit rules content in transaction review. Icon for accept known fixed.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/thirdpartydeposits/AccountThirdPartyDepositsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/thirdpartydeposits/AccountThirdPartyDepositsScreen.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.presentation.account.settings.thirdpartydepos
 
 import androidx.activity.compose.BackHandler
 import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -300,7 +301,7 @@ fun getDepositRuleCopiesAndIcon(depositRule: Network.Account.OnLedgerSettings.Th
             Triple(
                 stringResource(id = R.string.accountSettings_thirdPartyDeposits_onlyKnown),
                 stringResource(id = R.string.accountSettings_thirdPartyDeposits_onlyKnownSubtitle),
-                com.babylon.wallet.android.designsystem.R.drawable.ic_accept_all,
+                com.babylon.wallet.android.designsystem.R.drawable.ic_accept_known,
             )
         }
 
@@ -335,7 +336,7 @@ fun DepositOptionItem(
         horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingMedium)
     ) {
         icon?.let {
-            Icon(painter = painterResource(id = it), contentDescription = null)
+            Image(painter = painterResource(id = it), contentDescription = null)
         }
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/AccountDepositSettingsTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/AccountDepositSettingsTypeContent.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.presentation.transaction.composables
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -68,16 +69,31 @@ fun AccountDepositSettingsTypeContent(
                             AccountDefaultDepositRule.ALLOW_EXISTING -> R.string.transactionReview_accountDepositSettings_acceptKnownRule
                         }
                     ).formattedSpans(boldStyle = SpanStyle(fontWeight = FontWeight.SemiBold, color = RadixTheme.colors.gray1))
+                    val icon = when (newRule) {
+                        AccountDefaultDepositRule.ACCEPT -> com.babylon.wallet.android.designsystem.R.drawable.ic_accept_all
+                        AccountDefaultDepositRule.REJECT -> com.babylon.wallet.android.designsystem.R.drawable.ic_deny_all
+                        AccountDefaultDepositRule.ALLOW_EXISTING -> com.babylon.wallet.android.designsystem.R.drawable.ic_accept_known
+                    }
                     val ruleBackgroundShape =
                         if (accountWithSettings.onlyDepositRuleChanged) RadixTheme.shapes.roundedRectBottomMedium else RectangleShape
-                    Text(
-                        text = ruleText,
-                        style = RadixTheme.typography.body1Regular,
+
+                    Row(
                         modifier = Modifier
                             .background(RadixTheme.colors.gray5, shape = ruleBackgroundShape)
                             .padding(RadixTheme.dimensions.paddingDefault),
-                        color = RadixTheme.colors.gray1
-                    )
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Image(
+                            modifier = Modifier.padding(end = RadixTheme.dimensions.paddingDefault),
+                            painter = painterResource(id = icon),
+                            contentDescription = null
+                        )
+                        Text(
+                            text = ruleText,
+                            style = RadixTheme.typography.body1Regular,
+                            color = RadixTheme.colors.gray1
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
Changed icon for accept known rule.
Added icon container in transaction review page when settings deposit rule.

## How to test

1. Go to accounts third party deposit
2. Change deposit rule
3. Verify that correct icons are displayed.

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/f5f4db5f-66c8-4c36-8a88-bdba5b694fa7" width="300">
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/e3c1f2c2-3bb5-43e5-a819-1705df01ec1b" width="300">


## PR submission checklist
- [x] I have verified that deposit rules icon are displayed correctly.
