### PR TITLE
Update prices when pull to refresh

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/cache/database/TokenPriceDao.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/cache/database/TokenPriceDao.kt
@@ -23,6 +23,7 @@ interface TokenPriceDao {
     companion object {
         private val tokenPriceCacheDuration = 5.toDuration(DurationUnit.MINUTES)
 
-        fun tokenPriceCacheValidity() = InstantGenerator().toEpochMilli() - tokenPriceCacheDuration.inWholeMilliseconds
+        fun tokenPriceCacheValidity(isRefreshing: Boolean = false) =
+            InstantGenerator().toEpochMilli() - if (isRefreshing) 0 else tokenPriceCacheDuration.inWholeMilliseconds
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogViewModel.kt
@@ -78,7 +78,11 @@ class AssetDialogViewModel @Inject constructor(
                     _state.update { it.copy(accountContext = account) }
 
                     if (account != null) {
-                        val assetPrice = getFiatValueUseCase.forAsset(asset = asset, account = account).getOrThrow()
+                        val assetPrice = getFiatValueUseCase.forAsset(
+                            asset = asset,
+                            account = account,
+                            isRefreshing = true
+                        ).getOrThrow()
                         _state.update { it.copy(assetPrice = assetPrice) }
                     }
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
@@ -56,7 +56,7 @@ class AssetsChooserDelegate @Inject constructor(
                 val assets = accountWithAssets?.assets
 
                 accountWithAssets?.let {
-                    getFiatValueUseCase.forAccount(accountWithAssets = it)
+                    getFiatValueUseCase.forAccount(accountWithAssets = it, isRefreshing = true)
                         .onSuccess { assetsPrices ->
                             updateSheetState { state ->
                                 state.copy(assetsWithAssetsPrices = assetsPrices.associateBy { assetPrice -> assetPrice.asset })

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -133,10 +133,16 @@ class WalletViewModel @Inject constructor(
                 }
             }
             .onEach { accountsWithAssets ->
+                // keep the val here because the onResourcesReceived sets the refreshing to false
+                val isRefreshing = state.value.isRefreshing
+
                 _state.update { it.onResourcesReceived(accountsWithAssets) }
 
                 val accountsAddressesWithAssetsPrices = accountsWithAssets.associate { accountWithAssets ->
-                    accountWithAssets.account.address to getFiatValueUseCase.forAccount(accountWithAssets).getOrNull()
+                    accountWithAssets.account.address to getFiatValueUseCase.forAccount(
+                        accountWithAssets = accountWithAssets,
+                        isRefreshing = isRefreshing
+                    ).getOrNull()
                 }
                 _state.update { walletUiState ->
                     walletUiState.copy(

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/GetFiatValueUseCaseTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/GetFiatValueUseCaseTest.kt
@@ -30,7 +30,7 @@ class GetFiatValueUseCaseTest {
     @Test
     fun `assert that all the tokens of the given accounts have their prices`() = testScope.runTest {
         mockAccountsWithMockAssets.forEach { accountWithAssets ->
-            val assetPriceAddresses = getFiatValueUseCase.forAccount(accountWithAssets).getOrThrow().map {
+            val assetPriceAddresses = getFiatValueUseCase.forAccount(accountWithAssets, isRefreshing = false).getOrThrow().map {
                 it.asset.resource.resourceAddress
             }.toSet()
 
@@ -41,7 +41,7 @@ class GetFiatValueUseCaseTest {
 
     @Test
     fun `given a token when it is not included in the result of the prices then it does not have fiat value`() = testScope.runTest {
-        val assetPrices = getFiatValueUseCase.forAccount(mockAccountsWithMockAssets[0]).getOrThrow()
+        val assetPrices = getFiatValueUseCase.forAccount(mockAccountsWithMockAssets[0], isRefreshing = false).getOrThrow()
 
         val assetPrice = assetPrices.find { it.asset.resource.name == "OtherToken" }
         assertNotNull(assetPrice?.asset)
@@ -60,7 +60,7 @@ class GetFiatValueUseCaseTest {
         val accountWithAssets = accountsWithAssets[0]
 
         testScope.runTest {
-            val assetPricesForAccount = getFiatValueUseCase.forAccount(accountWithAssets).getOrThrow()
+            val assetPricesForAccount = getFiatValueUseCase.forAccount(accountWithAssets, isRefreshing = false).getOrThrow()
 
             val pricesPerAsset: Map<Asset, Double> = assetPricesForAccount.associate { assetPrice ->
                 assetPrice.asset to (assetPrice.price?.price ?: 0.0)
@@ -107,7 +107,7 @@ class GetFiatValueUseCaseTest {
         val accountWithAssets = accountsWithAssets[1]
 
         testScope.runTest {
-            val assetPricesForAccount = getFiatValueUseCase.forAccount(accountWithAssets).getOrThrow()
+            val assetPricesForAccount = getFiatValueUseCase.forAccount(accountWithAssets, isRefreshing = false).getOrThrow()
 
             val pricesPerAsset: Map<Asset, Double> = assetPricesForAccount.associate { assetPrice ->
                 assetPrice.asset to (assetPrice.price?.price ?: 0.0)
@@ -151,7 +151,7 @@ class GetFiatValueUseCaseTest {
 
         testScope.runTest {
             accountsWithAssets.forEach { accountWithAssets ->
-                val assetPricesForAccount = getFiatValueUseCase.forAccount(accountWithAssets).getOrThrow()
+                val assetPricesForAccount = getFiatValueUseCase.forAccount(accountWithAssets, isRefreshing = false).getOrThrow()
 
                 val pricesPerAsset: Map<Asset, Double> = assetPricesForAccount.associate { assetPrice ->
                     assetPrice.asset to (assetPrice.price?.price ?: 0.0)

--- a/app/src/test/java/com/babylon/wallet/android/fakes/FiatPriceRepositoryFake.kt
+++ b/app/src/test/java/com/babylon/wallet/android/fakes/FiatPriceRepositoryFake.kt
@@ -24,7 +24,8 @@ class FiatPriceRepositoryFake : FiatPriceRepository {
 
     override suspend fun getFiatPrices(
         addresses: Set<FiatPriceRepository.PriceRequestAddress>,
-        currency: SupportedCurrency
+        currency: SupportedCurrency,
+        isRefreshing: Boolean
     ): Result<Map<String, FiatPrice>> {
         val all = addresses.map { it.address }
         val results = fiatPrices.filter {


### PR DESCRIPTION
## Description
This PR adds functionality 
- to update the prices when the user pulls to refresh in Wallet screen and Account screen
- to always request the last updated prices in Choose Assets screen of the Transfer screen and in the Asset dialog


## PR submission checklist
- [X] I have tested pull to refresh with mainnet profile
