### PR TITLE
ABW-2860 - Bottom padding changed to get rid of padding being involved in animation.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
@@ -62,7 +62,7 @@ fun CommonTransferContent(
                             start = RadixTheme.dimensions.paddingDefault,
                             end = RadixTheme.dimensions.paddingDefault
                         )
-                        .padding(top = RadixTheme.dimensions.paddingLarge),
+                        .padding(top = RadixTheme.dimensions.paddingSemiLarge),
                     to = previewType.to.toPersistentList(),
                     promptForGuarantees = onPromptForGuarantees,
                     onFungibleResourceClick = { fungibleResource, isNewlyCreated ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolsContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolsContent.kt
@@ -111,6 +111,7 @@ fun PoolsContent(
         Column(
             modifier = Modifier
                 .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+                .padding(bottom = RadixTheme.dimensions.paddingMedium)
                 .fillMaxWidth()
                 .shadow(6.dp, RadixTheme.shapes.roundedRectDefault)
         ) {


### PR DESCRIPTION
## Description
When expanding pools, bottom part does not cut off upon animation.

## How to test

1. Trigger pool contribution
2. Expand and collapse Pools section
3. Observed that view is not cut off upon animation.

## Video
https://github.com/radixdlt/babylon-wallet-android/assets/108684750/ce6b93c3-8731-471a-996c-244eb097b9c5

## PR submission checklist
- [x] I have tested pool contribution transaction review and verified that view is not cut off upon animation when expanding/collapsing 
