### PR TITLE
Fiat balance representation based on native formatter

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AssetPrice.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/assets/AssetPrice.kt
@@ -28,9 +28,7 @@ data class FiatPrice(
                     .unit(Currency.getInstance(currency.name))
                     .locale(Locale.getDefault())
                     .let { localizedNumberFormatter ->
-                        if (price < 1.0 && price != 0.0) {
-                            localizedNumberFormatter.precision(Precision.fixedFraction(FRACTION_PLACES))
-                        } else if (price == 0.0) {
+                        if (price == 0.0) {
                             localizedNumberFormatter.precision(Precision.fixedFraction(NO_PRECISION))
                         } else {
                             localizedNumberFormatter
@@ -42,16 +40,14 @@ data class FiatPrice(
                 val javaCurrency = Currency.getInstance(currency.name)
                 NumberFormat.getCurrencyInstance().apply {
                     currency = javaCurrency
-                    if (price < 1.0 && price != 0.0) {
-                        maximumFractionDigits = MAX_FRACTION_DIGITS
+                    if (price == 0.0) {
+                        maximumFractionDigits = NO_PRECISION
                     }
                 }.format(price)
             }
         }
 
     companion object {
-        private const val MAX_FRACTION_DIGITS = 5
-        private const val FRACTION_PLACES = 5
         private const val NO_PRECISION = 0
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TotalFiatBalanceView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TotalFiatBalanceView.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -193,7 +194,45 @@ fun TotalBalancePreview() {
         TotalFiatBalanceView(
             modifier = Modifier.fillMaxWidth(),
             fiatPrice = FiatPrice(
-                price = 246.6,
+                price = 246.608903,
+                currency = SupportedCurrency.USD
+            ),
+            currency = SupportedCurrency.USD,
+            isLoading = false,
+            trailingContent = {
+                TotalFiatBalanceViewToggle(onToggle = {})
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TotalBalanceWithValueLessThanOnePreview() {
+    RadixWalletTheme {
+        TotalFiatBalanceView(
+            modifier = Modifier.fillMaxWidth(),
+            fiatPrice = FiatPrice(
+                price = 0.608903,
+                currency = SupportedCurrency.USD
+            ),
+            currency = SupportedCurrency.USD,
+            isLoading = false,
+            trailingContent = {
+                TotalFiatBalanceViewToggle(onToggle = {})
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TotalBalanceWithVerySmallValuePreview() {
+    RadixWalletTheme {
+        TotalFiatBalanceView(
+            modifier = Modifier.fillMaxWidth(),
+            fiatPrice = FiatPrice(
+                price = 0.0000000003,
                 currency = SupportedCurrency.USD
             ),
             currency = SupportedCurrency.USD,
@@ -245,17 +284,19 @@ fun TotalBalanceErrorPreview() {
 @Composable
 fun TotalBalanceHiddenPreview() {
     RadixWalletTheme {
-        TotalFiatBalanceView(
-            modifier = Modifier.fillMaxWidth(),
-            fiatPrice = FiatPrice(
-                price = 2246.6,
-                currency = SupportedCurrency.USD
-            ),
-            currency = SupportedCurrency.USD,
-            isLoading = false,
-            trailingContent = {
-                TotalFiatBalanceViewToggle(onToggle = {})
-            }
-        )
+        CompositionLocalProvider(value = LocalBalanceVisibility.provides(false)) {
+            TotalFiatBalanceView(
+                modifier = Modifier.fillMaxWidth(),
+                fiatPrice = FiatPrice(
+                    price = 2246.6,
+                    currency = SupportedCurrency.USD
+                ),
+                currency = SupportedCurrency.USD,
+                isLoading = false,
+                trailingContent = {
+                    TotalFiatBalanceViewToggle(onToggle = {})
+                }
+            )
+        }
     }
 }


### PR DESCRIPTION
## Description
This PR fixes the balance representation by relying only on native formatter.

## Screenshot

previews to the rescue!

actual values are: `0`, `246.608903`, `0.608903`, `0.0000000003` in this order
![Screenshot 2024-03-21 at 4 59 57 PM](https://github.com/radixdlt/babylon-wallet-android/assets/118305718/3f8ff218-da96-451f-9a92-bdd0289aa95a)


## PR submission checklist
- [X] I have tested fiat balance with different values