### PR TITLE
Refactor biometric extension to return result

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourcesDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourcesDialog.kt
@@ -30,6 +30,7 @@ import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesViewModel.AccessFactorSourcesUiState
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.formattedSpans
 import rdx.works.profile.domain.TestData.ledgerFactorSource
@@ -47,9 +48,9 @@ fun AccessFactorSourcesDialog(
         viewModel.oneOffEvent.collect { event ->
             when (event) {
                 AccessFactorSourcesViewModel.Event.RequestBiometricPrompt -> {
-                    context.biometricAuthenticate { isAuthenticated ->
-                        viewModel.biometricAuthenticationCompleted(isAuthenticated)
-                        if (isAuthenticated.not()) {
+                    context.biometricAuthenticate { result ->
+                        viewModel.biometricAuthenticationCompleted(result == BiometricAuthenticationResult.Succeeded)
+                        if (result != BiometricAuthenticationResult.Succeeded) {
                             onDismiss()
                         }
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/recover/scan/AccountRecoveryScanScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/recover/scan/AccountRecoveryScanScreen.kt
@@ -59,6 +59,7 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SimpleAccountCard
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.Constants
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
@@ -90,8 +91,8 @@ fun AccountRecoveryScanScreen(
         if (state.recoveryFactorSource is RecoveryFactorSource.VirtualDeviceFactorSource) {
             viewModel.startRecoveryScan()
         } else {
-            context.biometricAuthenticate { authenticated ->
-                if (authenticated) {
+            context.biometricAuthenticate { result ->
+                if (result == BiometricAuthenticationResult.Succeeded) {
                     viewModel.startScanForExistingFactorSource()
                 } else {
                     onBackClick()
@@ -143,7 +144,7 @@ private fun AccountRecoveryScanContent(
     onContinueClick: () -> Unit,
     isRestoring: Boolean
 ) {
-    val pages = ScanCompletePages.values()
+    val pages = ScanCompletePages.entries.toTypedArray()
     val scope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { pages.size })
 
@@ -260,7 +261,7 @@ fun ScanCompleteContent(
     allScannedAccountsSize: Int,
     onAccountSelected: (Selectable<Network.Account>) -> Unit
 ) {
-    val pages = ScanCompletePages.values()
+    val pages = ScanCompletePages.entries.toTypedArray()
     HorizontalPager(state = pagerState, userScrollEnabled = false) { page ->
         when (pages[page]) {
             ScanCompletePages.ActiveAccounts -> {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/devsettings/DevSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/devsettings/DevSettingsScreen.kt
@@ -31,6 +31,7 @@ import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 
 @Composable
@@ -52,8 +53,8 @@ fun DevSettingsScreen(
         error = state.error,
         hasAuthKey = state.hasAuthKey,
         onCreateAndUploadAuthKey = {
-            context.biometricAuthenticate {
-                if (it) {
+            context.biometricAuthenticate { result ->
+                if (result == BiometricAuthenticationResult.Succeeded) {
                     viewModel.onCreateAndUploadAuthKey()
                 }
             }
@@ -112,8 +113,8 @@ private fun DevSettingsContent(
                         .padding(horizontal = RadixTheme.dimensions.paddingLarge),
                     text = stringResource(R.string.accountSettings_getXrdTestTokens),
                     onClick = {
-                        context.biometricAuthenticate { authenticatedSuccessfully ->
-                            if (authenticatedSuccessfully) {
+                        context.biometricAuthenticate { result ->
+                            if (result == BiometricAuthenticationResult.Succeeded) {
                                 onGetFreeXrdClick()
                             }
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
@@ -22,6 +22,7 @@ import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
 import com.babylon.wallet.android.presentation.status.signing.FactorSourceInteractionBottomDialog
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.ChooseAccountContent
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import kotlinx.collections.immutable.persistentListOf
@@ -128,8 +129,8 @@ private fun HandleOneOffEvents(
                             context.biometricAuthenticateSuspend()
                         }
                     } else {
-                        context.biometricAuthenticate { authenticated ->
-                            if (authenticated) {
+                        context.biometricAuthenticate { result ->
+                            if (result == BiometricAuthenticationResult.Succeeded) {
                                 completeRequestHandling { true }
                             }
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaonetime/PersonaDataOnetimeScreen.kt
@@ -54,6 +54,7 @@ import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.composables.persona.PersonaDetailCard
 import com.babylon.wallet.android.presentation.ui.modifier.applyIf
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.formattedSpans
@@ -94,8 +95,8 @@ fun PersonaDataOnetimeScreen(
                             context.biometricAuthenticateSuspend()
                         })
                     } else {
-                        context.biometricAuthenticate { authenticated ->
-                            if (authenticated) {
+                        context.biometricAuthenticate { result ->
+                            if (result == BiometricAuthenticationResult.Succeeded) {
                                 sharedViewModel.completeRequestHandling()
                             }
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/personaongoing/PersonaDataOngoingScreen.kt
@@ -51,6 +51,7 @@ import com.babylon.wallet.android.presentation.ui.composables.BottomPrimaryButto
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.composables.persona.PersonaDetailCard
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.formattedSpans
@@ -101,8 +102,8 @@ fun PersonaDataOngoingScreen(
                             context.biometricAuthenticateSuspend()
                         })
                     } else {
-                        context.biometricAuthenticate { authenticated ->
-                            if (authenticated) {
+                        context.biometricAuthenticate { result ->
+                            if (result == BiometricAuthenticationResult.Succeeded) {
                                 sharedViewModel.completeRequestHandling()
                             }
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
@@ -53,6 +53,7 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAp
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.composables.card.PersonaSelectableCard
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.formattedSpans
@@ -101,8 +102,8 @@ fun SelectPersonaScreen(
                     context.biometricAuthenticateSuspend()
                 })
             } else {
-                context.biometricAuthenticate { authenticated ->
-                    if (authenticated) {
+                context.biometricAuthenticate { result ->
+                    if (result == BiometricAuthenticationResult.Succeeded) {
                         sharedViewModel.completeRequestHandling()
                     }
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
@@ -24,6 +24,7 @@ import com.babylon.wallet.android.presentation.dapp.unauthorized.login.Event
 import com.babylon.wallet.android.presentation.status.signing.FactorSourceInteractionBottomDialog
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.ChooseAccountContent
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import kotlinx.collections.immutable.persistentListOf
@@ -62,8 +63,8 @@ fun OneTimeChooseAccountsScreen(
                             context.biometricAuthenticateSuspend()
                         })
                     } else {
-                        context.biometricAuthenticate { authenticated ->
-                            if (authenticated) {
+                        context.biometricAuthenticate { result ->
+                            if (result == BiometricAuthenticationResult.Succeeded) {
                                 sharedViewModel.sendRequestResponse()
                             }
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/personaonetime/PersonaDataOnetimeScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/personaonetime/PersonaDataOnetimeScreen.kt
@@ -52,6 +52,7 @@ import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.composables.persona.PersonaDetailCard
 import com.babylon.wallet.android.presentation.ui.modifier.applyIf
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.formattedSpans
@@ -84,8 +85,8 @@ fun PersonaDataOnetimeScreen(
                             context.biometricAuthenticateSuspend()
                         })
                     } else {
-                        context.biometricAuthenticate { authenticated ->
-                            if (authenticated) {
+                        context.biometricAuthenticate { result ->
+                            if (result == BiometricAuthenticationResult.Succeeded) {
                                 sharedViewModel.sendRequestResponse()
                             }
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
@@ -60,6 +60,7 @@ import com.babylon.wallet.android.presentation.ui.composables.SecureScreen
 import com.babylon.wallet.android.presentation.ui.composables.SeedPhraseInputForm
 import com.babylon.wallet.android.presentation.ui.composables.SeedPhraseSuggestions
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import rdx.works.profile.data.model.SeedPhraseLength
 
@@ -82,8 +83,8 @@ fun AddSingleMnemonicScreen(
                 )
                 onStartRecovery()
             } else {
-                context.biometricAuthenticate { authenticated ->
-                    if (authenticated) {
+                context.biometricAuthenticate { result ->
+                    if (result == BiometricAuthenticationResult.Succeeded) {
                         viewModel.onAddFactorSource()
                     }
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -96,6 +96,7 @@ import com.babylon.wallet.android.presentation.ui.composables.SeedPhraseSuggesti
 import com.babylon.wallet.android.presentation.ui.composables.SimpleAccountCard
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.modifier.applyIf
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -266,8 +267,8 @@ private fun ImportLegacyWalletContent(
                 }
 
                 OlympiaImportEvent.BiometricPromptBeforeFinalImport -> {
-                    context.biometricAuthenticate { authenticatedSuccessfully ->
-                        if (authenticatedSuccessfully) {
+                    context.biometricAuthenticate { result ->
+                        if (result == BiometricAuthenticationResult.Succeeded) {
                             importAllAccounts()
                         }
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/SeedPhrasesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/SeedPhrasesScreen.kt
@@ -38,6 +38,7 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAp
 import com.babylon.wallet.android.presentation.ui.composables.RedWarningText
 import com.babylon.wallet.android.presentation.ui.composables.SimpleAccountCard
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
@@ -65,8 +66,8 @@ fun SeedPhrasesScreen(
         viewModel.oneOffEvent.collect {
             when (it) {
                 is SeedPhrasesViewModel.Effect.OnRequestToShowMnemonic -> {
-                    context.biometricAuthenticate { authenticated ->
-                        if (authenticated) {
+                    context.biometricAuthenticate { result ->
+                        if (result == BiometricAuthenticationResult.Succeeded) {
                             onNavigateToSeedPhrase(it.factorSourceID)
                         }
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/seedphrases/confirm/ConfirmMnemonicScreen.kt
@@ -40,6 +40,7 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAp
 import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SecureScreen
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 
 @Composable
@@ -55,8 +56,10 @@ fun ConfirmMnemonicScreen(
         state = state,
         onBackClick = onDismiss,
         onSubmitClick = {
-            context.biometricAuthenticate { authenticated ->
-                if (authenticated) viewModel.onSubmit()
+            context.biometricAuthenticate { result ->
+                if (result == BiometricAuthenticationResult.Succeeded) {
+                    viewModel.onSubmit()
+                }
             }
         },
         onWordTyped = viewModel::onWordChanged,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/PersonasScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/PersonasScreen.kt
@@ -34,6 +34,7 @@ import com.babylon.wallet.android.presentation.settings.personas.PersonasViewMod
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.card.PersonaCard
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -66,8 +67,8 @@ fun PersonasScreen(
         onPersonaClick = onPersonaClick,
         onApplySecuritySettings = { factorSourceID ->
             (factorSourceID as? FactorSource.FactorSourceID.FromHash)?.let { id ->
-                context.biometricAuthenticate { authenticated ->
-                    if (authenticated) {
+                context.biometricAuthenticate { result ->
+                    if (result == BiometricAuthenticationResult.Succeeded) {
                         onNavigateToMnemonicBackup(id)
                     }
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaScreen.kt
@@ -50,6 +50,7 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAp
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.composables.persona.AddFieldSheet
 import com.babylon.wallet.android.presentation.ui.composables.persona.PersonaDataFieldInput
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.findFragmentActivity
 import kotlinx.collections.immutable.ImmutableList
@@ -143,8 +144,8 @@ fun CreatePersonaContent(
                     text = stringResource(id = R.string.createPersona_saveAndContinueButtonTitle),
                     onClick = {
                         context.findFragmentActivity()?.let { activity ->
-                            activity.biometricAuthenticate { authenticatedSuccessfully ->
-                                if (authenticatedSuccessfully) {
+                            activity.biometricAuthenticate { result ->
+                                if (result == BiometricAuthenticationResult.Succeeded) {
                                     onPersonaCreateClick()
                                 }
                             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailScreen.kt
@@ -48,6 +48,7 @@ import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.composables.WarningButton
 import com.babylon.wallet.android.presentation.ui.composables.card.DappCard
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -96,8 +97,8 @@ fun PersonaDetailScreen(
         onEditPersona = onEditPersona,
         onDAppClick = onDAppClick,
         onCreateAndUploadAuthKey = {
-            context.biometricAuthenticate {
-                if (it) {
+            context.biometricAuthenticate { result ->
+                if (result == BiometricAuthenticationResult.Succeeded) {
                     viewModel.onCreateAndUploadAuthKey()
                 }
             }

--- a/app/src/main/java/com/babylon/wallet/android/utils/BiometricExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/BiometricExtensions.kt
@@ -12,26 +12,26 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 fun FragmentActivity.biometricAuthenticate(
-    authenticationCallback: (successful: Boolean) -> Unit,
+    authenticationCallback: (biometricAuthenticationResult: BiometricAuthenticationResult) -> Unit,
 ) {
     val biometricManager = BiometricManager.from(this)
     val canAuthenticate = biometricManager.canAuthenticate(ALLOWED_AUTHENTICATORS) == BiometricManager.BIOMETRIC_SUCCESS
     if (!canAuthenticate) {
-        authenticationCallback(false)
+        authenticationCallback(BiometricAuthenticationResult.Error)
         return
     }
 
     val authCallback = object : BiometricPrompt.AuthenticationCallback() {
         override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-            authenticationCallback(true)
+            authenticationCallback(BiometricAuthenticationResult.Succeeded)
         }
 
         override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
-            authenticationCallback(false)
+            authenticationCallback(BiometricAuthenticationResult.Error)
         }
 
         override fun onAuthenticationFailed() {
-            authenticationCallback(false)
+            authenticationCallback(BiometricAuthenticationResult.Failed)
         }
     }
 
@@ -82,6 +82,10 @@ suspend fun FragmentActivity.biometricAuthenticateSuspend(): Boolean {
             biometricPrompt.authenticate(promptInfo)
         }
     }
+}
+
+enum class BiometricAuthenticationResult {
+    Succeeded, Error, Failed
 }
 
 private val ALLOWED_AUTHENTICATORS = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/app/src/main/java/com/babylon/wallet/android/utils/ContextExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/ContextExtensions.kt
@@ -19,11 +19,15 @@ val backupSettingsScreenIntent: Intent
         )
     }
 
-fun Context.biometricAuthenticate(authenticationCallback: (successful: Boolean) -> Unit) {
+fun Context.biometricAuthenticate(
+    authenticationCallback: (biometricAuthenticationResult: BiometricAuthenticationResult) -> Unit
+) {
     findFragmentActivity()?.let { activity ->
-        activity.biometricAuthenticate { authenticatedSuccessfully ->
-            authenticationCallback(authenticatedSuccessfully)
-        }
+        activity.biometricAuthenticate(
+            authenticationCallback = { biometricAuthenticationResult ->
+                authenticationCallback(biometricAuthenticationResult)
+            }
+        )
     }
 }
 


### PR DESCRIPTION
## Description
This PR refactors the biometric extension function to return result instead of boolean. 
Currently we return `false`  for both failed auth and other error (e.g. user dismisses biometric auth). Now, we need to distinguish those two cases.
