### PR TITLE
Make all nf thumbnails to be rounded rectangles

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
@@ -534,8 +534,7 @@ private fun AssetItem(
             is Resource.FungibleResource -> Thumbnail.Fungible(token = asset.resource, modifier = Modifier.size(44.dp))
             is Resource.NonFungibleResource -> Thumbnail.NonFungible(
                 collection = asset.resource,
-                modifier = Modifier.size(44.dp),
-                shape = RadixTheme.shapes.roundedRectSmall
+                modifier = Modifier.size(44.dp)
             )
 
             else -> {}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
@@ -378,8 +378,7 @@ private fun DepositorItem(
             is Resource.FungibleResource -> Thumbnail.Fungible(token = depositor.resource, modifier = Modifier.size(44.dp))
             is Resource.NonFungibleResource -> Thumbnail.NonFungible(
                 collection = depositor.resource,
-                modifier = Modifier.size(44.dp),
-                shape = RadixTheme.shapes.roundedRectSmall
+                modifier = Modifier.size(44.dp)
             )
 
             else -> {}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialogContent.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
@@ -167,7 +167,7 @@ fun NonFungibleAssetDialogContent(
                         .padding(vertical = RadixTheme.dimensions.paddingDefault)
                         .size(104.dp),
                     collection = asset.resource,
-                    shape = CircleShape
+                    radius = CornerSize(RadixTheme.dimensions.paddingMedium)
                 )
             } else {
                 Box(
@@ -176,7 +176,7 @@ fun NonFungibleAssetDialogContent(
                         .size(104.dp)
                         .radixPlaceholder(
                             visible = true,
-                            shape = CircleShape
+                            shape = RadixTheme.shapes.roundedRectMedium
                         )
                 )
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/AccountDepositSettingsTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/AccountDepositSettingsTypeContent.kt
@@ -252,8 +252,7 @@ private fun AccountRuleChangeRow(resource: Resource?, modifier: Modifier = Modif
 
             is Resource.NonFungibleResource -> Thumbnail.NonFungible(
                 collection = resource,
-                modifier = Modifier.size(44.dp),
-                shape = RadixTheme.shapes.roundedRectSmall
+                modifier = Modifier.size(44.dp)
             )
 
             else -> {}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionAccountCard.kt
@@ -218,8 +218,7 @@ private fun TransferableItemContent(
             is TransferableAsset.NonFungible.NFTAssets -> {
                 Thumbnail.NonFungible(
                     modifier = Modifier.size(44.dp),
-                    collection = resource.resource,
-                    shape = RadixTheme.shapes.roundedRectSmall
+                    collection = resource.resource
                 )
             }
 
@@ -648,8 +647,7 @@ private fun TransferableNftItemContent(
     ) {
         Thumbnail.NonFungible(
             modifier = Modifier.size(44.dp),
-            collection = transferable.resource,
-            shape = RadixTheme.shapes.roundedRectSmall
+            collection = transferable.resource
         )
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.Center) {
             Text(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/SpendingAssetItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/SpendingAssetItem.kt
@@ -264,8 +264,7 @@ private fun NonFungibleSpendingAsset(
     ) {
         Thumbnail.NonFungible(
             modifier = Modifier.size(55.dp),
-            collection = resource,
-            shape = RadixTheme.shapes.roundedRectSmall
+            collection = resource
         )
         Spacer(modifier = Modifier.width(RadixTheme.dimensions.paddingDefault))
         Column {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
@@ -118,7 +119,7 @@ object Thumbnail {
     fun NonFungible(
         modifier: Modifier = Modifier,
         collection: Resource.NonFungibleResource?,
-        shape: Shape = RadixTheme.shapes.roundedRectSmall
+        radius: CornerSize = CornerSize(size = RadixTheme.dimensions.paddingSmall)
     ) {
         var viewSize: IntSize? by remember { mutableStateOf(null) }
         val imageType = remember(collection, viewSize) {
@@ -137,7 +138,7 @@ object Thumbnail {
             imageContentScale = ContentScale.Crop,
             emptyDrawable = R.drawable.ic_nfts,
             emptyContentScale = CustomContentScale.standard(density = density),
-            shape = shape,
+            shape = RoundedCornerShape(radius),
             contentDescription = collection?.name.orEmpty()
         )
     }
@@ -550,13 +551,12 @@ fun NonFungibleResourcesPreview() {
                 Thumbnail.NonFungible(
                     modifier = Modifier.size(100.dp),
                     collection = withUrl,
-                    shape = CircleShape
+                    radius = CornerSize(size = 12.dp)
                 )
 
                 Thumbnail.NonFungible(
-                    modifier = Modifier.size(100.dp),
-                    collection = withUrl,
-                    shape = RadixTheme.shapes.roundedRectSmall
+                    modifier = Modifier.size(50.dp),
+                    collection = withUrl
                 )
             }
 
@@ -573,13 +573,12 @@ fun NonFungibleResourcesPreview() {
                 Thumbnail.NonFungible(
                     modifier = Modifier.size(100.dp),
                     collection = withNoUrl,
-                    shape = CircleShape
+                    radius = CornerSize(size = 12.dp)
                 )
 
                 Thumbnail.NonFungible(
-                    modifier = Modifier.size(100.dp),
-                    collection = withNoUrl,
-                    shape = RadixTheme.shapes.roundedRectSmall
+                    modifier = Modifier.size(50.dp),
+                    collection = withNoUrl
                 )
             }
 
@@ -603,13 +602,12 @@ fun NonFungibleResourcesPreview() {
                 Thumbnail.NonFungible(
                     modifier = Modifier.size(100.dp),
                     collection = error,
-                    shape = CircleShape
+                    radius = CornerSize(size = 12.dp)
                 )
 
                 Thumbnail.NonFungible(
-                    modifier = Modifier.size(100.dp),
-                    collection = error,
-                    shape = RadixTheme.shapes.roundedRectSmall
+                    modifier = Modifier.size(50.dp),
+                    collection = error
                 )
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
@@ -132,8 +132,7 @@ private fun NFTHeader(
         ) {
             Thumbnail.NonFungible(
                 modifier = Modifier.size(44.dp),
-                collection = collection,
-                shape = RadixTheme.shapes.roundedRectSmall
+                collection = collection
             )
             Column(verticalArrangement = Arrangement.Center) {
                 if (collection.name.isNotEmpty()) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
@@ -406,8 +406,7 @@ private fun StakeClaims(
         ) {
             Thumbnail.NonFungible(
                 modifier = Modifier.size(36.dp),
-                collection = validatorWithStakes.stakeClaimNft?.nonFungibleResource,
-                shape = RadixTheme.shapes.roundedRectSmall
+                collection = validatorWithStakes.stakeClaimNft?.nonFungibleResource
             )
 
             Text(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/NonFungibleCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/NonFungibleCard.kt
@@ -50,8 +50,7 @@ fun NonFungibleCard(
     ) {
         Thumbnail.NonFungible(
             modifier = Modifier.size(44.dp),
-            collection = nonFungible,
-            shape = RadixTheme.shapes.roundedRectSmall
+            collection = nonFungible
         )
         Text(
             modifier = Modifier.weight(1f),


### PR DESCRIPTION
## Description
Self explanatory

## Screenshot
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/a5a867f5-fd0e-45fb-91a9-82cd7b586f72" width="300">

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
