### PR TITLE
Show virtual values in non Mainnet network for debug builds

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/di/DataModule.kt
+++ b/app/src/main/java/com/babylon/wallet/android/di/DataModule.kt
@@ -19,7 +19,10 @@ import com.babylon.wallet.android.data.repository.state.StateRepositoryImpl
 import com.babylon.wallet.android.data.repository.stream.StreamRepository
 import com.babylon.wallet.android.data.repository.stream.StreamRepositoryImpl
 import com.babylon.wallet.android.data.repository.tokenprice.FiatPriceRepository
-import com.babylon.wallet.android.data.repository.tokenprice.FiatPriceRepositoryImpl
+import com.babylon.wallet.android.data.repository.tokenprice.Mainnet
+import com.babylon.wallet.android.data.repository.tokenprice.MainnetFiatPriceRepository
+import com.babylon.wallet.android.data.repository.tokenprice.Testnet
+import com.babylon.wallet.android.data.repository.tokenprice.TestnetFiatPriceRepository
 import com.babylon.wallet.android.data.repository.transaction.TransactionRepository
 import com.babylon.wallet.android.data.repository.transaction.TransactionRepositoryImpl
 import dagger.Binds
@@ -66,8 +69,15 @@ interface DataModule {
     ): NetworkInfoRepository
 
     @Binds
-    fun bindFiatPriceRepository(
-        tokenPriceRepository: FiatPriceRepositoryImpl
+    @Mainnet
+    fun bindMainnetFiatPriceRepository(
+        tokenPriceRepository: MainnetFiatPriceRepository
+    ): FiatPriceRepository
+
+    @Binds
+    @Testnet
+    fun bindTestnetFiatPriceRepository(
+        tokenPriceRepository: TestnetFiatPriceRepository
     ): FiatPriceRepository
 
     @Binds

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/GetFiatValueUseCaseTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/GetFiatValueUseCaseTest.kt
@@ -5,6 +5,7 @@ import com.babylon.wallet.android.domain.usecases.assets.GetFiatValueUseCase
 import com.babylon.wallet.android.fakes.FiatPriceRepositoryFake
 import com.babylon.wallet.android.fakes.StateRepositoryFake
 import com.babylon.wallet.android.mockdata.mockAccountsWithMockAssets
+import io.mockk.mockk
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -21,7 +22,8 @@ class GetFiatValueUseCaseTest {
 
     private val tokenPriceRepositoryFake = FiatPriceRepositoryFake()
     private val getFiatValueUseCase = GetFiatValueUseCase(
-        fiatPriceRepository = tokenPriceRepositoryFake,
+        mainnetFiatPriceRepository = tokenPriceRepositoryFake,
+        testnetFiatPriceRepository = mockk(),
         stateRepository = StateRepositoryFake()
     )
 


### PR DESCRIPTION
## Description
The PR adds to the repository introducing a Testnet implementation which
1. for testnet xrd addresses, requests mainnet's xrd price
2. for the rest of addresses, returns a random result from real tokens that exist on mainnet
3. if the build is not in debug mode (`EXPERIMENTAL_FEATURES_ENABLED`) then `PricesNotSupportedInNetwork` is returned so the UI can act accordingly.

The testnet repository will relay to the mainnet repositoryby requesting mainnet addresses. So no need for re-implementing the caching logic.
