### PR TITLE
[ABW-3070] Show fiat values in account context only

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogViewModel.kt
@@ -131,7 +131,7 @@ class AssetDialogViewModel @Inject constructor(
         val accountContext: Network.Account? = null,
     ) : UiState {
 
-        val isLoadingBalance = assetPrice == null
+        val isLoadingBalance = args.underAccountAddress != null && assetPrice == null
 
         val claimState: ClaimState?
             get() {


### PR DESCRIPTION
## Description
Only show fiat values in account context.

## How to test

1. Open asset details from tx review and verify there is no infinite shimmer