### PR TITLE
NPS survey fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ android {
         minSdk rootProject.ext.minSdk
         targetSdk rootProject.ext.targetSdk
         versionCode 29
-        versionName "1.4.1"
+        versionName "1.5.0"
         buildConfigField "boolean", "DEBUG_MODE", "true"
         buildConfigField "boolean", "CRASH_REPORTING_AVAILABLE", "false"
         buildConfigField "boolean", "EXPERIMENTAL_FEATURES_ENABLED", "true"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -100,3 +100,5 @@
 # R8 full mode strips generic signatures from return types if not kept.
 -if interface * { @retrofit2.http.* public *** *(...); }
 -keep,allowoptimization,allowshrinking,allowobfuscation class <3>
+
+-keep class com.babylon.wallet.android.data.gateway.survey.** { *; }

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/TransactionStatusClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/TransactionStatusClient.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import rdx.works.core.preferences.PreferencesManager
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,6 +24,7 @@ import javax.inject.Singleton
 class TransactionStatusClient @Inject constructor(
     private val pollTransactionStatusUseCase: PollTransactionStatusUseCase,
     private val appEventBus: AppEventBus,
+    private val preferencesManager: PreferencesManager,
     @ApplicationScope private val appScope: CoroutineScope
 ) {
 
@@ -51,6 +53,7 @@ class TransactionStatusClient @Inject constructor(
         appScope.launch {
             val pollResult = pollTransactionStatusUseCase(txID, requestId, transactionType, endEpoch)
             pollResult.result.onSuccess {
+                preferencesManager.incrementTransactionCompleteCounter()
                 appEventBus.sendEvent(AppEvent.RefreshResourcesNeeded)
             }
             updateTransactionStatus(pollResult)

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
@@ -19,6 +19,7 @@ class PollTransactionStatusUseCase @Inject constructor(
         transactionType: TransactionType = TransactionType.Generic,
         endEpoch: ULong
     ): TransactionStatusData {
+        var defaultPollDelayMs = DEFAULT_POLL_INTERVAL_MS
         while (true) {
             transactionRepository.getTransactionStatus(txID).onSuccess { statusCheckResult ->
                 val currentEpoch = statusCheckResult.ledgerState.epoch.toULong()
@@ -28,7 +29,8 @@ class PollTransactionStatusUseCase @Inject constructor(
                     TransactionPayloadStatus.unknown,
                     TransactionPayloadStatus.commitPendingOutcomeUnknown,
                     TransactionPayloadStatus.pending -> {
-                        delay(POLLING_INTERVAL_MS)
+                        delay(defaultPollDelayMs)
+                        defaultPollDelayMs += POLL_INTERVAL_MS
                     }
 
                     TransactionPayloadStatus.committedSuccess -> {
@@ -97,6 +99,7 @@ class PollTransactionStatusUseCase @Inject constructor(
     }
 
     companion object {
-        private const val POLLING_INTERVAL_MS = 2000L
+        private const val DEFAULT_POLL_INTERVAL_MS = 2000L
+        private const val POLL_INTERVAL_MS = 1000L
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/PollTransactionStatusUseCase.kt
@@ -5,6 +5,7 @@ import com.babylon.wallet.android.data.gateway.generated.models.TransactionPaylo
 import com.babylon.wallet.android.data.repository.TransactionStatusData
 import com.babylon.wallet.android.data.repository.transaction.TransactionRepository
 import com.babylon.wallet.android.domain.RadixWalletException
+import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 class PollTransactionStatusUseCase @Inject constructor(
@@ -27,7 +28,7 @@ class PollTransactionStatusUseCase @Inject constructor(
                     TransactionPayloadStatus.unknown,
                     TransactionPayloadStatus.commitPendingOutcomeUnknown,
                     TransactionPayloadStatus.pending -> {
-                        // Keep Polling
+                        delay(POLLING_INTERVAL_MS)
                     }
 
                     TransactionPayloadStatus.committedSuccess -> {
@@ -93,5 +94,9 @@ class PollTransactionStatusUseCase @Inject constructor(
                 }
             }
         }
+    }
+
+    companion object {
+        private const val POLLING_INTERVAL_MS = 2000L
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/survey/NPSSurveyDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/survey/NPSSurveyDialog.kt
@@ -35,7 +35,7 @@ fun NPSSurveyDialog(
 
     BottomSheetDialogWrapper(
         modifier = modifier,
-        onDismiss = onDismiss,
+        onDismiss = viewModel::onBackPress,
         showDragHandle = true,
         title = stringResource(id = R.string.empty)
     ) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -99,13 +99,16 @@ class WalletViewModel @Inject constructor(
 
     private fun observeNpsSurveyState() {
         viewModelScope.launch {
-            npsSurveyStateObserver.npsSurveyState().filterIsInstance<NPSSurveyState.Active>().collectLatest { state ->
-                _state.update { it.copy(isNpsSurveyShown = true) }
+            npsSurveyStateObserver.npsSurveyState.filterIsInstance<NPSSurveyState.Active>().collectLatest {
+                if (state.value.isNpsSurveyShown.not()) {
+                    sendEvent(WalletEvent.ShowNpsSurvey)
+                    _state.update { state -> state.copy(isNpsSurveyShown = true) }
+                }
             }
         }
     }
 
-    fun npsSurveyShown() {
+    fun dismissSurvey() {
         viewModelScope.launch {
             _state.update { it.copy(isNpsSurveyShown = false) }
         }
@@ -236,6 +239,8 @@ class WalletViewModel @Inject constructor(
 internal sealed interface WalletEvent : OneOffEvent {
     data class NavigateToMnemonicBackup(val factorSourceId: FactorSourceID.FromHash) : WalletEvent
     data class NavigateToMnemonicRestore(val factorSourceId: FactorSourceID.FromHash) : WalletEvent
+
+    data object ShowNpsSurvey : WalletEvent
 }
 
 data class WalletUiState(

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/NPSSurveyStateObserverTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/NPSSurveyStateObserverTest.kt
@@ -36,7 +36,7 @@ class NPSSurveyStateObserverTest {
     fun `given survey has never been shown and less than 10 transactions performed, verify no survey shown`() = runTest {
         val event = mutableListOf<NPSSurveyState>()
 
-        useCase.npsSurveyState().onEach {
+        useCase.npsSurveyState.onEach {
             event.add(it)
         }
             .launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
@@ -49,7 +49,7 @@ class NPSSurveyStateObserverTest {
     fun `given survey has never been shown and 10 transactions performed, verify survey shown`() = runTest {
         val useCase = NPSSurveyStateObserver(preferencesManager)
         val event = mutableListOf<NPSSurveyState>()
-        useCase.npsSurveyState().onEach {
+        useCase.npsSurveyState.onEach {
             event.add(it)
         }
             .launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
@@ -70,7 +70,7 @@ class NPSSurveyStateObserverTest {
 
         val event = mutableListOf<NPSSurveyState>()
 
-        useCase.npsSurveyState().onEach {
+        useCase.npsSurveyState.onEach {
             event.add(it)
         }
             .launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
@@ -88,7 +88,7 @@ class NPSSurveyStateObserverTest {
         val useCase = NPSSurveyStateObserver(preferencesManager)
 
         val event = mutableListOf<NPSSurveyState>()
-        useCase.npsSurveyState().onEach {
+        useCase.npsSurveyState.onEach {
             event.add(it)
         }
             .launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/NPSSurveyStateObserverTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/NPSSurveyStateObserverTest.kt
@@ -80,7 +80,7 @@ class NPSSurveyStateObserverTest {
 
         advanceUntilIdle()
 
-        Assert.assertEquals(event.first(), NPSSurveyState.InActive)
+        Assert.assertEquals(event.last(), NPSSurveyState.InActive)
     }
 
     @Test

--- a/app/src/test/java/com/babylon/wallet/android/fakes/FakePreferenceManager.kt
+++ b/app/src/test/java/com/babylon/wallet/android/fakes/FakePreferenceManager.kt
@@ -78,9 +78,8 @@ class FakePreferenceManager : PreferencesManager {
         TODO("Not yet implemented")
     }
 
-    override fun transactionCompleteCounter(): Flow<Int> {
-        return _transactionCompleteCounter
-    }
+    override val transactionCompleteCounter: Flow<Int>
+        get() = _transactionCompleteCounter
 
     override suspend fun incrementTransactionCompleteCounter() {
         _transactionCompleteCounter.emit(_transactionCompleteCounter.value + 1)

--- a/app/src/test/java/com/babylon/wallet/android/presentation/WalletViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/WalletViewModelTest.kt
@@ -1,6 +1,8 @@
 package com.babylon.wallet.android.presentation
 
 import app.cash.turbine.test
+import com.babylon.wallet.android.NPSSurveyState
+import com.babylon.wallet.android.NPSSurveyStateObserver
 import com.babylon.wallet.android.data.gateway.model.ExplicitMetadataKey
 import com.babylon.wallet.android.domain.model.assets.AccountWithAssets
 import com.babylon.wallet.android.domain.model.assets.Assets
@@ -10,8 +12,6 @@ import com.babylon.wallet.android.domain.model.resources.XrdResource
 import com.babylon.wallet.android.domain.model.resources.metadata.Metadata
 import com.babylon.wallet.android.domain.model.resources.metadata.MetadataType
 import com.babylon.wallet.android.domain.usecases.GetEntitiesWithSecurityPromptUseCase
-import com.babylon.wallet.android.NPSSurveyState
-import com.babylon.wallet.android.NPSSurveyStateObserver
 import com.babylon.wallet.android.domain.usecases.assets.GetFiatValueUseCase
 import com.babylon.wallet.android.domain.usecases.assets.GetWalletAssetsUseCase
 import com.babylon.wallet.android.mockdata.account
@@ -84,7 +84,7 @@ class WalletViewModelTest : StateViewModelTest<WalletViewModel>() {
         every { getProfileUseCase() } returns flowOf(sampleProfile)
         every { appEventBus.events } returns MutableSharedFlow()
         every { preferencesManager.isRadixBannerVisible } returns flowOf(false)
-        every { npsSurveyStateObserver.npsSurveyState() } returns flowOf(NPSSurveyState.InActive)
+        every { npsSurveyStateObserver.npsSurveyState } returns flowOf(NPSSurveyState.InActive)
     }
 
     @Test

--- a/core/src/main/java/rdx/works/core/preferences/PreferencesManager.kt
+++ b/core/src/main/java/rdx/works/core/preferences/PreferencesManager.kt
@@ -29,6 +29,7 @@ interface PreferencesManager {
     val isRadixBannerVisible: Flow<Boolean>
     val isLinkConnectionStatusIndicatorEnabled: Flow<Boolean>
     val lastNPSSurveyInstant: Flow<Instant?>
+    val transactionCompleteCounter: Flow<Int>
 
     suspend fun updateLastBackupInstant(backupInstant: Instant)
 
@@ -52,8 +53,6 @@ interface PreferencesManager {
     suspend fun markDeviceRootedDialogShown()
 
     suspend fun setLinkConnectionStatusIndicator(isEnabled: Boolean)
-    fun transactionCompleteCounter(): Flow<Int>
-
     suspend fun incrementTransactionCompleteCounter()
 
     suspend fun updateLastNPSSurveyInstant(npsSurveyInstant: Instant)
@@ -202,10 +201,6 @@ class PreferencesManagerImpl @Inject constructor(
         }
     }
 
-    override fun transactionCompleteCounter(): Flow<Int> = dataStore.data.map { preferences ->
-        preferences[KEY_TRANSACTIONS_COMPLETE_COUNT] ?: 0
-    }
-
     override suspend fun incrementTransactionCompleteCounter() {
         dataStore.edit { preferences ->
             val oldValue = preferences[KEY_TRANSACTIONS_COMPLETE_COUNT] ?: 0
@@ -218,6 +213,10 @@ class PreferencesManagerImpl @Inject constructor(
             preferences[KEY_SHOW_NPS_SURVEY_INSTANT]?.let {
                 Instant.parse(it)
             }
+        }
+    override val transactionCompleteCounter: Flow<Int>
+        get() = dataStore.data.map { preferences ->
+            preferences[KEY_TRANSACTIONS_COMPLETE_COUNT] ?: 0
         }
 
     override suspend fun updateLastNPSSurveyInstant(npsSurveyInstant: Instant) {


### PR DESCRIPTION
## Description
- properly trigger blank nps request when tapping X or swiping to close the NPS survey
- prevent listening to poll status twice. Because in the past we incremented tx counter in the status dialog collect P {} block, every transaction resulted in increment of 2.
- moved increment code to the transaction poll client, where it is run in app scope so we can be certain it is run even if status dialog go away
- make sure we can't fire NPS dialog twice even if status flow would emit multiple times. Dialog can only be shown again after current one is dmissed
- added change to history date selection logic - now when we have everything loaded and we tap on a month that does not have a transaction, we scroll to first tx before that date. Added comments on the logic as well

## How to test

1. Dismiss the dialog by X/swipe to close and observe in logcat that empty request is sent
2. Verofy that indeed 10 txes are needed to show the dialog first time.
3. History scroll can be tested using account that has one month break in transactions. 

## PR submission checklist
- [x] I have tested scenarios above and confirm they work
