### PR TITLE
[ABW-3061] Fix format when balance is zero

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AssetPrice.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AssetPrice.kt
@@ -27,11 +27,13 @@ data class FiatPrice(
                 NumberFormatter.with()
                     .unit(Currency.getInstance(currency.name))
                     .locale(Locale.getDefault())
-                    .let {
+                    .let { localizedNumberFormatter ->
                         if (price < 1.0 && price != 0.0) {
-                            it.precision(Precision.fixedFraction(FRACTION_PLACES))
+                            localizedNumberFormatter.precision(Precision.fixedFraction(FRACTION_PLACES))
+                        } else if (price == 0.0) {
+                            localizedNumberFormatter.precision(Precision.fixedFraction(NO_PRECISION))
                         } else {
-                            it
+                            localizedNumberFormatter
                         }
                     }
                     .format(price)
@@ -50,6 +52,7 @@ data class FiatPrice(
     companion object {
         private const val MAX_FRACTION_DIGITS = 5
         private const val FRACTION_PLACES = 5
+        private const val NO_PRECISION = 0
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TotalFiatBalanceView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TotalFiatBalanceView.kt
@@ -128,11 +128,12 @@ private fun TotalBalanceContent(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
     ) {
+        val shouldShowContentColor = (fiatPrice != null && isPriceVisible && fiatPrice.price != 0.0)
         Text(
             modifier = Modifier.weight(1f, fill = false),
             text = annotatedFormat,
             style = contentStyle,
-            color = if (fiatPrice != null && isPriceVisible) contentColor else hiddenContentColor,
+            color = if (shouldShowContentColor) contentColor else hiddenContentColor,
             maxLines = 1
         )
 
@@ -166,8 +167,25 @@ fun TotalFiatBalanceViewToggle(
     )
 }
 
-@Preview("default", showBackground = true)
-@Preview("large font", fontScale = 2f, showBackground = true)
+@Preview(showBackground = true)
+@Composable
+fun TotalBalanceZeroPreview() {
+    RadixWalletTheme {
+        TotalFiatBalanceView(
+            modifier = Modifier.fillMaxWidth(),
+            fiatPrice = FiatPrice(
+                price = 0.0,
+                currency = SupportedCurrency.USD
+            ),
+            currency = SupportedCurrency.USD,
+            isLoading = false,
+            trailingContent = {
+                TotalFiatBalanceViewToggle(onToggle = {})
+            }
+        )
+    }
+}
+
 @Preview(showBackground = true)
 @Composable
 fun TotalBalancePreview() {
@@ -187,8 +205,8 @@ fun TotalBalancePreview() {
     }
 }
 
-@Preview("default with long value", showBackground = true)
 @Preview(showBackground = true)
+@Preview("large font", fontScale = 2f, showBackground = true)
 @Composable
 fun TotalBalanceWithLongValuePreview() {
     RadixWalletTheme {
@@ -207,7 +225,6 @@ fun TotalBalanceWithLongValuePreview() {
     }
 }
 
-@Preview("default", showBackground = true)
 @Preview(showBackground = true)
 @Composable
 fun TotalBalanceErrorPreview() {
@@ -224,7 +241,6 @@ fun TotalBalanceErrorPreview() {
     }
 }
 
-@Preview("default", showBackground = true)
 @Preview(showBackground = true)
 @Composable
 fun TotalBalanceHiddenPreview() {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -250,21 +250,22 @@ private fun WalletAccountList(
             )
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
         }
-        itemsIndexed(state.accountResources) { _, accountWithResources ->
+        itemsIndexed(state.accountsAndAssets) { _, accountWithAssets ->
             AccountCardView(
                 modifier = Modifier
                     .padding(horizontal = RadixTheme.dimensions.paddingLarge)
                     .throttleClickable {
-                        onAccountClick(accountWithResources.account)
+                        onAccountClick(accountWithAssets.account)
                     },
-                accountWithAssets = accountWithResources,
-                fiatTotalValue = state.totalFiatValueForAccount(accountWithResources.account.address),
-                accountTag = state.getTag(accountWithResources.account),
-                isLoadingResources = accountWithResources.assets == null,
-                isLoadingBalance = state.isBalanceLoadingForAccount(accountWithResources.account.address),
-                securityPromptType = state.securityPrompt(accountWithResources.account),
+                accountWithAssets = accountWithAssets,
+                fiatTotalValue = state.totalFiatValueForAccount(accountWithAssets.account.address),
+                accountTag = state.getTag(accountWithAssets.account),
+                isLoadingResources = accountWithAssets.assets == null,
+                isLoadingBalance = accountWithAssets.assets == null ||
+                    state.isBalanceLoadingForAccount(accountWithAssets.account.address),
+                securityPromptType = state.securityPrompt(accountWithAssets.account),
                 onApplySecuritySettings = {
-                    onApplySecuritySettings(accountWithResources.account, it)
+                    onApplySecuritySettings(accountWithAssets.account, it)
                 }
             )
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
@@ -369,7 +370,7 @@ fun WalletContentPreview() {
         with(SampleDataProvider()) {
             WalletContent(
                 state = WalletUiState(
-                    accountsWithResources = listOf(
+                    accountsWithAssets = listOf(
                         sampleAccountWithoutResources(),
                         sampleAccountWithoutResources(name = "my account with a way too much long name")
                     ),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -261,7 +261,11 @@ data class WalletUiState(
         get() = accountsWithAssets == null && loading
 
     val isWalletBalanceLoading: Boolean
-        get() = accountsAddressesWithAssetsPrices.isNullOrEmpty()
+        get() {
+            // if assets loading then getFiatValueUseCase won't fetch any actual prices
+            val areAnyAssetsLoading = accountsAndAssets.any { accountWithAssets -> accountWithAssets.assets == null }
+            return isLoading || areAnyAssetsLoading || accountsAddressesWithAssetsPrices.isNullOrEmpty()
+        }
 
     fun isBalanceLoadingForAccount(accountAddress: String): Boolean {
         return accountsAddressesWithAssetsPrices?.containsKey(accountAddress) != true

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -239,7 +239,7 @@ internal sealed interface WalletEvent : OneOffEvent {
 }
 
 data class WalletUiState(
-    private val accountsWithResources: List<AccountWithAssets>? = null,
+    private val accountsWithAssets: List<AccountWithAssets>? = null,
     private val accountsAddressesWithAssetsPrices: Map<String, List<AssetPrice>?>? = null,
     private val loading: Boolean = true,
     private val refreshing: Boolean = false,
@@ -251,14 +251,14 @@ data class WalletUiState(
     val isNpsSurveyShown: Boolean = false
 ) : UiState {
 
-    val accountResources: List<AccountWithAssets>
-        get() = accountsWithResources.orEmpty()
+    val accountsAndAssets: List<AccountWithAssets>
+        get() = accountsWithAssets.orEmpty()
 
     /**
      * Initial loading of the screen.
      */
     val isLoading: Boolean
-        get() = accountsWithResources == null && loading
+        get() = accountsWithAssets == null && loading
 
     val isWalletBalanceLoading: Boolean
         get() = accountsAddressesWithAssetsPrices.isNullOrEmpty()
@@ -305,7 +305,7 @@ data class WalletUiState(
      *
      */
     fun totalFiatValueForAccount(accountAddress: String): FiatPrice? {
-        val accountWithAssets = accountResources.find {
+        val accountWithAssets = accountsAndAssets.find {
             it.account.address == accountAddress
         }
         if (accountWithAssets?.assets?.ownsAnyAssetsThatContributeToBalance?.not() == true) {
@@ -360,14 +360,14 @@ data class WalletUiState(
     }
 
     private fun isDappDefinitionAccount(forAccount: Network.Account): Boolean {
-        return accountResources.find { accountWithResources ->
+        return accountsAndAssets.find { accountWithResources ->
             accountWithResources.account.address == forAccount.address
         }?.isDappDefinitionAccountType ?: false
     }
 
     fun loadingResources(accounts: List<Network.Account>, isRefreshing: Boolean): WalletUiState = copy(
-        accountsWithResources = accounts.map { account ->
-            val current = accountsWithResources?.find { account == it.account }
+        accountsWithAssets = accounts.map { account ->
+            val current = accountsWithAssets?.find { account == it.account }
             AccountWithAssets(
                 account = account,
                 details = current?.details,
@@ -379,14 +379,14 @@ data class WalletUiState(
     )
 
     fun onResourcesReceived(accountsWithResources: List<AccountWithAssets>): WalletUiState = copy(
-        accountsWithResources = accountsWithResources,
+        accountsWithAssets = accountsWithResources,
         loading = false,
         refreshing = false
     )
 
     fun onResourcesError(error: Throwable?): WalletUiState = copy(
         uiMessage = UiMessage.ErrorMessage(error),
-        accountsWithResources = accountsWithResources?.map { account ->
+        accountsWithAssets = accountsWithAssets?.map { account ->
             if (account.assets == null) {
                 // If assets don't exist leave them empty
                 account.copy(assets = Assets())


### PR DESCRIPTION
## Description
This PR fixes:
- the text color of the balance when is 0
- the format of the balance when is 0. Now it should be "0" instead of "0.00"
- the loading of total wallet fiat balance


## How to test

1. You need a wallet with empty accounts

## Screenshot

<img width="233" alt="Screenshot 2024-03-19 at 2 59 09 PM" src="https://github.com/radixdlt/babylon-wallet-android/assets/118305718/863870d9-8157-481a-be8c-60cdd104858a">


## PR submission checklist
- [x] I have tested wallet with zero balance
