### PR TITLE
Assertion failed message and lower default deposit guarantee

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,7 +90,7 @@ android {
         debugAlpha {
             initWith debug
             applicationIdSuffix ".alpha"
-            buildConfigField "boolean", "CRASH_REPORTING_AVAILABLE", "false"
+            buildConfigField "boolean", "CRASH_REPORTING_AVAILABLE", "true"
             minifyEnabled true
             debuggable false
             resValue "string", "app_name", "Radix Wallet Alpha"

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/stream/StreamRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/stream/StreamRepository.kt
@@ -25,7 +25,7 @@ interface StreamRepository {
         stateVersion: Long? = null
     ): Result<StreamTransactionsResponse>
 
-    suspend fun updateAccountFirstTransactionDate(accountAddress: String): Result<StreamTransactionsResponse>
+    suspend fun getAccountFirstTransactionDate(accountAddress: String): Result<StreamTransactionsResponse>
 
     companion object {
         const val PAGE_SIZE = 20
@@ -50,7 +50,7 @@ class StreamRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateAccountFirstTransactionDate(accountAddress: String): Result<StreamTransactionsResponse> {
+    override suspend fun getAccountFirstTransactionDate(accountAddress: String): Result<StreamTransactionsResponse> {
         return withContext(dispatcher) {
             runCatching {
                 streamApi.streamTransactions(

--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -125,6 +125,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
 
         sealed class TransactionCommitted : TransactionSubmitException() {
             data class Failure(val txId: String) : TransactionCommitted()
+            data class AssertionFailed(val txId: String) : TransactionCommitted()
         }
 
         fun getDappMessage(): String? {
@@ -151,6 +152,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
                 is TransactionCommitted.Failure -> WalletErrorType.SubmittedTransactionHasFailedTransactionStatus
                 is TransactionRejected.Permanently -> WalletErrorType.SubmittedTransactionHasPermanentlyRejectedTransactionStatus
                 is TransactionRejected.Temporary -> WalletErrorType.SubmittedTransactionHasTemporarilyRejectedTransactionStatus
+                is TransactionCommitted.AssertionFailed -> WalletErrorType.SubmittedTransactionHasFailedTransactionStatus
             }
     }
 
@@ -319,6 +321,10 @@ fun RadixWalletException.TransactionSubmitException.toUserFriendlyMessage(contex
                 txProcessingTime
             )
         }
+
+        is RadixWalletException.TransactionSubmitException.TransactionCommitted.AssertionFailed -> {
+            context.getString(R.string.transactionStatus_assertionFailure_text)
+        }
     }
 }
 
@@ -334,6 +340,7 @@ fun RadixWalletException.PrepareTransactionException.toUserFriendlyMessage(conte
             is RadixWalletException.PrepareTransactionException.ConvertManifest -> R.string.error_transactionFailure_manifest
             is RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities ->
                 R.string.error_transactionFailure_missingSigners
+
             is RadixWalletException.PrepareTransactionException.PrepareNotarizedTransaction -> R.string.error_transactionFailure_prepare
             is RadixWalletException.PrepareTransactionException.SubmitNotarizedTransaction -> R.string.error_transactionFailure_submit
             is RadixWalletException.PrepareTransactionException.FailedToFindAccountWithEnoughFundsToLockFee ->

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/assets/UpdateAccountFirstTransactionDateUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/assets/UpdateAccountFirstTransactionDateUseCase.kt
@@ -5,6 +5,7 @@ import com.babylon.wallet.android.data.repository.stream.StreamRepository
 import com.babylon.wallet.android.di.coroutines.DefaultDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import java.time.Instant
 import javax.inject.Inject
 
 class UpdateAccountFirstTransactionDateUseCase @Inject constructor(
@@ -14,8 +15,8 @@ class UpdateAccountFirstTransactionDateUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(
         accountAddress: String
-    ) {
-        streamRepository.updateAccountFirstTransactionDate(accountAddress).mapCatching { response ->
+    ): Result<Instant?> {
+        return streamRepository.getAccountFirstTransactionDate(accountAddress).mapCatching { response ->
             response.items.firstOrNull()?.confirmedAt?.toInstant()
         }.onSuccess { firstTransactionDate ->
             withContext(dispatcher) {

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
@@ -42,14 +42,20 @@ class PollTransactionStatusUseCase @Inject constructor(
 
                     TransactionPayloadStatus.committedFailure -> {
                         // Stop Polling: MESSAGE 2
+                        val isAssertionFailure = statusCheckResult.errorMessage?.contains("AssertionFailed") == true
+                        val exception = if (isAssertionFailure) {
+                            RadixWalletException.TransactionSubmitException.TransactionCommitted.AssertionFailed(
+                                txID
+                            )
+                        } else {
+                            RadixWalletException.TransactionSubmitException.TransactionCommitted.Failure(
+                                txID
+                            )
+                        }
                         return TransactionStatusData(
                             txId = txID,
                             requestId = requestId,
-                            result = Result.failure(
-                                RadixWalletException.TransactionSubmitException.TransactionCommitted.Failure(
-                                    txID
-                                )
-                            ),
+                            result = Result.failure(exception),
                             transactionType = transactionType
                         )
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransactionPreviewHeader.kt
@@ -17,14 +17,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.data.transaction.TransactionVersion
@@ -61,13 +64,20 @@ fun TransactionPreviewHeader(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
-                        Text(
-                            modifier = Modifier.weight(1.5f),
-                            text = stringResource(R.string.transactionReview_title),
-                            color = RadixTheme.colors.gray1,
-                            textAlign = TextAlign.Start,
-                            maxLines = 2,
-                        )
+                        CompositionLocalProvider(
+                            value = LocalDensity provides Density(
+                                density = LocalDensity.current.density,
+                                fontScale = 1f
+                            )
+                        ) {
+                            Text(
+                                modifier = Modifier.weight(1.5f),
+                                text = stringResource(R.string.transactionReview_title),
+                                color = RadixTheme.colors.gray1,
+                                textAlign = TextAlign.Start,
+                                maxLines = 2,
+                            )
+                        }
                         if (state.proposingDApp?.iconUrl != null) {
                             Thumbnail.DApp(
                                 modifier = Modifier

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1037,4 +1037,5 @@ If you have any “Legacy” Accounts (created on the Olympia network) to import
   <string name="survey_reason_heading">What’s the main reason for your score?</string>
   <string name="survey_reason_fieldHint">Let us know...</string>
   <string name="survey_submitButton">Submit Feedback - Thanks!</string>
+  <string name="transactionStatus_assertionFailure_text">Transaction failed because a guarantee on transaction results was not met. Consider reducing your preferred guarantee %%</string>
 </resources>

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,15 +12,19 @@ android {
     defaultConfig {
         minSdk rootProject.ext.minSdk
         targetSdk rootProject.ext.targetSdk
+        buildConfigField "boolean", "CRASH_REPORTING_ENABLED", "false"
     }
 
     buildTypes {
         debug {
-
+        }
+        debugAlpha {
+            buildConfigField "boolean", "CRASH_REPORTING_ENABLED", "true"
         }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            buildConfigField "boolean", "CRASH_REPORTING_ENABLED", "false"
         }
     }
     compileOptions {

--- a/core/src/main/java/rdx/works/core/preferences/PreferencesManager.kt
+++ b/core/src/main/java/rdx/works/core/preferences/PreferencesManager.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import rdx.works.core.BuildConfig
 import rdx.works.core.UUIDGenerator
 import java.time.Instant
 import javax.inject.Inject
@@ -131,7 +132,7 @@ class PreferencesManagerImpl @Inject constructor(
 
     override val isCrashReportingEnabled: Flow<Boolean> = dataStore.data
         .map { preferences ->
-            preferences[KEY_CRASH_REPORTING_ENABLED] ?: false
+            preferences[KEY_CRASH_REPORTING_ENABLED] ?: BuildConfig.CRASH_REPORTING_ENABLED
         }
 
     override suspend fun markFactorSourceBackedUp(id: String) {

--- a/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Transaction.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/apppreferences/Transaction.kt
@@ -12,7 +12,7 @@ data class Transaction(
 ) {
     companion object {
         val default = Transaction(
-            defaultDepositGuarantee = 1.0
+            defaultDepositGuarantee = 0.99
         )
     }
 }


### PR DESCRIPTION
## Description
- assertion failure message
- lower defaut deposit guarantee value - 0.99
- enable crashlytics in firebase alpha build
- make title in tx review screen fixed size not dependent on system font scale setting to avoid excessive whitespace

## How to test

1. Execute tx with guarantees > 100%
2. Observe failure message

## Screenshot
I took screenshot before adding % symbol to a string
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/118203440/477858d8-4e29-4d31-9c75-2ed62eb8468b" width="300">

## PR submission checklist
- [x] I have tested assertion failure message is shown and new default deposit guarantee is set for new wallet creation
