### PR TITLE
[ABW-2898] Simplify choose and add ledger screens

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -419,7 +419,7 @@ private fun ImportLegacyWalletContent(
                 onClose = onCloseSettings,
                 waitingForLedgerResponse = waitingForLedgerResponse,
                 onBackClick = onCloseSettings,
-                isLinkedConnectorEstablished = true
+                isAddingLedgerDeviceInProgress = false
 
             )
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
@@ -113,16 +113,10 @@ fun LedgerHardwareWalletsScreen(
                     },
                     backIconType = BackIconType.Back,
                     onMessageShown = addLedgerDeviceViewModel::onMessageShown,
-                    onClose = {
-                        addLedgerDeviceViewModel.initState()
-                        viewModel.onCloseClick()
-                    },
+                    onClose = viewModel::onCloseClick,
                     waitingForLedgerResponse = false,
-                    onBackClick = {
-                        addLedgerDeviceViewModel.initState()
-                        viewModel.onCloseClick()
-                    },
-                    isLinkedConnectorEstablished = addLedgerDeviceState.isAnyLinkedConnectorConnected
+                    onBackClick = viewModel::onCloseClick,
+                    isAddingLedgerDeviceInProgress = addLedgerDeviceState.isAddingLedgerDeviceInProgress,
                 )
             }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
@@ -54,7 +54,8 @@ fun AddLedgerDeviceScreen(
     onClose: () -> Unit,
     waitingForLedgerResponse: Boolean,
     onBackClick: () -> Unit,
-    isLinkedConnectorEstablished: Boolean
+    isAddingLedgerDeviceInProgress: Boolean,
+    isAddingNewLinkConnectorInProgress: Boolean = false
 ) {
     BackHandler(onBack = onBackClick)
 
@@ -140,8 +141,7 @@ fun AddLedgerDeviceScreen(
                                 modifier = Modifier.fillMaxWidth(),
                                 onClick = onSendAddLedgerRequestClick,
                                 text = stringResource(id = com.babylon.wallet.android.R.string.addLedgerDevice_addDevice_continue),
-                                enabled = isLinkedConnectorEstablished,
-                                isLoading = isLinkedConnectorEstablished.not()
+                                isLoading = isAddingLedgerDeviceInProgress || isAddingNewLinkConnectorInProgress
                             )
                         }
 
@@ -230,7 +230,8 @@ fun AddLedgerDeviceScreenPreview() {
             onClose = {},
             waitingForLedgerResponse = false,
             onBackClick = {},
-            isLinkedConnectorEstablished = true
+            isAddingLedgerDeviceInProgress = false,
+            isAddingNewLinkConnectorInProgress = false
         )
     }
 }
@@ -251,7 +252,8 @@ fun AddLedgerDeviceContentPreview3() {
             onClose = {},
             waitingForLedgerResponse = false,
             onBackClick = {},
-            isLinkedConnectorEstablished = true
+            isAddingLedgerDeviceInProgress = false,
+            isAddingNewLinkConnectorInProgress = false
         )
     }
 }


### PR DESCRIPTION
## Description
This PR  fixes several bugs in the choose and add ledger screens.

### The rule is the following:
- if at least one linked connector is configured in the wallet then every screen that involves a ledger will try to send messages over the data channel **no matter if it is open or closed**. In case it's closed we show the appropriate ui message "failed to connect..."
- if no linked connectors are configured in the wallet then every screen that involves a ledger will show the "add link connector screen" when wallet tries to send a message over the data channel


## How to test

**Use case 1**
1. add a link connector in the wallet
2. create an account with an existing ledger 
3. create another account by adding a new ledger (during the account creation flow)

verify that everything works as expected

---

**Use case 2**
1. add a link connector in the wallet
2. click forget from the CE of the browser
3. create an account with an existing ledger 
5. create another account by adding a new ledger (during the account creation flow)

verify that you see ui messages with a failure message

---

**Use case 3**
1. remove all linked connectors from the wallet
2. create an account with an existing ledger 
3. create another account by adding a new ledger (during the account creation flow)

verify that you get the add link connector prompt/screen

---

## PR submission checklist
- [x] I have tested ledger flows in account creation and ledger hardware wallets in settings
