### PR TITLE
[ABW-3049] History dates sticky headers

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
@@ -99,8 +99,6 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
-private const val FIXED_LIST_ELEMENTS = 0
-
 @Composable
 fun HistoryScreen(
     modifier: Modifier = Modifier,
@@ -215,7 +213,7 @@ fun HistoryContent(
             timeFilterScrollState.scrollToItem(state.timeFilterItems.lastIndex)
         }
     }
-    MonitorListScroll(state = listState, fixedListElements = FIXED_LIST_ELEMENTS, onLoadMore = { direction ->
+    MonitorListScroll(state = listState, onLoadMore = { direction ->
         when (direction) {
             ScrollInfo.Direction.UP -> {
                 if (state.canLoadMoreUp) {
@@ -569,7 +567,6 @@ private fun SyncSheetState(
 @Composable
 private fun MonitorListScroll(
     state: LazyListState,
-    fixedListElements: Int,
     onScrollEvent: (ScrollInfo) -> Unit,
     onLoadMore: (ScrollInfo.Direction) -> Unit,
     loadThreshold: Int = 6
@@ -592,36 +589,23 @@ private fun MonitorListScroll(
         derivedStateOf {
             val lastItem = state.layoutInfo.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf false
             val threshold = state.layoutInfo.totalItemsCount - loadThreshold - 1
-            if (threshold <= fixedListElements) {
+            if (threshold <= 0) {
                 return@derivedStateOf false
             }
-            state.layoutInfo.totalItemsCount > fixedListElements && lastItem.index >= threshold
+            state.layoutInfo.totalItemsCount > 0 && lastItem.index >= threshold
         }
     }
     val loadMoreUp by remember(state) {
         derivedStateOf {
-            val firstItem = state.layoutInfo.visibleItemsInfo.firstOrNull {
-                if (fixedListElements == 0) {
-                    true
-                } else {
-                    it.index > fixedListElements - 1
-                }
-            } ?: return@derivedStateOf false
-            state.layoutInfo.totalItemsCount > fixedListElements && firstItem.index <= fixedListElements + loadThreshold
+            val firstItem = state.layoutInfo.visibleItemsInfo.firstOrNull() ?: return@derivedStateOf false
+            state.layoutInfo.totalItemsCount > 0 && firstItem.index <= loadThreshold
         }
     }
     val scrollInfo by remember(state) {
         derivedStateOf {
-            val firstItem = state.layoutInfo.visibleItemsInfo.firstOrNull {
-                if (fixedListElements == 0) {
-                    true
-                } else {
-                    it.index > fixedListElements - 1
-                }
-            }
+            val firstItem = state.layoutInfo.visibleItemsInfo.firstOrNull()
             val lastItem = state.layoutInfo.visibleItemsInfo.lastOrNull()
             ScrollInfo(
-                fixedListElements = fixedListElements,
                 firstVisibleIndex = firstItem?.index,
                 lastVisibleIndex = lastItem?.index,
                 totalCount = state.layoutInfo.totalItemsCount
@@ -651,19 +635,11 @@ private fun MonitorListScroll(
 }
 
 data class ScrollInfo(
-    val fixedListElements: Int = 0,
     val direction: Direction? = null,
-    private val firstVisibleIndex: Int?,
-    private val lastVisibleIndex: Int?,
+    val firstVisibleIndex: Int?,
+    val lastVisibleIndex: Int?,
     val totalCount: Int
 ) {
-
-    val firstVisible: Int?
-        get() = firstVisibleIndex?.let { it - fixedListElements }
-
-    val lastVisible: Int?
-        get() = lastVisibleIndex?.let { it - fixedListElements }
-
     enum class Direction {
         UP, DOWN
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
@@ -245,8 +245,10 @@ class HistoryViewModel @Inject constructor(
 
             ScrollInfo.Direction.DOWN -> {
                 if (_state.value.canLoadMoreDown.not()) {
+                    Timber.d("History: Nothing to load at the bottom")
                     return
                 }
+                Timber.d("History: Loading data at the bottom, cursor: ${_state.value.historyData?.prevCursorId}")
                 _state.update { it.copy(loadMoreState = State.LoadingMoreState.Down) }
                 viewModelScope.launch {
                     _state.value.historyData?.let { currentData ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
@@ -265,9 +265,9 @@ class HistoryViewModel @Inject constructor(
     fun onScrollEvent(event: ScrollInfo) {
         if (_state.value.areScrollEventsIgnored.not()) {
             val items = _state.value.historyItems ?: return
-            val firstVisibleItemDate = event.firstVisible?.let { items.getOrNull(it) }?.dateTime ?: return
-            val lastVisibleItemDate = event.lastVisible?.let { items.getOrNull(it) }?.dateTime ?: return
-            _state.update { it.copy(firstVisibleIndex = event.firstVisible) }
+            val firstVisibleItemDate = event.firstVisibleIndex?.let { items.getOrNull(it) }?.dateTime ?: return
+            val lastVisibleItemDate = event.lastVisibleIndex?.let { items.getOrNull(it) }?.dateTime ?: return
+            _state.update { it.copy(firstVisibleIndex = event.firstVisibleIndex) }
             when (event.direction) {
                 ScrollInfo.Direction.UP -> {
                     selectDate(firstVisibleItemDate)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
@@ -166,6 +166,7 @@ class HistoryViewModel @Inject constructor(
         }
         var item = existingIndex?.let { _state.value.historyItems?.getOrNull(it) }
         if (existingIndex == null || existingIndex == -1) {
+            if (_state.value.canLoadMore.not()) return
             _state.update { it.copy(loadMoreState = State.LoadingMoreState.NewRange, areScrollEventsIgnored = true) }
             viewModelScope.launch {
                 getAccountHistoryUseCase.getHistoryChunk(
@@ -347,7 +348,7 @@ class HistoryViewModel @Inject constructor(
                 } else {
                     State.Content.Loaded(
                         historyData = historyData,
-                        historyItems = historyItems.toPersistentList()
+                        historyItems = historyItems.toPersistentList(),
                     )
                 },
                 loadMoreState = if (resetLoadingMoreState) null else it.loadMoreState,
@@ -420,6 +421,9 @@ data class State(
 
     val canLoadMoreDown: Boolean
         get() = content is Content.Loaded && loadMoreState == null && content.historyData.nextCursorId != null
+
+    val canLoadMore: Boolean
+        get() = canLoadMoreUp || canLoadMoreDown
 
     val filtersChanged: Boolean
         get() = filters != currentFilters

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
@@ -229,7 +229,6 @@ class HistoryViewModel @Inject constructor(
                     Timber.d("History: Nothing to load at the top")
                     return
                 }
-                Timber.d("History: Loading data at the top, cursor: ${_state.value.historyData?.prevCursorId}")
                 _state.update { it.copy(loadMoreState = State.LoadingMoreState.Up) }
                 viewModelScope.launch {
                     _state.value.historyData?.let { currentData ->
@@ -248,7 +247,6 @@ class HistoryViewModel @Inject constructor(
                     Timber.d("History: Nothing to load at the bottom")
                     return
                 }
-                Timber.d("History: Loading data at the bottom, cursor: ${_state.value.historyData?.prevCursorId}")
                 _state.update { it.copy(loadMoreState = State.LoadingMoreState.Down) }
                 viewModelScope.launch {
                     _state.value.historyData?.let { currentData ->


### PR DESCRIPTION
## Description
- Adds sticky headers for date type items in history list. 
- simplify list state monitoring - current implementation does not use fixed items at the top, so we don't need additional scroll logic.

## How to test

1. Play with history and verify if it works as expected, data is still loaded and jumping between months sets proper position on the list/month strip

## PR submission checklist
- [x] I have tested history list scrolling and loading with sticky headers

