### PR TITLE
ABW-1914 - When displaying guarantees we take divisibility into the account.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/LiquidStakeUnit.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/LiquidStakeUnit.kt
@@ -2,6 +2,8 @@ package com.babylon.wallet.android.domain.model.assets
 
 import android.net.Uri
 import com.babylon.wallet.android.domain.model.resources.Resource
+import rdx.works.core.divideWithDivisibility
+import rdx.works.core.multiplyWithDivisibility
 import java.math.BigDecimal
 
 data class LiquidStakeUnit(
@@ -27,13 +29,16 @@ data class LiquidStakeUnit(
         get() {
             if (fungibleResource.currentSupply == null) return null
 
-            return fungibleResource.ownedAmount?.divide(fungibleResource.currentSupply, fungibleResource.mathContext)
+            return fungibleResource.ownedAmount?.divideWithDivisibility(
+                fungibleResource.currentSupply,
+                fungibleResource.divisibility
+            )
         }
 
     fun stakeValue(): BigDecimal? = stakeValueInXRD(validator.totalXrdStake)
 
     fun stakeValueInXRD(totalXrdStake: BigDecimal?): BigDecimal? {
         if (totalXrdStake == null) return null
-        return percentageOwned?.multiply(totalXrdStake, fungibleResource.mathContext)
+        return percentageOwned?.multiplyWithDivisibility(totalXrdStake, fungibleResource.divisibility)
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/PoolUnit.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/PoolUnit.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.domain.model.assets
 
 import com.babylon.wallet.android.domain.model.resources.Pool
 import com.babylon.wallet.android.domain.model.resources.Resource
+import rdx.works.core.divideWithDivisibility
 import java.math.BigDecimal
 
 data class PoolUnit(
@@ -26,7 +27,7 @@ data class PoolUnit(
         return if (stake.ownedAmount != null && stake.divisibility != null && poolUnitSupply != BigDecimal.ZERO) {
             stake.ownedAmount
                 .multiply(resourceVaultBalance)
-                .divide(poolUnitSupply, stake.mathContext)
+                .divideWithDivisibility(poolUnitSupply, stake.divisibility)
         } else {
             null
         }

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/resources/Resource.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/resources/Resource.kt
@@ -99,13 +99,6 @@ sealed class Resource {
                 ""
             }
 
-        val mathContext: MathContext
-            get() = if (divisibility == null) {
-                MathContext.UNLIMITED
-            } else {
-                MathContext(divisibility, RoundingMode.HALF_DOWN)
-            }
-
         @Suppress("CyclomaticComplexMethod")
         override fun compareTo(other: FungibleResource): Int {
             // XRD should always be first

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -37,10 +37,12 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.core.mapWhen
+import rdx.works.core.multiplyWithDivisibility
 import rdx.works.core.ret.crypto.PrivateKey
 import rdx.works.profile.data.model.pernetwork.Network
 import rdx.works.profile.domain.ProfileException
 import java.math.BigDecimal
+import java.math.MathContext
 import java.math.RoundingMode
 import javax.inject.Inject
 
@@ -550,7 +552,20 @@ sealed interface AccountWithPredictedGuarantee {
         get() = (guaranteeAmountString.toDoubleOrNull() ?: 0.0).div(100.0)
 
     val guaranteedAmount: BigDecimal
-        get() = transferable.amount * guaranteeOffsetDecimal.toBigDecimal()
+        get() = transferable.amount.multiplyWithDivisibility(guaranteeOffsetDecimal.toBigDecimal(), divisibility)
+
+    private val divisibility: Int?
+        get() = when (val asset = transferable) {
+            is TransferableAsset.Fungible.Token -> {
+                asset.resource.divisibility
+            }
+            is TransferableAsset.Fungible.LSUAsset -> {
+                asset.resource.divisibility
+            }
+            is TransferableAsset.Fungible.PoolUnitAsset -> {
+                asset.resource.divisibility
+            }
+        }
 
     fun increase(): AccountWithPredictedGuarantee {
         val newOffset = (guaranteeOffsetDecimal.toBigDecimal().plus(BigDecimal(0.001)))

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorStakeProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorStakeProcessor.kt
@@ -13,6 +13,8 @@ import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.radixdlt.ret.DetailedManifestClass
 import com.radixdlt.ret.ExecutionSummary
 import kotlinx.coroutines.flow.first
+import rdx.works.core.divideWithDivisibility
+import rdx.works.core.multiplyWithDivisibility
 import rdx.works.profile.derivation.model.NetworkId
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.accountOnCurrentNetwork
@@ -64,8 +66,8 @@ class ValidatorStakeProcessor @Inject constructor(
             val validator =
                 involvedValidators.find { it.address == validatorAddress } ?: error("No validator found")
             val lsuAmount = depositedResources.value.sumOf { it.amount }
-            val xrdWorth = lsuAmount.divide(totalStakedLsuForAccount, lsuResource.mathContext)
-                .multiply(totalStakeXrdWorthForAccount, lsuResource.mathContext)
+            val xrdWorth = lsuAmount.divideWithDivisibility(totalStakedLsuForAccount, lsuResource.divisibility)
+                .multiplyWithDivisibility(totalStakeXrdWorthForAccount, lsuResource.divisibility)
             val guaranteeType = depositedResources.value.first().guaranteeType(defaultDepositGuarantees)
             Transferable.Depositing(
                 transferable = TransferableAsset.Fungible.LSUAsset(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorUnstakeProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorUnstakeProcessor.kt
@@ -16,6 +16,8 @@ import com.radixdlt.ret.ExecutionSummary
 import com.radixdlt.ret.NonFungibleGlobalId
 import com.radixdlt.ret.ResourceIndicator
 import kotlinx.coroutines.flow.first
+import rdx.works.core.divideWithDivisibility
+import rdx.works.core.multiplyWithDivisibility
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.accountOnCurrentNetwork
 import rdx.works.profile.domain.currentNetwork
@@ -105,8 +107,8 @@ class ValidatorUnstakeProcessor @Inject constructor(
             val validatorAddress = lsuResource.validatorAddress ?: error("No validator address found")
             val validator = involvedValidators.find { it.address == validatorAddress } ?: error("No validator found")
             val totalLSU = depositedResources.value.sumOf { it.amount }
-            val xrdWorth = totalLSU.divide(lsuResource.currentSupply, lsuResource.mathContext)
-                .multiply(validator.totalXrdStake, lsuResource.mathContext)
+            val xrdWorth = totalLSU.divideWithDivisibility(lsuResource.currentSupply, lsuResource.divisibility)
+                .multiplyWithDivisibility(validator.totalXrdStake, lsuResource.divisibility)
             Transferable.Withdrawing(
                 transferable = TransferableAsset.Fungible.LSUAsset(
                     amount = totalLSU,

--- a/core/src/main/java/rdx/works/core/BigDecimalExtensions.kt
+++ b/core/src/main/java/rdx/works/core/BigDecimalExtensions.kt
@@ -78,3 +78,23 @@ fun BigDecimal.displayableQuantity(): String {
 
 @Suppress("MagicNumber")
 fun BigDecimal.toRETDecimal(roundingMode: RoundingMode): Decimal = Decimal(setScale(18, roundingMode).toPlainString())
+
+fun BigDecimal.multiplyWithDivisibility(
+    multiplicand: BigDecimal?,
+    divisibility: Int?,
+    roundingMode: RoundingMode = RoundingMode.HALF_DOWN
+): BigDecimal = divisibility?.let {
+    multiply(multiplicand).setScale(it, roundingMode)
+} ?: run {
+    multiply(multiplicand)
+}
+
+fun BigDecimal.divideWithDivisibility(
+    divisor: BigDecimal?,
+    divisibility: Int?,
+    roundingMode: RoundingMode = RoundingMode.HALF_DOWN
+): BigDecimal = divisibility?.let {
+    divide(divisor, it, roundingMode)
+} ?: run {
+    divide(divisor)
+}


### PR DESCRIPTION
## Description
This PR fixes two problems:
1. When showing Guarantees on Customise Guarantees screen, we taking divisibility of the token into the account. So when divisibility is 2 we only display up to 2 decimal places after decimal point. We also respect general token formatting that we use across the whole app.

2. In some places when multiplying or dividing we took MathContext as an argument which uses precision rather than scale (which we want). So I updated this to use divisibility and set it as scale.

## How to test

1. Test guarantees with a token that has some limited divisibility and observe that its guaranteed amount does not exceed this limit.


## PR submission checklist
- [x] I have tested guaranteed amount and verified it does not exceed divisibility limit 
