### PR TITLE
Asset details with correct amounts in transaction review

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/cache/database/StateDao.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/cache/database/StateDao.kt
@@ -56,10 +56,16 @@ interface StateDao {
     fun updatePools(pools: List<PoolWithResourcesJoinResult>) {
         insertPoolDetails(pools.map { it.pool })
 
-        val resourcesInvolved = pools.map { pool ->
-            listOf(pool.poolUnitResource) + pool.resources.map { it.second }
+        val poolUnitResources = pools.map { pool ->
+            pool.poolUnitResource
+        }
+        insertOrReplaceResources(poolUnitResources)
+
+        val resourcesInvolvedInPools = pools.map { pool ->
+            pool.resources.map { it.second }
         }.flatten()
-        insertOrReplaceResources(resourcesInvolved)
+        insertOrIgnoreResources(resourcesInvolvedInPools)
+
         val poolResourcesJoin = pools.map { poolResource -> poolResource.resources.map { it.first } }.flatten()
         insertPoolResources(poolResourcesJoin)
 
@@ -101,6 +107,9 @@ interface StateDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertOrReplaceResources(resources: List<ResourceEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    fun insertOrIgnoreResources(resources: List<ResourceEntity>)
 
     @Query(
         """

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/PoolUnit.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/PoolUnit.kt
@@ -22,7 +22,12 @@ data class PoolUnit(
 
     fun resourceRedemptionValue(item: Resource.FungibleResource): BigDecimal? {
         val resourceVaultBalance = pool?.resources?.find { it.resourceAddress == item.resourceAddress }?.ownedAmount ?: return null
-        return if (stake.ownedAmount != null && stake.divisibility != null && stake.currentSupply != null) {
+        return if (
+            stake.ownedAmount != null &&
+            stake.divisibility != null &&
+            stake.currentSupply != null &&
+            stake.currentSupply != BigDecimal.ZERO
+        ) {
             stake.ownedAmount
                 .multiply(resourceVaultBalance)
                 .divide(stake.currentSupply, stake.mathContext)

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/PoolUnit.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/PoolUnit.kt
@@ -22,15 +22,11 @@ data class PoolUnit(
 
     fun resourceRedemptionValue(item: Resource.FungibleResource): BigDecimal? {
         val resourceVaultBalance = pool?.resources?.find { it.resourceAddress == item.resourceAddress }?.ownedAmount ?: return null
-        return if (
-            stake.ownedAmount != null &&
-            stake.divisibility != null &&
-            stake.currentSupply != null &&
-            stake.currentSupply != BigDecimal.ZERO
-        ) {
+        val poolUnitSupply = stake.currentSupply ?: BigDecimal.ZERO
+        return if (stake.ownedAmount != null && stake.divisibility != null && poolUnitSupply != BigDecimal.ZERO) {
             stake.ownedAmount
                 .multiply(resourceVaultBalance)
-                .divide(stake.currentSupply, stake.mathContext)
+                .divide(poolUnitSupply, stake.mathContext)
         } else {
             null
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -12,7 +12,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.babylon.wallet.android.domain.model.TransferableAsset
-import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.model.resources.XrdResource
 import com.babylon.wallet.android.presentation.account.AccountScreen
 import com.babylon.wallet.android.presentation.account.createaccount.ROUTE_CREATE_ACCOUNT
@@ -76,6 +75,7 @@ import kotlinx.coroutines.flow.StateFlow
 import rdx.works.profile.derivation.model.NetworkId
 import rdx.works.profile.domain.backup.BackupType
 
+@Suppress("CyclomaticComplexMethod")
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun NavigationHost(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -311,18 +311,18 @@ fun NavigationHost(
             onBackClick = {
                 navController.popBackStack()
             },
-            onFungibleClick = { resource, isNewlyCreated ->
+            onTransferableFungibleClick = { asset ->
                 navController.fungibleAssetDialog(
-                    resourceAddress = resource.resourceAddress,
-                    amount = resource.ownedAmount,
-                    isNewlyCreated = isNewlyCreated
+                    resourceAddress = asset.resource.resourceAddress,
+                    amount = asset.amount,
+                    isNewlyCreated = asset.isNewlyCreated
                 )
             },
-            onNonFungibleClick = { resource, item, isNewlyCreated ->
+            onTransferableNonFungibleClick = { asset, item ->
                 navController.nftAssetDialog(
-                    resourceAddress = resource.resourceAddress,
+                    resourceAddress = asset.resource.resourceAddress,
                     localId = item.localId.code,
-                    isNewlyCreated = isNewlyCreated
+                    isNewlyCreated = asset.isNewlyCreated
                 )
             },
             onDAppClick = { dApp ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialog.kt
@@ -54,19 +54,17 @@ fun AssetDialog(
         Box(modifier = Modifier.fillMaxHeight(fraction = 0.9f)) {
             when (val asset = state.asset) {
                 is Token -> FungibleDialogContent(
-                    resourceAddress = state.args.resourceAddress,
-                    isAmountPresent = state.args.isAmountPresent,
-                    isNewlyCreated = state.args.isNewlyCreated,
-                    token = asset
+                    args = state.args as AssetDialogArgs.Fungible,
+                    token = asset,
                 )
 
                 is LiquidStakeUnit -> LSUDialogContent(
-                    resourceAddress = state.args.resourceAddress,
+                    args = state.args as AssetDialogArgs.Fungible,
                     lsu = asset
                 )
 
                 is PoolUnit -> PoolUnitDialogContent(
-                    resourceAddress = state.args.resourceAddress,
+                    args = state.args as AssetDialogArgs.Fungible,
                     poolUnit = asset
                 )
                 // Includes NFTs and stake claims
@@ -86,9 +84,7 @@ fun AssetDialog(
                 // When asset is not retrieved yet, we show the placeholders for tokens, or NFTs
                 null -> when (val args = state.args) {
                     is AssetDialogArgs.Fungible -> FungibleDialogContent(
-                        resourceAddress = args.resourceAddress,
-                        isAmountPresent = args.isAmountPresent,
-                        isNewlyCreated = args.isNewlyCreated,
+                        args = state.args as AssetDialogArgs.Fungible,
                         token = null
                     )
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogNav.kt
@@ -137,6 +137,7 @@ fun NavGraphBuilder.assetDialog(
             },
             navArgument(ARG_AMOUNTS) {
                 type = NavType.StringType
+                nullable = true
             },
             navArgument(ARG_LOCAL_ID) {
                 type = NavType.StringType

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogNav.kt
@@ -7,13 +7,17 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.dialog
 import androidx.navigation.navArgument
+import com.babylon.wallet.android.data.gateway.generated.infrastructure.Serializer
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
 import java.math.BigDecimal
 import java.net.URLEncoder
 
 private const val ROUTE = "asset_dialog"
 private const val ARG_RESOURCE_ADDRESS = "resource_address"
 private const val ARG_NEWLY_CREATED = "newly_created"
-private const val ARG_AMOUNT = "amount"
+private const val ARG_AMOUNTS = "amounts"
 private const val ARG_LOCAL_ID = "local_id"
 private const val ARG_UNDER_ACCOUNT_ADDRESS = "under_account_address"
 
@@ -23,17 +27,17 @@ private const val ARG_RESOURCE_TYPE_VALUE_NFT = "nft"
 
 fun NavController.fungibleAssetDialog(
     resourceAddress: String,
-    amount: BigDecimal? = null,
+    amounts: Map<String, BigDecimal> = emptyMap(),
     isNewlyCreated: Boolean = false,
-    underAccountAddress: String? = null
+    underAccountAddress: String? = null,
 ) {
-    val amountParam = if (amount != null) "&$ARG_AMOUNT=${amount.toPlainString()}" else ""
     val underAccountAddressParam = if (underAccountAddress != null) "&$ARG_UNDER_ACCOUNT_ADDRESS=$underAccountAddress" else ""
+    val fungibleAmounts = Serializer.kotlinxSerializationJson.encodeToString(FungibleAmounts(amounts))
     navigate(
         route = "$ROUTE/$ARG_RESOURCE_TYPE_VALUE_FUNGIBLE" +
             "?${ARG_RESOURCE_ADDRESS}=$resourceAddress" +
             "&${ARG_NEWLY_CREATED}=$isNewlyCreated" +
-            amountParam +
+            "&$ARG_AMOUNTS=$fungibleAmounts" +
             underAccountAddressParam
     )
 }
@@ -55,20 +59,25 @@ fun NavController.nftAssetDialog(
     )
 }
 
+@Serializable
+private data class FungibleAmounts(
+    val amounts: Map<String, @Contextual BigDecimal>
+)
+
 sealed interface AssetDialogArgs {
     val resourceAddress: String
     val isNewlyCreated: Boolean
     val underAccountAddress: String?
 
-    val isAmountPresent: Boolean
-        get() = (this as? Fungible)?.amount != null
-
     data class Fungible(
         override val resourceAddress: String,
         override val isNewlyCreated: Boolean,
         override val underAccountAddress: String?,
-        val amount: BigDecimal?,
-    ) : AssetDialogArgs
+        private val amounts: Map<String, BigDecimal>,
+    ) : AssetDialogArgs {
+
+        fun fungibleAmountOf(address: String): BigDecimal? = amounts[address]
+    }
 
     data class NFT(
         override val resourceAddress: String,
@@ -80,12 +89,16 @@ sealed interface AssetDialogArgs {
     companion object {
         fun from(savedStateHandle: SavedStateHandle): AssetDialogArgs {
             return when (requireNotNull(savedStateHandle[ARG_RESOURCE_TYPE])) {
-                ARG_RESOURCE_TYPE_VALUE_FUNGIBLE -> Fungible(
-                    resourceAddress = requireNotNull(savedStateHandle[ARG_RESOURCE_ADDRESS]),
-                    isNewlyCreated = requireNotNull(savedStateHandle[ARG_NEWLY_CREATED]),
-                    underAccountAddress = savedStateHandle[ARG_UNDER_ACCOUNT_ADDRESS],
-                    amount = savedStateHandle.get<String>(ARG_AMOUNT)?.toBigDecimalOrNull()
-                )
+                ARG_RESOURCE_TYPE_VALUE_FUNGIBLE -> {
+                    val amountsSerialized = requireNotNull(savedStateHandle.get<String>(ARG_AMOUNTS))
+                    val fungibleAmounts = Serializer.kotlinxSerializationJson.decodeFromString<FungibleAmounts>(amountsSerialized)
+                    Fungible(
+                        resourceAddress = requireNotNull(savedStateHandle[ARG_RESOURCE_ADDRESS]),
+                        isNewlyCreated = requireNotNull(savedStateHandle[ARG_NEWLY_CREATED]),
+                        underAccountAddress = savedStateHandle[ARG_UNDER_ACCOUNT_ADDRESS],
+                        amounts = fungibleAmounts.amounts
+                    )
+                }
                 ARG_RESOURCE_TYPE_VALUE_NFT -> NFT(
                     resourceAddress = requireNotNull(savedStateHandle[ARG_RESOURCE_ADDRESS]),
                     isNewlyCreated = requireNotNull(savedStateHandle[ARG_NEWLY_CREATED]),
@@ -105,7 +118,7 @@ fun NavGraphBuilder.assetDialog(
         route = "$ROUTE/{$ARG_RESOURCE_TYPE}" +
             "?$ARG_RESOURCE_ADDRESS={$ARG_RESOURCE_ADDRESS}" +
             "&$ARG_NEWLY_CREATED={$ARG_NEWLY_CREATED}" +
-            "&$ARG_AMOUNT={$ARG_AMOUNT}" +
+            "&$ARG_AMOUNTS={$ARG_AMOUNTS}" +
             "&$ARG_LOCAL_ID={$ARG_LOCAL_ID}" +
             "&$ARG_UNDER_ACCOUNT_ADDRESS={$ARG_UNDER_ACCOUNT_ADDRESS}",
         arguments = listOf(
@@ -122,9 +135,8 @@ fun NavGraphBuilder.assetDialog(
             navArgument(ARG_RESOURCE_TYPE) {
                 type = NavType.StringType
             },
-            navArgument(ARG_AMOUNT) {
+            navArgument(ARG_AMOUNTS) {
                 type = NavType.StringType
-                nullable = true
             },
             navArgument(ARG_LOCAL_ID) {
                 type = NavType.StringType

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogViewModel.kt
@@ -53,7 +53,9 @@ class AssetDialogViewModel @Inject constructor(
                     is Asset.Fungible -> {
                         val fungibleArgs = (args as? AssetDialogArgs.Fungible) ?: return@mapCatching asset
 
-                        val resourceWithAmount = asset.resource.copy(ownedAmount = fungibleArgs.amount)
+                        val resourceWithAmount = asset.resource.copy(
+                            ownedAmount = fungibleArgs.fungibleAmountOf(asset.resource.resourceAddress)
+                        )
                         when (asset) {
                             is LiquidStakeUnit -> asset.copy(fungibleResource = resourceWithAmount)
                             is PoolUnit -> asset.copy(stake = resourceWithAmount)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/fungible/FungibleDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/fungible/FungibleDialogContent.kt
@@ -26,6 +26,7 @@ import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.assets.Token
 import com.babylon.wallet.android.domain.model.resources.isXrd
 import com.babylon.wallet.android.presentation.account.composable.AssetMetadataRow
+import com.babylon.wallet.android.presentation.status.assets.AssetDialogArgs
 import com.babylon.wallet.android.presentation.status.assets.BehavioursSection
 import com.babylon.wallet.android.presentation.status.assets.TagsSection
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
@@ -38,11 +39,12 @@ import java.math.BigDecimal
 @Composable
 fun FungibleDialogContent(
     modifier: Modifier = Modifier,
-    resourceAddress: String,
-    isAmountPresent: Boolean,
-    isNewlyCreated: Boolean,
-    token: Token?
+    token: Token?,
+    args: AssetDialogArgs.Fungible,
 ) {
+    val resourceAddress = args.resourceAddress
+    val isNewlyCreated = args.isNewlyCreated
+    val amount = args.fungibleAmountOf(resourceAddress) ?: token?.resource?.ownedAmount
     Column(
         modifier = modifier
             .background(RadixTheme.colors.defaultBackground)
@@ -70,12 +72,13 @@ fun FungibleDialogContent(
             )
         }
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-        if (isAmountPresent) {
+        if (amount != null) {
             TokenBalance(
                 modifier = Modifier
                     .fillMaxWidth(fraction = if (token?.resource == null) 0.5f else 1f)
                     .radixPlaceholder(visible = token?.resource == null),
-                fungibleResource = token?.resource
+                amount = amount,
+                symbol = token?.resource?.symbol.orEmpty(),
             )
         }
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/lsu/LSUDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/lsu/LSUDialogContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -38,7 +39,9 @@ import com.babylon.wallet.android.presentation.ui.composables.assets.assetOutlin
 import com.babylon.wallet.android.presentation.ui.composables.resources.AddressRow
 import com.babylon.wallet.android.presentation.ui.composables.resources.TokenBalance
 import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
+import com.radixdlt.ret.Address
 import rdx.works.core.displayableQuantity
+import rdx.works.profile.derivation.model.NetworkId
 import java.math.BigDecimal
 
 @Composable
@@ -114,9 +117,17 @@ fun LSUDialogContent(
         }
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
 
+        val xrdWorth = remember(args, lsu) {
+            val xrdResourceAddress = runCatching {
+                val networkId = NetworkId.from(Address(args.resourceAddress).networkId().toInt())
+                XrdResource.address(networkId = networkId)
+            }.getOrNull()
+
+            xrdResourceAddress?.let { args.fungibleAmountOf(it) } ?: lsu?.stakeValue()
+        }
         LSUResourceValue(
             modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingMedium),
-            lsu = lsu,
+            amount = xrdWorth
         )
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
         HorizontalDivider(
@@ -217,8 +228,8 @@ fun LSUDialogContent(
 
 @Composable
 private fun LSUResourceValue(
-    lsu: LiquidStakeUnit?,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    amount: BigDecimal?
 ) {
     Row(
         modifier = modifier
@@ -248,8 +259,8 @@ private fun LSUResourceValue(
         Text(
             modifier = Modifier
                 .widthIn(min = RadixTheme.dimensions.paddingXXXXLarge * 2)
-                .radixPlaceholder(visible = lsu == null),
-            text = lsu?.stakeValue()?.displayableQuantity().orEmpty(),
+                .radixPlaceholder(visible = amount == null),
+            text = amount?.displayableQuantity().orEmpty(),
             style = RadixTheme.typography.secondaryHeader,
             color = RadixTheme.colors.gray1,
             textAlign = TextAlign.End,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/lsu/LSUDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/lsu/LSUDialogContent.kt
@@ -29,6 +29,7 @@ import com.babylon.wallet.android.domain.model.assets.LiquidStakeUnit
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.model.resources.XrdResource
 import com.babylon.wallet.android.presentation.account.composable.AssetMetadataRow
+import com.babylon.wallet.android.presentation.status.assets.AssetDialogArgs
 import com.babylon.wallet.android.presentation.status.assets.BehavioursSection
 import com.babylon.wallet.android.presentation.status.assets.TagsSection
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
@@ -43,9 +44,11 @@ import java.math.BigDecimal
 @Composable
 fun LSUDialogContent(
     modifier: Modifier = Modifier,
-    resourceAddress: String,
-    lsu: LiquidStakeUnit?
+    lsu: LiquidStakeUnit?,
+    args: AssetDialogArgs.Fungible
 ) {
+    val resourceAddress = args.resourceAddress
+    val amount = args.fungibleAmountOf(resourceAddress) ?: lsu?.stakeValue()
     Column(
         modifier = modifier
             .background(RadixTheme.colors.defaultBackground)
@@ -77,7 +80,8 @@ fun LSUDialogContent(
             modifier = Modifier
                 .fillMaxWidth(fraction = if (lsu == null) 0.5f else 1f)
                 .radixPlaceholder(visible = lsu == null),
-            fungibleResource = lsu?.fungibleResource
+            amount = amount,
+            symbol = lsu?.resource?.symbol.orEmpty()
         )
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
         HorizontalDivider(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/pool/PoolUnitDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/pool/PoolUnitDialogContent.kt
@@ -36,6 +36,7 @@ import com.babylon.wallet.android.presentation.ui.composables.assets.assetOutlin
 import com.babylon.wallet.android.presentation.ui.composables.resources.AddressRow
 import com.babylon.wallet.android.presentation.ui.composables.resources.TokenBalance
 import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
+import kotlinx.collections.immutable.toImmutableMap
 import rdx.works.core.displayableQuantity
 import java.math.BigDecimal
 
@@ -98,7 +99,7 @@ fun PoolUnitDialogContent(
             val resourcesWithAmount = remember(poolUnit, args) {
                 poolUnit.pool?.resources?.associateWith {
                     args.fungibleAmountOf(it.resourceAddress) ?: poolUnit.resourceRedemptionValue(it)
-                }.orEmpty()
+                }.orEmpty().toImmutableMap()
             }
             PoolResourcesValues(
                 modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewNav.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.babylon.wallet.android.domain.model.DApp
+import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.navigation.markAsHighPriority
 
@@ -29,8 +30,8 @@ fun NavController.transactionReview(requestId: String) {
 
 fun NavGraphBuilder.transactionReviewScreen(
     onBackClick: () -> Unit,
-    onFungibleClick: (Resource.FungibleResource, Boolean) -> Unit,
-    onNonFungibleClick: (Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit,
+    onTransferableFungibleClick: (TransferableAsset.Fungible) -> Unit,
+    onTransferableNonFungibleClick: (TransferableAsset.NonFungible, Resource.NonFungibleResource.Item) -> Unit,
     onDAppClick: (DApp) -> Unit
 ) {
     markAsHighPriority(ROUTE_TRANSACTION_REVIEW)
@@ -43,8 +44,8 @@ fun NavGraphBuilder.transactionReviewScreen(
         TransactionReviewScreen(
             viewModel = hiltViewModel(),
             onDismiss = onBackClick,
-            onFungibleClick = onFungibleClick,
-            onNonFungibleClick = onNonFungibleClick,
+            onTransferableFungibleClick = onTransferableFungibleClick,
+            onTransferableNonFungibleClick = onTransferableNonFungibleClick,
             onDAppClick = onDAppClick
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -39,6 +39,7 @@ import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.model.DApp
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.domain.model.TransactionManifestData
+import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.userFriendlyMessage
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
@@ -74,21 +75,12 @@ fun TransactionReviewScreen(
     modifier: Modifier = Modifier,
     viewModel: TransactionReviewViewModel,
     onDismiss: () -> Unit,
-    onFungibleClick: (Resource.FungibleResource, Boolean) -> Unit,
-    onNonFungibleClick: (Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit,
+    onTransferableFungibleClick: (asset: TransferableAsset.Fungible) -> Unit,
+    onTransferableNonFungibleClick: (asset: TransferableAsset.NonFungible, Resource.NonFungibleResource.Item) -> Unit,
     onDAppClick: (DApp) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
-
-    LaunchedEffect(Unit) {
-        viewModel.oneOffEvent.collect {
-            when (it) {
-                is TransactionReviewViewModel.Event.OnFungibleClick -> onFungibleClick(it.resource, it.isNewlyCreated)
-                is TransactionReviewViewModel.Event.OnNonFungibleClick -> onNonFungibleClick(it.resource, it.item, it.isNewlyCreated)
-            }
-        }
-    }
 
     TransactionPreviewContent(
         onBackClick = viewModel::onBackClick,
@@ -110,8 +102,8 @@ fun TransactionReviewScreen(
         onGuaranteeValueDecreased = viewModel::onGuaranteeValueDecreased,
         onDAppClick = onDAppClick,
         onUnknownComponentsClick = viewModel::onUnknownComponentsClick,
-        onFungibleResourceClick = viewModel::onFungibleResourceClick,
-        onNonFungibleResourceClick = viewModel::onNonFungibleResourceClick,
+        onTransferableFungibleClick = onTransferableFungibleClick,
+        onNonTransferableFungibleClick = onTransferableNonFungibleClick,
         onChangeFeePayerClick = viewModel::onChangeFeePayerClick,
         onSelectFeePayerClick = viewModel::onSelectFeePayerClick,
         onPayerSelected = viewModel::onPayerSelected,
@@ -170,8 +162,8 @@ private fun TransactionPreviewContent(
     onGuaranteeValueDecreased: (AccountWithPredictedGuarantee) -> Unit,
     onDAppClick: (DApp) -> Unit,
     onUnknownComponentsClick: (ImmutableList<String>) -> Unit,
-    onFungibleResourceClick: (Resource.FungibleResource, Boolean) -> Unit,
-    onNonFungibleResourceClick: (Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit,
+    onTransferableFungibleClick: (asset: TransferableAsset.Fungible) -> Unit,
+    onNonTransferableFungibleClick: (asset: TransferableAsset.NonFungible, Resource.NonFungibleResource.Item) -> Unit,
     onChangeFeePayerClick: () -> Unit,
     onSelectFeePayerClick: () -> Unit,
     onPayerSelected: (Network.Account) -> Unit,
@@ -299,8 +291,8 @@ private fun TransactionPreviewContent(
                                     onUnknownComponentsClick = { componentAddresses ->
                                         onUnknownComponentsClick(componentAddresses.toPersistentList())
                                     },
-                                    onFungibleResourceClick = onFungibleResourceClick,
-                                    onNonFungibleResourceClick = onNonFungibleResourceClick
+                                    onTransferableFungibleClick = onTransferableFungibleClick,
+                                    onNonTransferableFungibleClick = onNonTransferableFungibleClick
                                 )
                             }
 
@@ -313,8 +305,8 @@ private fun TransactionPreviewContent(
                             is PreviewType.Transfer.Staking -> {
                                 StakeTypeContent(
                                     state = state,
-                                    onFungibleResourceClick = onFungibleResourceClick,
-                                    onNonFungibleResourceClick = onNonFungibleResourceClick,
+                                    onTransferableFungibleClick = onTransferableFungibleClick,
+                                    onNonTransferableFungibleClick = onNonTransferableFungibleClick,
                                     onPromptForGuarantees = promptForGuarantees,
                                     previewType = preview
                                 )
@@ -323,7 +315,7 @@ private fun TransactionPreviewContent(
                             is PreviewType.Transfer.Pool -> {
                                 PoolTypeContent(
                                     state = state,
-                                    onFungibleResourceClick = onFungibleResourceClick,
+                                    onTransferableFungibleClick = onTransferableFungibleClick,
                                     onPromptForGuarantees = promptForGuarantees,
                                     previewType = preview,
                                     onDAppClick = onDAppClick,
@@ -512,8 +504,8 @@ fun TransactionPreviewContentPreview() {
             onCustomizeClick = {},
             onDAppClick = {},
             onUnknownComponentsClick = {},
-            onFungibleResourceClick = { _, _ -> },
-            onNonFungibleResourceClick = { _, _, _ -> },
+            onTransferableFungibleClick = {},
+            onNonTransferableFungibleClick = { _, _ -> },
             onGuaranteeValueChanged = { _, _ -> },
             onGuaranteeValueIncreased = {},
             onGuaranteeValueDecreased = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -20,17 +20,11 @@ import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.model.assets.ValidatorDetail
 import com.babylon.wallet.android.domain.model.resources.Badge
 import com.babylon.wallet.android.domain.model.resources.Resource
-import com.babylon.wallet.android.domain.model.resources.Resource.FungibleResource
-import com.babylon.wallet.android.domain.model.resources.Resource.NonFungibleResource
 import com.babylon.wallet.android.domain.model.resources.isXrd
 import com.babylon.wallet.android.domain.usecases.GetDAppsUseCase
-import com.babylon.wallet.android.presentation.common.OneOffEvent
-import com.babylon.wallet.android.presentation.common.OneOffEventHandler
-import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
 import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.UiState
-import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel.Event
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel.State
 import com.babylon.wallet.android.presentation.transaction.analysis.TransactionAnalysisDelegate
 import com.babylon.wallet.android.presentation.transaction.fees.TransactionFees
@@ -61,7 +55,7 @@ class TransactionReviewViewModel @Inject constructor(
     private val getDAppsUseCase: GetDAppsUseCase,
     incomingRequestRepository: IncomingRequestRepository,
     savedStateHandle: SavedStateHandle,
-) : StateViewModel<State>(), OneOffEventHandler<Event> by OneOffEventHandlerImpl() {
+) : StateViewModel<State>() {
 
     private val args = TransactionReviewArgs(savedStateHandle)
 
@@ -222,22 +216,6 @@ class TransactionReviewViewModel @Inject constructor(
         }
     }
 
-    fun onFungibleResourceClick(fungibleResource: FungibleResource, isNewlyCreated: Boolean) {
-        viewModelScope.launch {
-            sendEvent(Event.OnFungibleClick(fungibleResource, isNewlyCreated))
-        }
-    }
-
-    fun onNonFungibleResourceClick(
-        nonFungibleResource: NonFungibleResource,
-        item: NonFungibleResource.Item,
-        isNewlyCreated: Boolean
-    ) {
-        viewModelScope.launch {
-            sendEvent(Event.OnNonFungibleClick(nonFungibleResource, item, isNewlyCreated))
-        }
-    }
-
     fun dismissTerminalErrorDialog() {
         _state.update { it.copy(error = null) }
         onBackClick()
@@ -245,19 +223,6 @@ class TransactionReviewViewModel @Inject constructor(
 
     fun onAcknowledgeRawTransactionWarning() {
         _state.update { it.copy(showRawTransactionWarning = false) }
-    }
-
-    sealed interface Event : OneOffEvent {
-        data class OnFungibleClick(
-            val resource: FungibleResource,
-            val isNewlyCreated: Boolean
-        ) : Event
-
-        data class OnNonFungibleClick(
-            val resource: NonFungibleResource,
-            val item: NonFungibleResource.Item,
-            val isNewlyCreated: Boolean
-        ) : Event
     }
 
     data class State(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolContributionProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolContributionProcessor.kt
@@ -63,14 +63,17 @@ class PoolContributionProcessor @Inject constructor(
                     val poolUnitAmount = contributions.find {
                         it.poolUnitsResourceAddress.addressString() == poolUnit.resourceAddress
                     }?.poolUnitsAmount?.asStr()?.toBigDecimalOrNull()
+                    val contributionPerResource = contributedResourceAddresses.associateWith { contributedResourceAddress ->
+                        contributions.mapNotNull { it.contributedResources[contributedResourceAddress]?.asStr()?.toBigDecimal() }
+                            .sumOf { it }
+                    }
                     Transferable.Depositing(
                         transferable = TransferableAsset.Fungible.PoolUnitAsset(
                             amount = contributions.map { it.poolUnitsAmount.asStr().toBigDecimal() }.sumOf { it },
-                            unit = poolUnit.copy(stake = poolUnit.stake.copy(ownedAmount = poolUnitAmount)),
-                            contributionPerResource = contributedResourceAddresses.associateWith { contributedResourceAddress ->
-                                contributions.mapNotNull { it.contributedResources[contributedResourceAddress]?.asStr()?.toBigDecimal() }
-                                    .sumOf { it }
-                            }
+                            unit = poolUnit.copy(
+                                stake = poolUnit.stake.copy(ownedAmount = poolUnitAmount)
+                            ),
+                            contributionPerResource = contributionPerResource
                         ),
                         guaranteeType = guaranteeType,
                     )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.TransferableAsset
-import com.babylon.wallet.android.domain.model.assets.Asset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/CommonTransferContent.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.domain.model.TransferableAsset
+import com.babylon.wallet.android.domain.model.assets.Asset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel
@@ -19,8 +21,8 @@ import kotlinx.collections.immutable.toPersistentList
 fun CommonTransferContent(
     modifier: Modifier = Modifier,
     state: TransactionReviewViewModel.State,
-    onFungibleResourceClick: (fungibleResource: Resource.FungibleResource, Boolean) -> Unit,
-    onNonFungibleResourceClick: (nonFungibleResource: Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit,
+    onTransferableFungibleClick: (asset: TransferableAsset.Fungible) -> Unit,
+    onNonTransferableFungibleClick: (asset: TransferableAsset.NonFungible, Resource.NonFungibleResource.Item) -> Unit,
     previewType: PreviewType.Transfer,
     onPromptForGuarantees: () -> Unit,
     middleSection: @Composable () -> Unit
@@ -41,12 +43,8 @@ fun CommonTransferContent(
             WithdrawAccountContent(
                 modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault),
                 from = previewType.from.toPersistentList(),
-                onFungibleResourceClick = { fungibleResource, isNewlyCreated ->
-                    onFungibleResourceClick(fungibleResource, isNewlyCreated)
-                },
-                onNonFungibleResourceClick = { nonFungibleResource, nonFungibleResourceItem, isNewlyCreated ->
-                    onNonFungibleResourceClick(nonFungibleResource, nonFungibleResourceItem, isNewlyCreated)
-                }
+                onTransferableFungibleClick = onTransferableFungibleClick,
+                onNonTransferableFungibleClick = onNonTransferableFungibleClick
             )
 
             Column(
@@ -65,12 +63,8 @@ fun CommonTransferContent(
                         .padding(top = RadixTheme.dimensions.paddingLarge),
                     to = previewType.to.toPersistentList(),
                     promptForGuarantees = onPromptForGuarantees,
-                    onFungibleResourceClick = { fungibleResource, isNewlyCreated ->
-                        onFungibleResourceClick(fungibleResource, isNewlyCreated)
-                    },
-                    onNonFungibleResourceClick = { nonFungibleResource, nonFungibleResourceItem, isNewlyCreated ->
-                        onNonFungibleResourceClick(nonFungibleResource, nonFungibleResourceItem, isNewlyCreated)
-                    }
+                    onTransferableFungibleClick = onTransferableFungibleClick,
+                    onNonTransferableFungibleClick = onNonTransferableFungibleClick
                 )
             }
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/DepositAccountContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/DepositAccountContent.kt
@@ -32,6 +32,7 @@ import com.babylon.wallet.android.designsystem.composable.RadixTextButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.SampleDataProvider
+import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
 import com.babylon.wallet.android.presentation.transaction.hasCustomizableGuarantees
@@ -45,8 +46,8 @@ fun DepositAccountContent(
     modifier: Modifier = Modifier,
     to: ImmutableList<AccountWithTransferableResources>,
     promptForGuarantees: () -> Unit,
-    onFungibleResourceClick: (fungibleResource: Resource.FungibleResource, Boolean) -> Unit,
-    onNonFungibleResourceClick: (nonFungibleResource: Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit
+    onTransferableFungibleClick: (asset: TransferableAsset.Fungible) -> Unit,
+    onNonTransferableFungibleClick: (asset: TransferableAsset.NonFungible, Resource.NonFungibleResource.Item) -> Unit
 ) {
     if (to.isNotEmpty()) {
         Column(modifier = modifier) {
@@ -89,12 +90,8 @@ fun DepositAccountContent(
                     val lastItem = index == to.size - 1
                     TransactionAccountCard(
                         account = accountEntry,
-                        onFungibleResourceClick = { fungibleResource, isNewlyCreated ->
-                            onFungibleResourceClick(fungibleResource, isNewlyCreated)
-                        },
-                        onNonFungibleResourceClick = { nonFungibleResource, nonFungibleResourceItem, isNewlyCreated ->
-                            onNonFungibleResourceClick(nonFungibleResource, nonFungibleResourceItem, isNewlyCreated)
-                        }
+                        onTransferableFungibleClick = onTransferableFungibleClick,
+                        onTransferableNonFungibleClick = onNonTransferableFungibleClick
                     )
 
                     if (!lastItem) {
@@ -148,8 +145,8 @@ fun DepositAccountPreview() {
         DepositAccountContent(
             to = listOf(SampleDataProvider().accountWithTransferableResourcesOwned).toPersistentList(),
             promptForGuarantees = {},
-            onFungibleResourceClick = { _, _ -> },
-            onNonFungibleResourceClick = { _, _, _ -> }
+            onTransferableFungibleClick = { },
+            onNonTransferableFungibleClick = { _, _ -> }
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolTypeContent.kt
@@ -11,6 +11,8 @@ import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.SampleDataProvider
 import com.babylon.wallet.android.domain.model.DApp
+import com.babylon.wallet.android.domain.model.TransferableAsset
+import com.babylon.wallet.android.domain.model.assets.Asset
 import com.babylon.wallet.android.domain.model.resources.Pool
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.PreviewType
@@ -23,7 +25,7 @@ import kotlinx.collections.immutable.toPersistentList
 fun PoolTypeContent(
     modifier: Modifier = Modifier,
     state: TransactionReviewViewModel.State,
-    onFungibleResourceClick: (fungibleResource: Resource.FungibleResource, Boolean) -> Unit,
+    onTransferableFungibleClick: (asset: TransferableAsset.Fungible) -> Unit,
     previewType: PreviewType.Transfer.Pool,
     onPromptForGuarantees: () -> Unit,
     onDAppClick: (DApp) -> Unit,
@@ -36,8 +38,8 @@ fun PoolTypeContent(
     CommonTransferContent(
         modifier = modifier.fillMaxSize(),
         state = state,
-        onFungibleResourceClick = onFungibleResourceClick,
-        onNonFungibleResourceClick = { _, _, _ -> },
+        onTransferableFungibleClick = onTransferableFungibleClick,
+        onNonTransferableFungibleClick = { _, _ -> },
         previewType = previewType,
         onPromptForGuarantees = onPromptForGuarantees,
         middleSection = {
@@ -63,7 +65,7 @@ fun PoolTypePreview() {
                 isNetworkFeeLoading = false,
                 previewType = PreviewType.NonConforming
             ),
-            onFungibleResourceClick = { _, _ -> },
+            onTransferableFungibleClick = {},
             previewType = PreviewType.Transfer.Pool(
                 to = persistentListOf(),
                 from = listOf(SampleDataProvider().accountWithTransferablePool).toPersistentList(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolTypeContent.kt
@@ -12,9 +12,7 @@ import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.SampleDataProvider
 import com.babylon.wallet.android.domain.model.DApp
 import com.babylon.wallet.android.domain.model.TransferableAsset
-import com.babylon.wallet.android.domain.model.assets.Asset
 import com.babylon.wallet.android.domain.model.resources.Pool
-import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel
 import kotlinx.collections.immutable.persistentListOf

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/StakeTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/StakeTypeContent.kt
@@ -10,6 +10,7 @@ import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.SampleDataProvider
+import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel
@@ -20,8 +21,8 @@ import kotlinx.collections.immutable.toPersistentList
 fun StakeTypeContent(
     modifier: Modifier = Modifier,
     state: TransactionReviewViewModel.State,
-    onFungibleResourceClick: (fungibleResource: Resource.FungibleResource, Boolean) -> Unit,
-    onNonFungibleResourceClick: (nonFungibleResource: Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit,
+    onTransferableFungibleClick: (asset: TransferableAsset.Fungible) -> Unit,
+    onNonTransferableFungibleClick: (asset: TransferableAsset.NonFungible, Resource.NonFungibleResource.Item) -> Unit,
     previewType: PreviewType.Transfer.Staking,
     onPromptForGuarantees: () -> Unit
 ) {
@@ -38,8 +39,8 @@ fun StakeTypeContent(
     CommonTransferContent(
         modifier = modifier.fillMaxSize(),
         state = state,
-        onFungibleResourceClick = onFungibleResourceClick,
-        onNonFungibleResourceClick = onNonFungibleResourceClick,
+        onTransferableFungibleClick = onTransferableFungibleClick,
+        onNonTransferableFungibleClick = onNonTransferableFungibleClick,
         previewType = previewType,
         onPromptForGuarantees = onPromptForGuarantees,
         middleSection = {
@@ -63,8 +64,8 @@ fun StakeUnstakeTypePreview() {
                 isNetworkFeeLoading = false,
                 previewType = PreviewType.NonConforming
             ),
-            onFungibleResourceClick = { _, _ -> },
-            onNonFungibleResourceClick = { _, _, _ -> },
+            onTransferableFungibleClick = { _ -> },
+            onNonTransferableFungibleClick = { _, _ -> },
             previewType = PreviewType.Transfer.Staking(
                 to = persistentListOf(),
                 from = listOf(SampleDataProvider().accountWithTransferableResourceLsu).toPersistentList(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountCard.kt
@@ -39,7 +39,6 @@ import com.babylon.wallet.android.domain.SampleDataProvider
 import com.babylon.wallet.android.domain.model.GuaranteeAssertion
 import com.babylon.wallet.android.domain.model.Transferable
 import com.babylon.wallet.android.domain.model.TransferableAsset
-import com.babylon.wallet.android.domain.model.assets.StakeClaim
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.model.resources.XrdResource
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountCard.kt
@@ -39,6 +39,7 @@ import com.babylon.wallet.android.domain.SampleDataProvider
 import com.babylon.wallet.android.domain.model.GuaranteeAssertion
 import com.babylon.wallet.android.domain.model.Transferable
 import com.babylon.wallet.android.domain.model.TransferableAsset
+import com.babylon.wallet.android.domain.model.assets.StakeClaim
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.domain.model.resources.XrdResource
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
@@ -55,8 +56,8 @@ import rdx.works.profile.data.model.pernetwork.Network
 fun TransactionAccountCard(
     modifier: Modifier = Modifier,
     account: AccountWithTransferableResources,
-    onFungibleResourceClick: (fungibleResource: Resource.FungibleResource, Boolean) -> Unit,
-    onNonFungibleResourceClick: (nonFungibleResource: Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit
+    onTransferableFungibleClick: (asset: TransferableAsset.Fungible) -> Unit,
+    onTransferableNonFungibleClick: (asset: TransferableAsset.NonFungible, Resource.NonFungibleResource.Item) -> Unit
 ) {
     Column(
         modifier = modifier,
@@ -74,7 +75,7 @@ fun TransactionAccountCard(
             when (val asset = transferable.transferable) {
                 is TransferableAsset.Fungible.Token -> TransferableItemContent(
                     modifier = Modifier.throttleClickable {
-                        onFungibleResourceClick(asset.resource, asset.isNewlyCreated)
+                        onTransferableFungibleClick(asset)
                     },
                     transferable = transferable,
                     shape = shape,
@@ -86,7 +87,7 @@ fun TransactionAccountCard(
                         val lastNFT = itemIndex == asset.resource.items.lastIndex
                         TransferableNftItemContent(
                             modifier = Modifier.throttleClickable {
-                                onNonFungibleResourceClick(asset.resource, item, asset.isNewlyCreated)
+                                onTransferableNonFungibleClick(asset, item)
                             },
                             transferable = asset,
                             shape = if (lastAsset && lastNFT) RadixTheme.shapes.roundedRectBottomMedium else RectangleShape,
@@ -98,12 +99,12 @@ fun TransactionAccountCard(
                 is TransferableAsset.Fungible.PoolUnitAsset -> TransferablePoolUnitItemContent(
                     transferable = transferable,
                     shape = shape,
-                    onFungibleResourceClick = onFungibleResourceClick
+                    onClick = onTransferableFungibleClick
                 )
 
                 is TransferableAsset.Fungible.LSUAsset -> TransferableLsuItemContent(
                     modifier = Modifier.throttleClickable {
-                        onFungibleResourceClick(asset.lsu.fungibleResource, asset.isNewlyCreated)
+                        onTransferableFungibleClick(asset)
                     },
                     transferable = transferable,
                     shape = shape,
@@ -112,7 +113,7 @@ fun TransactionAccountCard(
                 is TransferableAsset.NonFungible.StakeClaimAssets -> TransferableStakeClaimNftItemContent(
                     transferable = asset,
                     shape = shape,
-                    onNonFungibleResourceClick = onNonFungibleResourceClick
+                    onClick = onTransferableNonFungibleClick
                 )
             }
 
@@ -408,7 +409,7 @@ private fun TransferableStakeClaimNftItemContent(
     modifier: Modifier = Modifier,
     transferable: TransferableAsset.NonFungible.StakeClaimAssets,
     shape: Shape,
-    onNonFungibleResourceClick: (nonFungibleResource: Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit
+    onClick: (TransferableAsset.NonFungible.StakeClaimAssets, Resource.NonFungibleResource.Item) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -465,10 +466,9 @@ private fun TransferableStakeClaimNftItemContent(
                 modifier = Modifier
                     .clip(RadixTheme.shapes.roundedRectSmall)
                     .throttleClickable {
-                        onNonFungibleResourceClick(
-                            transferable.resource,
-                            item,
-                            transferable.isNewlyCreated
+                        onClick(
+                            transferable,
+                            item
                         )
                     }
                     .fillMaxWidth()
@@ -512,17 +512,14 @@ private fun TransferablePoolUnitItemContent(
     modifier: Modifier = Modifier,
     transferable: Transferable,
     shape: Shape,
-    onFungibleResourceClick: (fungibleResource: Resource.FungibleResource, Boolean) -> Unit
+    onClick: (poolUnit: TransferableAsset.Fungible.PoolUnitAsset) -> Unit
 ) {
     val transferablePoolUnit = transferable.transferable as TransferableAsset.Fungible.PoolUnitAsset
     Column(
         modifier = modifier
             .height(IntrinsicSize.Min)
             .throttleClickable {
-                onFungibleResourceClick(
-                    transferablePoolUnit.resource,
-                    transferablePoolUnit.isNewlyCreated
-                )
+                onClick(transferablePoolUnit)
             }
             .background(
                 color = RadixTheme.colors.gray5,
@@ -691,8 +688,8 @@ fun TransactionAccountCardPreview() {
                     )
                 }
             ),
-            onFungibleResourceClick = { _, _ -> },
-            onNonFungibleResourceClick = { _, _, _ -> }
+            onTransferableFungibleClick = { },
+            onTransferableNonFungibleClick = { _, _ -> }
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransferTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransferTypeContent.kt
@@ -9,6 +9,8 @@ import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.SampleDataProvider
 import com.babylon.wallet.android.domain.model.DApp
+import com.babylon.wallet.android.domain.model.TransferableAsset
+import com.babylon.wallet.android.domain.model.assets.Asset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel
@@ -22,14 +24,14 @@ fun TransferTypeContent(
     onPromptForGuarantees: () -> Unit,
     onDAppClick: (DApp) -> Unit,
     onUnknownComponentsClick: (List<String>) -> Unit,
-    onFungibleResourceClick: (fungibleResource: Resource.FungibleResource, Boolean) -> Unit,
-    onNonFungibleResourceClick: (nonFungibleResource: Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit
+    onTransferableFungibleClick: (asset: TransferableAsset.Fungible) -> Unit,
+    onNonTransferableFungibleClick: (asset: TransferableAsset.NonFungible, Resource.NonFungibleResource.Item) -> Unit,
 ) {
     CommonTransferContent(
         modifier = modifier.fillMaxSize(),
         state = state,
-        onFungibleResourceClick = onFungibleResourceClick,
-        onNonFungibleResourceClick = onNonFungibleResourceClick,
+        onTransferableFungibleClick = onTransferableFungibleClick,
+        onNonTransferableFungibleClick = onNonTransferableFungibleClick,
         previewType = preview,
         onPromptForGuarantees = onPromptForGuarantees,
         middleSection = {
@@ -61,8 +63,8 @@ fun TransactionPreviewTypePreview() {
             onPromptForGuarantees = {},
             onDAppClick = { _ -> },
             onUnknownComponentsClick = {},
-            onFungibleResourceClick = { _, _ -> },
-            onNonFungibleResourceClick = { _, _, _ -> }
+            onTransferableFungibleClick = {},
+            onNonTransferableFungibleClick = { _, _ -> }
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransferTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransferTypeContent.kt
@@ -10,7 +10,6 @@ import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.SampleDataProvider
 import com.babylon.wallet.android.domain.model.DApp
 import com.babylon.wallet.android.domain.model.TransferableAsset
-import com.babylon.wallet.android.domain.model.assets.Asset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/WithdrawAccountContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/WithdrawAccountContent.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.domain.model.TransferableAsset
+import com.babylon.wallet.android.domain.model.assets.Asset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
 import com.babylon.wallet.android.presentation.ui.composables.DSR
@@ -32,8 +34,8 @@ import kotlinx.collections.immutable.ImmutableList
 fun WithdrawAccountContent(
     modifier: Modifier = Modifier,
     from: ImmutableList<AccountWithTransferableResources>,
-    onFungibleResourceClick: (fungibleResource: Resource.FungibleResource, Boolean) -> Unit,
-    onNonFungibleResourceClick: (nonFungibleResource: Resource.NonFungibleResource, Resource.NonFungibleResource.Item, Boolean) -> Unit
+    onTransferableFungibleClick: (asset: TransferableAsset.Fungible) -> Unit,
+    onNonTransferableFungibleClick: (asset: TransferableAsset.NonFungible, Resource.NonFungibleResource.Item) -> Unit,
 ) {
     if (from.isNotEmpty()) {
         Row(
@@ -73,12 +75,8 @@ fun WithdrawAccountContent(
             from.forEachIndexed { index, account ->
                 TransactionAccountCard(
                     account = account,
-                    onFungibleResourceClick = { fungibleResource, isNewlyCreated ->
-                        onFungibleResourceClick(fungibleResource, isNewlyCreated)
-                    },
-                    onNonFungibleResourceClick = { nonFungibleResource, nonFungibleResourceItem, isNewlyCreated ->
-                        onNonFungibleResourceClick(nonFungibleResource, nonFungibleResourceItem, isNewlyCreated)
-                    }
+                    onTransferableFungibleClick = onTransferableFungibleClick,
+                    onTransferableNonFungibleClick = onNonTransferableFungibleClick
                 )
 
                 if (index != from.lastIndex) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/WithdrawAccountContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/WithdrawAccountContent.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.model.TransferableAsset
-import com.babylon.wallet.android.domain.model.assets.Asset
 import com.babylon.wallet.android.domain.model.resources.Resource
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
 import com.babylon.wallet.android.presentation.ui.composables.DSR

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
@@ -28,6 +28,8 @@ import com.babylon.wallet.android.presentation.account.composable.EmptyResources
 import com.babylon.wallet.android.presentation.transfer.assets.AssetsTab
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.toImmutableMap
 import rdx.works.core.displayableQuantity
 import java.math.BigDecimal
 
@@ -136,7 +138,7 @@ private fun PoolUnitItem(
         val resourcesWithAmounts = remember(poolUnit) {
             poolUnit.pool?.resources?.associateWith {
                 poolUnit.resourceRedemptionValue(it)
-            }.orEmpty()
+            }.orEmpty().toImmutableMap()
         }
         PoolResourcesValues(
             modifier = Modifier
@@ -150,7 +152,7 @@ private fun PoolUnitItem(
 @Composable
 fun PoolResourcesValues(
     modifier: Modifier = Modifier,
-    resources: Map<Resource.FungibleResource, BigDecimal?>,
+    resources: ImmutableMap<Resource.FungibleResource, BigDecimal?>,
     isCompact: Boolean = true
 ) {
     Column(modifier = modifier.assetOutlineBorder()) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/TokenBalance.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/resources/TokenBalance.kt
@@ -1,28 +1,29 @@
 package com.babylon.wallet.android.presentation.ui.composables.resources
 
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
-import com.babylon.wallet.android.domain.model.resources.Resource
 import rdx.works.core.displayableQuantity
+import java.math.BigDecimal
 
 @Composable
 fun TokenBalance(
     modifier: Modifier = Modifier,
-    fungibleResource: Resource.FungibleResource?,
+    amount: BigDecimal?,
+    symbol: String,
     align: TextAlign = TextAlign.Center
 ) {
     Text(
         modifier = modifier,
         text = buildAnnotatedString {
-            if (fungibleResource?.ownedAmount != null) {
-                append(fungibleResource.ownedAmount.displayableQuantity())
+            if (amount != null) {
+                append(amount.displayableQuantity())
                 withStyle(style = RadixTheme.typography.header.toSpanStyle()) {
-                    append(" ${fungibleResource.symbol}")
+                    append(" $symbol")
                 }
             }
         },


### PR DESCRIPTION
## Description
As discussed in standup, when there is the first time the user contributes to a pool or stakes to a validator with no stakes at the moment, the asset details screen would not show the correct amounts. Since Asset details was built to show whatever ledger knows at this point in time. Actions in transaction review are not yet submitted on ledger and might cause discrepancies on what the user sees in TR screen and what sees in Asset details screen.

The way to handle it is to pass the amounts involved as a map:
```
Map<Resource Address, BigDecimal>
```
This applies for fungibles. 
1. For tokens the amount of the token is passed in this map 
```
mapOf(token.address to token.amount)
```
2. For LSUs the amount of the LSU and the 
```
mapOf(
    lsu.address to lsu.amount,
    XRD.address to lsu.xrdWorth
)
```
3. For pool units the pool unit's amount and the involved resources amounts
```
mapOf(
   poolUnit.address to poolUnit.amount,
   involvedResourceAddressX to poolUnit.redemptionValue(involvedResourceAddressX),
   ...
)
```

----
On another note, there was also another [bug](https://rdxworks.slack.com/archives/C03Q8QK1GLW/p1706730209740629). This is fixed by ignoring resources that already exist in db and exist in a newly fetched pool.

## How to test
1. You can create a new pool in sandbox.
2. Then try to contribute the first amounts.
3. On TR screen click on the pool unit.
4. It used to crash at this point, because the total supply is 0. Now we override the calculation according to the one coming from RET.

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
