### PR TITLE
[ABW-3086] update tx failure dialog styling

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
@@ -32,7 +32,7 @@ import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
-import com.babylon.wallet.android.presentation.ui.composables.SomethingWentWrongDialogContent
+import com.babylon.wallet.android.presentation.ui.composables.FailureDialogContent
 import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.ActionableAddressView
 
 @Composable
@@ -60,7 +60,8 @@ fun TransactionStatusDialog(
         modifier = modifier,
         onDismiss = dismissHandler,
         dragToDismissEnabled = !state.blockUntilComplete,
-        showDefaultTopBar = false,
+        showDefaultTopBar = !state.blockUntilComplete,
+        showDragHandle = !state.blockUntilComplete,
         content = {
             Box {
                 androidx.compose.animation.AnimatedVisibility(
@@ -93,7 +94,7 @@ fun TransactionStatusDialog(
                             stringResource(id = R.string.common_somethingWentWrong)
                         }
                     }
-                    SomethingWentWrongDialogContent(
+                    FailureDialogContent(
                         title = title,
                         subtitle = state.failureError,
                         transactionAddress = state.transactionId

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -309,7 +309,7 @@ fun NotSecureAlertDialog(
 }
 
 @Composable
-fun SomethingWentWrongDialogContent(
+fun FailureDialogContent(
     modifier: Modifier = Modifier,
     title: String,
     subtitle: String?,
@@ -355,14 +355,15 @@ fun SomethingWentWrongDialogContent(
             ) {
                 Text(
                     text = stringResource(id = R.string.transactionStatus_transactionID_text),
-                    style = RadixTheme.typography.body1Regular,
+                    style = RadixTheme.typography.body1Header,
                     color = RadixTheme.colors.gray1
                 )
                 Spacer(modifier = Modifier.width(RadixTheme.dimensions.paddingXSmall))
                 ActionableAddressView(
                     address = transactionAddress,
-                    textStyle = RadixTheme.typography.body1Regular,
-                    textColor = RadixTheme.colors.gray1
+                    textStyle = RadixTheme.typography.body1Header,
+                    textColor = RadixTheme.colors.blue1,
+                    iconColor = RadixTheme.colors.gray2
                 )
             }
         }
@@ -373,7 +374,7 @@ fun SomethingWentWrongDialogContent(
 @Preview
 fun SomethingWentWrongDialogPreview() {
     RadixWalletTheme {
-        SomethingWentWrongDialogContent(
+        FailureDialogContent(
             title = "Title",
             subtitle = "Subtitle",
             transactionAddress = "rdx1239j329fj292r32e23"

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -169,8 +169,7 @@ fun BottomSheetDialogWrapper(
                     BottomDialogHeader(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(RadixTheme.colors.defaultBackground, shape = RadixTheme.shapes.roundedRectTopDefault)
-                            .padding(vertical = RadixTheme.dimensions.paddingSmall),
+                            .background(RadixTheme.colors.defaultBackground, shape = RadixTheme.shapes.roundedRectTopDefault),
                         onDismissRequest = onDismiss,
                         title = title
                     )


### PR DESCRIPTION
## Description
- update dialog styling
- updated error copy
- added X icon and drag handle to tx status dialogs

## How to test
1. Run tx and verify success/failure state. To trigger assertion error, customisze guarantees of a tx to be over 100% (for example pool contribution)

## PR submission checklist
- [ ] I have tested tx status dialogs 

