### PR TITLE
[ABW-2932] Exclude questionable permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,9 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" tools:node="remove"/>
 
     <application
         android:name=".BabylonApplication"


### PR DESCRIPTION
## Description
- exclude permissions that appear to be added automatically to merged manifest

## How to test

How I tested it is I run app with crashlytics enabled on lowest supported android api level - 27 and on android 14, and appear that crash reports are being sent. Still I'm unsure if those permissions will be removed from final build, as I don't see Crashlytics manifest to declare `targetSdk`, which is supposedly trigger for adding the additional permissions. 

## PR submission checklist
- [ ] I have tested that crashlytics reports are sent on api 27
