### PR TITLE
Make Pool unit Thumbnail a circle

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
@@ -292,7 +292,7 @@ object Thumbnail {
             imageType = poolUnit.stake.iconUrl?.let { ImageType.External(it, ThumbnailRequestSize.LARGE) },
             emptyDrawable = R.drawable.ic_pool_units,
             emptyContentScale = CustomContentScale.standard(density = LocalDensity.current),
-            shape = RadixTheme.shapes.roundedRectMedium,
+            shape = CircleShape,
             contentDescription = poolUnit.stake.displayTitle
         )
     }


### PR DESCRIPTION
## Description
Pool unit icon from a rounded rect is now a circle.

## How to test
1. Open a pool unit in an account or in a transaction

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
