### PR TITLE
[ABW-3069] Fix NFT asset details dialog

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
@@ -5,8 +5,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -68,9 +70,11 @@ fun Metadata.View(modifier: Modifier) {
     } else {
         Row(
             modifier = modifier,
-            horizontalArrangement = Arrangement.SpaceBetween
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
             KeyView()
+            Spacer(modifier = Modifier.width(RadixTheme.dimensions.paddingMedium))
             ValueView(isRenderedInNewLine = false)
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/signing/FactorSourceInteractionBottomDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/signing/FactorSourceInteractionBottomDialog.kt
@@ -48,7 +48,8 @@ fun FactorSourceInteractionBottomDialog(
     }
     BottomSheetDialogWrapper(
         onDismiss = dismissHandler,
-        addScrim = true
+        addScrim = true,
+        showDefaultTopBar = false
     ) {
         FactorSourceInteractionBottomDialogContent(
             modifier = modifier,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
@@ -56,72 +56,78 @@ fun TransactionStatusDialog(
             }
         }
     }
-    BottomSheetDialogWrapper(modifier = modifier, onDismiss = dismissHandler, dragToDismissEnabled = !state.blockUntilComplete, content = {
-        Box {
-            androidx.compose.animation.AnimatedVisibility(
-                visible = state.isCompleting,
-                enter = fadeIn(),
-                exit = fadeOut()
-            ) {
-                CompletingContent()
-            }
-
-            androidx.compose.animation.AnimatedVisibility(
-                visible = state.isFailed,
-                enter = fadeIn(),
-                exit = fadeOut()
-            ) {
-                val title = when (state.walletErrorType) {
-                    WalletErrorType.SubmittedTransactionHasFailedTransactionStatus -> {
-                        stringResource(id = R.string.transactionStatus_failed_title)
-                    }
-
-                    WalletErrorType.SubmittedTransactionHasPermanentlyRejectedTransactionStatus -> {
-                        stringResource(id = R.string.transactionStatus_rejected_title)
-                    }
-
-                    WalletErrorType.SubmittedTransactionHasTemporarilyRejectedTransactionStatus -> {
-                        stringResource(id = R.string.transactionStatus_error_title)
-                    }
-
-                    else -> {
-                        stringResource(id = R.string.common_somethingWentWrong)
-                    }
+    BottomSheetDialogWrapper(
+        modifier = modifier,
+        onDismiss = dismissHandler,
+        dragToDismissEnabled = !state.blockUntilComplete,
+        showDefaultTopBar = false,
+        content = {
+            Box {
+                androidx.compose.animation.AnimatedVisibility(
+                    visible = state.isCompleting,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    CompletingContent()
                 }
-                SomethingWentWrongDialogContent(
-                    title = title,
-                    subtitle = state.failureError,
-                    transactionAddress = state.transactionId
-                )
-            }
 
-            androidx.compose.animation.AnimatedVisibility(
-                visible = state.isSuccess,
-                enter = fadeIn(),
-                exit = fadeOut()
-            ) {
-                // Need to send the correct transaction id
-                SuccessContent(transactionAddress = state.transactionId)
-            }
-
-            if (state.isIgnoreTransactionModalShowing) {
-                BasicPromptAlertDialog(
-                    finish = { accepted ->
-                        if (accepted) {
-                            viewModel.onDismissConfirmed()
-                        } else {
-                            viewModel.onDismissCanceled()
+                androidx.compose.animation.AnimatedVisibility(
+                    visible = state.isFailed,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    val title = when (state.walletErrorType) {
+                        WalletErrorType.SubmittedTransactionHasFailedTransactionStatus -> {
+                            stringResource(id = R.string.transactionStatus_failed_title)
                         }
-                    },
-                    message = {
-                        Text(text = stringResource(id = R.string.transactionStatus_dismissDialog_message))
-                    },
-                    confirmText = stringResource(id = R.string.common_ok),
-                    dismissText = null
-                )
+
+                        WalletErrorType.SubmittedTransactionHasPermanentlyRejectedTransactionStatus -> {
+                            stringResource(id = R.string.transactionStatus_rejected_title)
+                        }
+
+                        WalletErrorType.SubmittedTransactionHasTemporarilyRejectedTransactionStatus -> {
+                            stringResource(id = R.string.transactionStatus_error_title)
+                        }
+
+                        else -> {
+                            stringResource(id = R.string.common_somethingWentWrong)
+                        }
+                    }
+                    SomethingWentWrongDialogContent(
+                        title = title,
+                        subtitle = state.failureError,
+                        transactionAddress = state.transactionId
+                    )
+                }
+
+                androidx.compose.animation.AnimatedVisibility(
+                    visible = state.isSuccess,
+                    enter = fadeIn(),
+                    exit = fadeOut()
+                ) {
+                    // Need to send the correct transaction id
+                    SuccessContent(transactionAddress = state.transactionId)
+                }
+
+                if (state.isIgnoreTransactionModalShowing) {
+                    BasicPromptAlertDialog(
+                        finish = { accepted ->
+                            if (accepted) {
+                                viewModel.onDismissConfirmed()
+                            } else {
+                                viewModel.onDismissCanceled()
+                            }
+                        },
+                        message = {
+                            Text(text = stringResource(id = R.string.transactionStatus_dismissDialog_message))
+                        },
+                        confirmText = stringResource(id = R.string.common_ok),
+                        dismissText = null
+                    )
+                }
             }
         }
-    })
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -356,12 +356,16 @@ fun TransferContent(
         BottomSheetDialogWrapper(
             addScrim = true,
             showDragHandle = true,
-            onDismiss = onSheetClosed
+            onDismiss = onSheetClosed,
+            showDefaultTopBar = false
         ) {
             when (val sheetState = state.sheet) {
                 is State.Sheet.ChooseAccounts -> {
                     ChooseAccountSheet(
-                        modifier = Modifier.fillMaxHeight(0.9f).imePadding(),
+                        modifier = Modifier
+                            .background(RadixTheme.colors.gray5)
+                            .fillMaxHeight(0.9f)
+                            .imePadding(),
                         onCloseClick = onSheetClosed,
                         state = sheetState,
                         onOwnedAccountSelected = onOwnedAccountSelected,
@@ -375,7 +379,10 @@ fun TransferContent(
 
                 is State.Sheet.ChooseAssets -> {
                     ChooseAssetsSheet(
-                        modifier = Modifier.fillMaxHeight(0.9f).imePadding(),
+                        modifier = Modifier
+                            .background(RadixTheme.colors.defaultBackground)
+                            .fillMaxHeight(0.9f)
+                            .imePadding(),
                         state = sheetState,
                         onTabClick = onChooseAssetTabClick,
                         onCollectionClick = onChooseAssetCollectionClick,
@@ -391,49 +398,6 @@ fun TransferContent(
                 is State.Sheet.None -> {}
             }
         }
-//        DefaultModalSheetLayout(
-//            modifier = Modifier.imePadding(),
-//            sheetState = bottomSheetState,
-//            sheetContent = {
-//                when (val sheetState = state.sheet) {
-//                    is State.Sheet.ChooseAccounts -> {
-//                        ChooseAccountSheet(
-//                            onCloseClick = onSheetClosed,
-//                            state = sheetState,
-//                            onOwnedAccountSelected = onOwnedAccountSelected,
-//                            onChooseAccountSubmitted = onChooseAccountSubmitted,
-//                            onAddressDecoded = onAddressDecoded,
-//                            onQrCodeIconClick = onQrCodeIconClick,
-//                            cancelQrScan = cancelQrScan,
-//                            onAddressChanged = onAddressTyped
-//                        )
-//                    }
-//
-//                    is State.Sheet.ChooseAssets -> {
-//                        ChooseAssetsSheet(
-//                            state = sheetState,
-//                            onTabClick = onChooseAssetTabClick,
-//                            onCollectionClick = onChooseAssetCollectionClick,
-//                            onCloseClick = onSheetClosed,
-//                            onAssetSelectionChanged = onAssetSelectionChanged,
-//                            onNextNFtsPageRequest = onNextNFTsPageRequest,
-//                            onStakesRequest = onStakesRequest,
-//                            onUiMessageShown = onUiMessageShown,
-//                            onChooseAssetsSubmitted = onChooseAssetsSubmitted
-//                        )
-//                    }
-//
-//                    is State.Sheet.None -> {}
-//                }
-//            },
-//            showDragHandle = true,
-//            containerColor = if (state.sheet is State.Sheet.ChooseAccounts) {
-//                RadixTheme.colors.defaultBackground
-//            } else {
-//                RadixTheme.colors.gray5
-//            },
-//            onDismissRequest = onSheetClosed
-//        )
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -99,6 +99,7 @@ fun BottomSheetDialogWrapper(
     dragToDismissEnabled: Boolean = true,
     addScrim: Boolean = false,
     showDragHandle: Boolean = false,
+    showDefaultTopBar: Boolean = true,
     title: String? = null,
     onDismiss: () -> Unit,
     content: @Composable () -> Unit
@@ -164,7 +165,7 @@ fun BottomSheetDialogWrapper(
                 if (showDragHandle) {
                     DefaultModalSheetDragHandle()
                 }
-                if (dragToDismissEnabled && title != null) {
+                if (showDefaultTopBar) {
                     BottomDialogHeader(
                         modifier = Modifier
                             .fillMaxWidth()


### PR DESCRIPTION
## Description
- add additional parameter that control if we show or not default dialog wrapper top bar
- center metadata view content and add spacing between label/value


## How to test

1. Open Various NFT details and verify dialog is now displayed properly, with drag to dismiss working

## PR submission checklist
- [x] I have tested dialog wrapper used in NFT asset details, signing bottom sheet and tx status and verified it works 
