### PR TITLE
ABW-2706 - Copy manifest icon added with copy funciton. Icon for collapse state changed.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/RawManifestView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/RawManifestView.kt
@@ -1,22 +1,71 @@
 package com.babylon.wallet.android.presentation.transaction.composables
 
-import androidx.compose.foundation.text.selection.SelectionContainer
+import android.content.ClipData
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.Typeface
 import androidx.compose.ui.unit.sp
+import androidx.core.content.getSystemService
+import com.babylon.wallet.android.designsystem.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 
 @Composable
 fun RawManifestView(
     modifier: Modifier = Modifier,
     manifest: String
 ) {
-    SelectionContainer {
+    val context = LocalContext.current
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.End
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(RadixTheme.dimensions.paddingSmall)
+                .background(
+                    color = RadixTheme.colors.gray4,
+                    shape = RadixTheme.shapes.roundedRectSmall
+                )
+                .throttleClickable {
+                    context
+                        .getSystemService<android.content.ClipboardManager>()
+                        ?.let { clipboardManager ->
+                            val clipData = ClipData.newPlainText(
+                                "Raw manifest",
+                                manifest
+                            )
+                            clipboardManager.setPrimaryClip(clipData)
+                        }
+                }
+                .padding(RadixTheme.dimensions.paddingSmall),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(
+                    id = R.drawable.ic_copy
+                ),
+                contentDescription = ""
+            )
+            Text(
+                text = stringResource(id = com.babylon.wallet.android.R.string.common_copy),
+                style = RadixTheme.typography.body1Header,
+                color = RadixTheme.colors.gray1
+            )
+        }
         Text(
-            modifier = modifier,
             text = manifest,
             color = RadixTheme.colors.gray1,
             fontSize = 13.sp,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
@@ -121,6 +121,11 @@ fun TransactionPreviewHeader(
         },
         actions = {
             if (state.isRawManifestToggleVisible) {
+                val icon = if (state.isRawManifestVisible) {
+                    com.babylon.wallet.android.designsystem.R.drawable.ic_manifest_collapse
+                } else {
+                    com.babylon.wallet.android.designsystem.R.drawable.ic_manifest_expand
+                }
                 IconButton(
                     modifier = Modifier
                         .padding(end = RadixTheme.dimensions.paddingXLarge)
@@ -133,7 +138,7 @@ fun TransactionPreviewHeader(
                 ) {
                     Icon(
                         painter = painterResource(
-                            id = com.babylon.wallet.android.designsystem.R.drawable.ic_manifest_expand
+                            id = icon
                         ),
                         tint = Color.Unspecified,
                         contentDescription = "manifest expand"

--- a/designsystem/src/main/res/drawable/ic_manifest_collapse.xml
+++ b/designsystem/src/main/res/drawable/ic_manifest_collapse.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="50dp"
+    android:height="40dp"
+    android:viewportWidth="50"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M4,0L46,0A4,4 0,0 1,50 4L50,36A4,4 0,0 1,46 40L4,40A4,4 0,0 1,0 36L0,4A4,4 0,0 1,4 0z"
+      android:fillColor="#E2E5ED"/>
+  <group>
+    <clip-path
+        android:pathData="M13,8h24v24h-24z"/>
+    <path
+        android:pathData="M32.895,16V12H17.105V16H32.895ZM32.895,28V24H17.105V28H32.895ZM16.053,10H33.947C34.526,10 35,10.45 35,11V17C35,17.55 34.526,18 33.947,18H16.053C15.474,18 15,17.55 15,17V11C15,10.45 15.474,10 16.053,10ZM16.053,22H33.947C34.526,22 35,22.45 35,23V29C35,29.55 34.526,30 33.947,30H16.053C15.474,30 15,29.55 15,29V23C15,22.45 15.474,22 16.053,22ZM35,19V21L15,21V19L35,19Z"
+        android:fillColor="#8A8FA4"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/designsystem/src/main/res/drawable/ic_manifest_expand.xml
+++ b/designsystem/src/main/res/drawable/ic_manifest_expand.xml
@@ -11,7 +11,7 @@
         android:fillColor="#E2E5ED"/>
     <path
         android:pathData="M9.4,16.6 L4.8,12l4.6,-4.6L8,6l-6,6 6,6 1.4,-1.4zM14.6,16.6 L19.2,12 14.6,7.4L16,6l6,6 -6,6 -1.4,-1.4z"
-        android:fillColor="#003057"/>
+        android:fillColor="#8A8FA4"/>
   </group>
 </vector>
 


### PR DESCRIPTION
## Description
Copy icon added instead of press and hold functionality to copy manifest.

## How to test

1. Trigger transfer and switch to raw manifest
2. Verify that icon for raw manifest switch is correct in top right corner.
3. Verify that copy icon is visible and can be used to copy manifest.  

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/108684750/0f527348-f578-4205-902a-5e359c6197a0" width="300">

## PR submission checklist
- [x] I have verified that copy icon is introduced to copy manifest content.
