### PR TITLE
ABW-2853 - Continue button greyed out if no seed phrase selected in Account Recovery Scan.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/recovery/chooseseed/ChooseSeedPhraseScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/recovery/chooseseed/ChooseSeedPhraseScreen.kt
@@ -108,6 +108,7 @@ private fun ChooseSeedPhraseContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(RadixTheme.dimensions.paddingDefault).navigationBarsPadding(),
+            enabled = state.isAnyFactorSourceSelected,
             text = stringResource(id = R.string.common_continue),
             onClick = onUseFactorSource
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/recovery/chooseseed/ChooseSeedPhraseScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/recovery/chooseseed/ChooseSeedPhraseScreen.kt
@@ -108,7 +108,7 @@ private fun ChooseSeedPhraseContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(RadixTheme.dimensions.paddingDefault).navigationBarsPadding(),
-            enabled = state.isAnyFactorSourceSelected,
+            enabled = state.selectedFactorSource != null,
             text = stringResource(id = R.string.common_continue),
             onClick = onUseFactorSource
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/recovery/chooseseed/ChooseSeedPhraseViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/recovery/chooseseed/ChooseSeedPhraseViewModel.kt
@@ -83,6 +83,9 @@ class ChooseSeedPhraseViewModel @Inject constructor(
     ) : UiState {
         val selectedFactorSource
             get() = factorSources.firstOrNull { it.selected }?.data?.deviceFactorSource
+
+        val isAnyFactorSourceSelected: Boolean
+            get() = factorSources.any { it.selected }
     }
 
     sealed interface Event : OneOffEvent {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/recovery/chooseseed/ChooseSeedPhraseViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/recovery/chooseseed/ChooseSeedPhraseViewModel.kt
@@ -83,9 +83,6 @@ class ChooseSeedPhraseViewModel @Inject constructor(
     ) : UiState {
         val selectedFactorSource
             get() = factorSources.firstOrNull { it.selected }?.data?.deviceFactorSource
-
-        val isAnyFactorSourceSelected: Boolean
-            get() = factorSources.any { it.selected }
     }
 
     sealed interface Event : OneOffEvent {


### PR DESCRIPTION
## Description
Continue button disabled if no seed phrase has been selected.

## How to test

1. Go to Account Recovery Scan
2. Make sure you have two seed phrases available
3. When entering Choose Seed Phrase screen verify that Continue button is disabled (greyed out) if no seed phrase is selected.

## Video
https://github.com/radixdlt/babylon-wallet-android/assets/108684750/c063906d-db5d-4ff3-b12a-45bd4dfd7b3c

## PR submission checklist
- [x] I have tested account recovery scan and verified that Continue button is greyed out if no seed phrase selected
