### PR TITLE
Minor history bugs

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
@@ -396,14 +396,6 @@ private fun HistoryButton(
                 tint = RadixTheme.colors.white,
                 contentDescription = null
             )
-        },
-        trailingContent = {
-            Icon(
-                modifier = Modifier.size(16.dp),
-                painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_link_out),
-                tint = RadixTheme.colors.white.copy(alpha = 0.5f),
-                contentDescription = null
-            )
         }
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FiltersDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FiltersDialog.kt
@@ -57,7 +57,7 @@ fun FiltersDialog(
     onClearAllFilters: () -> Unit,
     onTransactionTypeFilterSelected: (HistoryFilters.TransactionType?) -> Unit,
     onTransactionClassFilterSelected: (TransactionClass?) -> Unit,
-    onResourceFilterSelected: (Resource) -> Unit
+    onResourceFilterSelected: (Resource?) -> Unit
 ) {
     Scaffold(
         modifier = modifier,
@@ -114,7 +114,7 @@ fun FiltersDialog(
                             onTransactionTypeFilterSelected(entry)
                         }, onCloseClick = {
                             onTransactionTypeFilterSelected(null)
-                        })
+                        }, showCloseIcon = false)
                     }
                 }
             }
@@ -131,7 +131,7 @@ fun FiltersDialog(
                             onTransactionClassFilterSelected(entry)
                         }, onCloseClick = {
                             onTransactionClassFilterSelected(null)
-                        })
+                        }, showCloseIcon = false)
                     }
                 }
                 Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
@@ -144,7 +144,7 @@ fun FiltersDialog(
 @Composable
 private fun ResourcesSection(
     state: State,
-    onResourceFilterSelected: (Resource) -> Unit,
+    onResourceFilterSelected: (Resource?) -> Unit,
 ) {
     val maxFungiblesInCollapsedState = 12
     val maxNonFungiblesInCollapsedState = 6
@@ -192,13 +192,9 @@ private fun ResourcesSection(
                         selected = selected,
                         text = fungible.displayTitle.ifEmpty { fungible.resourceAddress.truncatedHash() },
                         onClick = {
-                            if (selected.not()) {
-                                onResourceFilterSelected(fungible)
-                            }
+                            onResourceFilterSelected(if (selected) null else fungible)
                         },
-                        onCloseClick = {
-                            onResourceFilterSelected(fungible)
-                        }
+                        showCloseIcon = false
                     )
                 }
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FiltersDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FiltersDialog.kt
@@ -148,11 +148,11 @@ private fun ResourcesSection(
 ) {
     val maxFungiblesInCollapsedState = 12
     val maxNonFungiblesInCollapsedState = 6
-    val fungibles = remember(state.fungibleResources) {
-        state.fungibleResources
+    val fungibles = remember(state.fungibleResourcesUsedInFilters) {
+        state.fungibleResourcesUsedInFilters
     }
-    val nonFungibles = remember(state.nonFungibleResources) {
-        state.nonFungibleResources
+    val nonFungibles = remember(state.nonFungibleResourcesUsedInFilters) {
+        state.nonFungibleResourcesUsedInFilters
     }
     val showMoreFungiblesButton by remember {
         derivedStateOf {
@@ -244,7 +244,8 @@ private fun ResourcesSection(
                         },
                         onCloseClick = {
                             onResourceFilterSelected(nonFungible)
-                        }
+                        },
+                        showCloseIcon = false
                     )
                 }
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FiltersStrip.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FiltersStrip.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -25,8 +24,7 @@ fun FiltersStrip(
     onTransactionTypeFilterRemoved: () -> Unit,
     onTransactionClassFilterRemoved: () -> Unit,
     onResourceFilterRemoved: () -> Unit,
-    modifier: Modifier = Modifier,
-    timeFilterScrollState: LazyListState,
+    modifier: Modifier = Modifier
 ) {
     LazyRow(
         modifier = modifier
@@ -38,8 +36,7 @@ fun FiltersStrip(
             end = RadixTheme.dimensions.paddingMedium,
             bottom = RadixTheme.dimensions.paddingMedium
         ),
-        userScrollEnabled = userInteractionEnabled,
-        state = timeFilterScrollState
+        userScrollEnabled = userInteractionEnabled
     ) {
         historyFilters?.transactionType?.let { transactionType ->
             item(key = transactionType.name) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/HistoryFilterTag.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/HistoryFilterTag.kt
@@ -24,6 +24,7 @@ fun HistoryFilterTag(
     modifier: Modifier = Modifier,
     selected: Boolean,
     text: String,
+    showCloseIcon: Boolean = true,
     leadingIcon: @Composable (() -> Unit)? = null,
     onClick: (() -> Unit)? = null,
     onCloseClick: (() -> Unit)? = null
@@ -37,7 +38,12 @@ fun HistoryFilterTag(
     Row(
         modifier = modifier
             .clip(RadixTheme.shapes.circle)
-            .applyIf(onClick != null, Modifier.clickable { onClick?.invoke() })
+            .applyIf(
+                onClick != null,
+                Modifier.clickable {
+                    onClick?.invoke()
+                }
+            )
             .applyIf(selected, tagSelectedModifier)
             .applyIf(!selected, tagBorderModifier),
         horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingXSmall),
@@ -49,7 +55,7 @@ fun HistoryFilterTag(
             style = RadixTheme.typography.body1HighImportance,
             color = if (selected) RadixTheme.colors.white else RadixTheme.colors.gray1
         )
-        if (selected) {
+        if (showCloseIcon) {
             Icon(
                 modifier = Modifier
                     .applyIf(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
@@ -89,11 +89,15 @@ import com.babylon.wallet.android.presentation.ui.composables.SimpleAccountCard
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.modifier.applyIf
 import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
-import com.babylon.wallet.android.utils.dayMonthDateFull
+import com.babylon.wallet.android.utils.LAST_USED_DATE_FORMAT
+import com.babylon.wallet.android.utils.LAST_USED_DATE_FORMAT_THIS_YEAR
 import com.babylon.wallet.android.utils.openUrl
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 private const val FIXED_LIST_ELEMENTS = 2
 
@@ -426,6 +430,28 @@ fun HistoryContent(
             onShowResults()
         })
     }
+}
+
+@Composable
+private fun Instant.dayMonthDateFull(): String {
+    val zoneId = ZoneId.systemDefault()
+    val currentYear = Instant.now().atZone(zoneId).year
+    val currentDay = Instant.now().atZone(zoneId).dayOfYear
+    val instantYear = atZone(zoneId).year
+    val instantDay = atZone(zoneId).dayOfYear
+    val isSameYear = currentYear == instantYear
+    val format = if (isSameYear) {
+        LAST_USED_DATE_FORMAT_THIS_YEAR
+    } else {
+        LAST_USED_DATE_FORMAT
+    }
+    val prefix = when {
+        isSameYear && currentDay == instantDay -> stringResource(id = R.string.transactionHistory_today) + ", "
+        isSameYear && currentDay - instantDay == 1 -> stringResource(id = R.string.transactionHistory_yesterday) + ", "
+        else -> stringResource(id = R.string.empty)
+    }
+    val formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneId.systemDefault())
+    return prefix + formatter.format(this)
 }
 
 @Composable

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
@@ -118,7 +118,7 @@ fun HistoryScreen(
         onScrollEvent = viewModel::onScrollEvent,
         onTransactionTypeFilterSelected = viewModel::onTransactionTypeFilterSelected,
         onTransactionClassFilterSelected = viewModel::onTransactionClassFilterSelected,
-        onResourceFilterRemoved = viewModel::onResourceFilterSelected,
+        onResourceFilterSelected = viewModel::onResourceFilterSelected,
         listState = listState,
         timeFilterScrollState = timeFilterScrollState,
         onMessageShown = viewModel::onMessageShown,
@@ -188,7 +188,7 @@ fun HistoryContent(
     onScrollEvent: (ScrollInfo) -> Unit,
     onTransactionTypeFilterSelected: (HistoryFilters.TransactionType?) -> Unit,
     onTransactionClassFilterSelected: (TransactionClass?) -> Unit,
-    onResourceFilterRemoved: (Resource?) -> Unit,
+    onResourceFilterSelected: (Resource?) -> Unit,
     listState: LazyListState,
     timeFilterScrollState: LazyListState,
     onMessageShown: () -> Unit,
@@ -388,7 +388,7 @@ fun HistoryContent(
                                 onShowResults()
                             },
                             onResourceFilterRemoved = {
-                                onResourceFilterRemoved(null)
+                                onResourceFilterSelected(null)
                                 onShowResults()
                             },
                             timeFilterScrollState = timeFilterScrollState
@@ -417,7 +417,7 @@ fun HistoryContent(
                 onClearAllFilters = onClearAllFilters,
                 onTransactionTypeFilterSelected = onTransactionTypeFilterSelected,
                 onTransactionClassFilterSelected = onTransactionClassFilterSelected,
-                onResourceFilterSelected = onResourceFilterRemoved,
+                onResourceFilterSelected = onResourceFilterSelected,
             )
         }, showDragHandle = true, containerColor = RadixTheme.colors.defaultBackground, onDismissRequest = {
             onShowFilters(false)
@@ -662,7 +662,7 @@ fun HistoryContentPreview() {
             onScrollEvent = {},
             onTransactionTypeFilterSelected = {},
             onTransactionClassFilterSelected = {},
-            onResourceFilterRemoved = {},
+            onResourceFilterSelected = {},
             listState = rememberLazyListState(),
             timeFilterScrollState = rememberLazyListState(),
             onMessageShown = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
@@ -390,8 +390,7 @@ fun HistoryContent(
                             onResourceFilterRemoved = {
                                 onResourceFilterSelected(null)
                                 onShowResults()
-                            },
-                            timeFilterScrollState = timeFilterScrollState
+                            }
                         )
                     }
                     if (state.timeFilterItems.isNotEmpty()) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
@@ -93,6 +93,7 @@ import com.babylon.wallet.android.utils.dayMonthDateFull
 import com.babylon.wallet.android.utils.openUrl
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 private const val FIXED_LIST_ELEMENTS = 2
 
@@ -206,6 +207,7 @@ fun HistoryContent(
     )
     LaunchedEffect(state.timeFilterItems.size) {
         if (state.timeFilterItems.isNotEmpty()) {
+            Timber.d("History: Scrolling to last item")
             timeFilterScrollState.scrollToItem(state.timeFilterItems.lastIndex)
         }
     }
@@ -397,7 +399,8 @@ fun HistoryContent(
                         TimePicker(
                             timeFilterState = timeFilterScrollState,
                             timeFilterItems = state.timeFilterItems,
-                            onTimeFilterSelected = onTimeFilterSelected
+                            onTimeFilterSelected = onTimeFilterSelected,
+                            userInteractionEnabled = state.shouldEnableUserInteraction
                         )
                     }
                 }
@@ -463,7 +466,8 @@ private fun TimePicker(
     modifier: Modifier = Modifier,
     timeFilterState: LazyListState,
     timeFilterItems: ImmutableList<Selectable<State.MonthFilter>>,
-    onTimeFilterSelected: (State.MonthFilter) -> Unit
+    onTimeFilterSelected: (State.MonthFilter) -> Unit,
+    userInteractionEnabled: Boolean
 ) {
     LazyRow(
         modifier = modifier
@@ -476,15 +480,13 @@ private fun TimePicker(
             end = RadixTheme.dimensions.paddingMedium,
             bottom = RadixTheme.dimensions.paddingMedium
         ),
+        userScrollEnabled = userInteractionEnabled,
         content = {
             items(timeFilterItems) { item ->
                 Text(
                     modifier = Modifier
                         .clip(RadixTheme.shapes.circle)
-                        .clickable {
-                            item.data
-                            onTimeFilterSelected(item.data)
-                        }
+                        .applyIf(userInteractionEnabled, Modifier.clickable { onTimeFilterSelected(item.data) })
                         .applyIf(
                             item.selected,
                             Modifier.background(RadixTheme.colors.gray4, RadixTheme.shapes.circle)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
@@ -446,8 +446,8 @@ private fun Instant.dayMonthDateFull(): String {
         LAST_USED_DATE_FORMAT
     }
     val prefix = when {
-        isSameYear && currentDay == instantDay -> stringResource(id = R.string.transactionHistory_today) + ", "
-        isSameYear && currentDay - instantDay == 1 -> stringResource(id = R.string.transactionHistory_yesterday) + ", "
+        isSameYear && currentDay == instantDay -> stringResource(id = R.string.transactionHistory_datePrefix_today) + ", "
+        isSameYear && currentDay - instantDay == 1 -> stringResource(id = R.string.transactionHistory_datePrefix_yesterday) + ", "
         else -> stringResource(id = R.string.empty)
     }
     val formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneId.systemDefault())

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
@@ -398,11 +398,16 @@ data class State(
             else -> null
         }
 
-    val fungibleResources: List<Resource.FungibleResource>
-        get() = accountWithAssets?.assets?.knownFungibles.orEmpty()
+    // we use this to show  for now we filter out LSU -
+    val fungibleResourcesUsedInFilters: List<Resource.FungibleResource>
+        get() = accountWithAssets?.assets?.tokens?.map {
+            it.resource
+        }.orEmpty() + accountWithAssets?.assets?.poolUnits?.map {
+            it.stake
+        }.orEmpty()
 
-    val nonFungibleResources: List<Resource.NonFungibleResource>
-        get() = accountWithAssets?.assets?.knownNonFungibles.orEmpty()
+    val nonFungibleResourcesUsedInFilters: List<Resource.NonFungibleResource>
+        get() = accountWithAssets?.assets?.nonFungibles?.map { it.collection }.orEmpty()
 
     val canLoadMoreUp: Boolean
         get() = content is Content.Loaded && loadMoreState == null && content.historyData.prevCursorId != null

--- a/app/src/main/java/com/babylon/wallet/android/utils/DateExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/DateExtensions.kt
@@ -52,26 +52,6 @@ fun Instant.dayMonthDateShort(): String {
     return formatter.format(this)
 }
 
-fun Instant.dayMonthDateFull(): String {
-    val zoneId = ZoneId.systemDefault()
-    val currentYear = Instant.now().atZone(zoneId).year
-    val currentDay = Instant.now().atZone(zoneId).dayOfYear
-    val instantYear = atZone(zoneId).year
-    val instantDay = atZone(zoneId).dayOfYear
-    val format = if (currentYear == instantYear) {
-        LAST_USED_DATE_FORMAT_THIS_YEAR
-    } else {
-        LAST_USED_DATE_FORMAT
-    }
-    val prefix = when {
-        currentDay == instantDay -> "Today, "
-        currentDay - instantDay == 1 -> "Yesterday, "
-        else -> ""
-    }
-    val formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneId.systemDefault())
-    return prefix + formatter.format(this)
-}
-
 fun Instant.timestampHoursMinutes(): String {
     val formatter = DateTimeFormatter.ofPattern(TIMESTAMP_HOURS_MINUTES).withZone(ZoneId.systemDefault())
     return formatter.format(this)

--- a/app/src/main/java/com/babylon/wallet/android/utils/DateExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/DateExtensions.kt
@@ -55,14 +55,21 @@ fun Instant.dayMonthDateShort(): String {
 fun Instant.dayMonthDateFull(): String {
     val zoneId = ZoneId.systemDefault()
     val currentYear = Instant.now().atZone(zoneId).year
+    val currentDay = Instant.now().atZone(zoneId).dayOfYear
     val instantYear = atZone(zoneId).year
+    val instantDay = atZone(zoneId).dayOfYear
     val format = if (currentYear == instantYear) {
         LAST_USED_DATE_FORMAT_THIS_YEAR
     } else {
         LAST_USED_DATE_FORMAT
     }
+    val prefix = when {
+        currentDay == instantDay -> "Today, "
+        currentDay - instantDay == 1 -> "Yesterday, "
+        else -> ""
+    }
     val formatter = DateTimeFormatter.ofPattern(format).withZone(ZoneId.systemDefault())
-    return formatter.format(this)
+    return prefix + formatter.format(this)
 }
 
 fun Instant.timestampHoursMinutes(): String {

--- a/core/src/main/java/rdx/works/core/BigDecimalExtensions.kt
+++ b/core/src/main/java/rdx/works/core/BigDecimalExtensions.kt
@@ -25,7 +25,7 @@ private const val SCIENTIFIC_NOTATION_THRESHOLD = 20
 fun BigDecimal.displayableQuantity(): String {
     val integralPart: BigInteger = this.toBigInteger()
     val integralPartLength = if (integralPart.signum() == 0) 0 else integralPart.toString().length
-    val tokenQuantityString = this.toString()
+    val tokenQuantityString = this.toPlainString()
     val decimalPartLength = if (tokenQuantityString.contains(".") &&
         (tokenQuantityString.substringAfter(".") == "0").not()
     ) {

--- a/core/src/test/java/com/babylon/wallet/core/DisplayableQuantityTest.kt
+++ b/core/src/test/java/com/babylon/wallet/core/DisplayableQuantityTest.kt
@@ -391,6 +391,24 @@ class TokenQuantityToDisplayTest {
 
         Assert.assertEquals(expectedTokenQuantityToDisplay, actual)
     }
+
+    @Test
+    fun zeroExample() {
+        val expectedTokenQuantityToDisplay = "0"
+
+        val actual = BigDecimal(0.000000000000083616).displayableQuantity()
+
+        Assert.assertEquals(expectedTokenQuantityToDisplay, actual)
+    }
+
+    @Test
+    fun zeroExample2() {
+        val expectedTokenQuantityToDisplay = "0"
+
+        val actual = BigDecimal(0.000000000000000001).displayableQuantity()
+
+        Assert.assertEquals(expectedTokenQuantityToDisplay, actual)
+    }
 }
 
 class DefaultLocaleRule : TestRule {

--- a/core/src/test/java/com/babylon/wallet/core/DisplayableQuantityTest.kt
+++ b/core/src/test/java/com/babylon/wallet/core/DisplayableQuantityTest.kt
@@ -393,19 +393,10 @@ class TokenQuantityToDisplayTest {
     }
 
     @Test
-    fun zeroExample() {
+    fun `scientific notation close to 0`() {
         val expectedTokenQuantityToDisplay = "0"
 
-        val actual = BigDecimal(0.000000000000083616).displayableQuantity()
-
-        Assert.assertEquals(expectedTokenQuantityToDisplay, actual)
-    }
-
-    @Test
-    fun zeroExample2() {
-        val expectedTokenQuantityToDisplay = "0"
-
-        val actual = BigDecimal(0.000000000000000001).displayableQuantity()
+        val actual = BigDecimal("0.8616E-14").displayableQuantity()
 
         Assert.assertEquals(expectedTokenQuantityToDisplay, actual)
     }


### PR DESCRIPTION
## Description
Following issues are fixed:
- https://radixdlt.atlassian.net/browse/ABW-2988 - issue here is bug in value formatting code, we need to use `toPlainString` before we start to process the value, otherwise we can get scientific notation string which is not expected input to `displayableQuantity`. See additional test I've added for that case
- https://radixdlt.atlassian.net/browse/ABW-3000 by mistake selected filters strip shared same scroll state as month selector
- https://radixdlt.atlassian.net/browse/ABW-2996 add "Today", "Yesterday" prefix to history date headers, if applicable
- remove X to close for history filter tags in a FilterDialog. Tags in history view (above month strip) still have X 

## How to test

1. first bug is only possible to test if you have near zero amount in the wallet, or using account address provided in the ticket, but this require hardcoding that address in the wallet. I'm pretty sure I tested that one enough

## PR submission checklist
- [x] I have tested all the bugfixes
