### PR TITLE
Show guaranteed amount for pool units if exists

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransferablePoolUnitItemContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransferablePoolUnitItemContent.kt
@@ -157,19 +157,21 @@ private fun PoolAmountSection(transferable: Transferable, modifier: Modifier = M
                 overflow = TextOverflow.Ellipsis,
                 textAlign = TextAlign.End
             )
+        }
 
-            (transferable.transferable as? TransferableAsset.Fungible)?.let {
-                Text(
-                    modifier = Modifier,
-                    text = it.amount.displayableQuantity(),
-                    style = RadixTheme.typography.body1Header,
-                    color = RadixTheme.colors.gray1,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.End
-                )
-            }
+        (transferable.transferable as? TransferableAsset.Fungible)?.let {
+            Text(
+                modifier = Modifier,
+                text = it.amount.displayableQuantity(),
+                style = RadixTheme.typography.body1Header,
+                color = RadixTheme.colors.gray1,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.End
+            )
+        }
 
+        if (guaranteedQuantity != null) {
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
             Text(
                 text = stringResource(id = R.string.transactionReview_guaranteed),


### PR DESCRIPTION
## Description
When the pool unit amount transferred is guaranteed we should show it.

## How to test

1. Do a transfer of a pool unit amount. You should see the amount just like for tokens
2. Do a contribution. You should see an estimated/guaranteed section instead of just the amount.

## Screenshot
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/7537c897-abfb-4669-9a23-36e7f81af331" width="300">

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
