### PR TITLE
[ABW-3050] Set selected month whne history first loads

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
@@ -84,6 +84,7 @@ class HistoryViewModel @Inject constructor(
         viewModelScope.launch {
             getAccountHistoryUseCase.getHistory(args.accountAddress, _state.value.filters).onSuccess { historyData ->
                 updateStateWith(historyData)
+                _state.value.historyItems?.firstOrNull()?.dateTime?.let { selectDate(it) }
             }.onFailure { error ->
                 _state.update {
                     it.copy(
@@ -118,7 +119,7 @@ class HistoryViewModel @Inject constructor(
         _state.update { state ->
             state.copy(
                 timeFilterItems = result.mapIndexed { index, monthFilter ->
-                    Selectable(monthFilter, index == result.lastIndex)
+                    Selectable(monthFilter)
                 }.toPersistentList()
             )
         }


### PR DESCRIPTION
## Description
Now we don't preselect first month on the list until history load


## How to test

1. Open account history which does not have tx in current month, but has some in the past

## PR submission checklist
- [x] I have tested that proper month is selected after history loads

