### PR TITLE
[ABW-2920] Refresh security prompt after seed phrase was restored

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
@@ -23,7 +23,7 @@ class GetEntitiesWithSecurityPromptUseCase @Inject constructor(
 
     operator fun invoke() = combine(
         getProfileUseCase.entitiesOnCurrentNetwork,
-        preferencesManager.getBackedUpFactorSourceIds().distinctUntilChanged()
+        preferencesManager.getBackedUpFactorSourceIds()
     ) { entities, backedUpFactorSourceIds ->
         entities.mapNotNull { entity ->
             mapToEntityWithSecurityPrompt(entity, backedUpFactorSourceIds)


### PR DESCRIPTION
## Description
- right now we react to any change in backed up factor sources. When we finish factor source seed restoration, we mark this factor source as backed up. But list already contained that factor source, since we don't remove it's id from the list when mnemonic access is lost due to encryption key change (on device security change).

## How to test

1. Remove device screen lock.
2. Re-add the lock
3. Open Wallet, restore main seed phrase.
4. Verify that recover prompt is gone from account cards

## PR submission checklist
- [x] I have tested account cards refresh after seed phrase recovery.
