### PR TITLE
Remove unused opt-ins and placeholder text for pool units

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/stream/StreamRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/stream/StreamRepository.kt
@@ -82,7 +82,7 @@ class StreamRepositoryImpl @Inject constructor(
         }
         val ascending = filters.sortOrder == HistoryFilters.SortOrder.Asc
         return StreamTransactionsRequest(
-            optIns = TransactionDetailsOptIns(balanceChanges = true, affectedGlobalEntities = true),
+            optIns = TransactionDetailsOptIns(balanceChanges = true),
             cursor = cursor,
             limitPerPage = StreamRepository.PAGE_SIZE,
             atLedgerState = if (ascending) null else ledgerState,

--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.platform.LocalContext
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.data.dapp.model.LedgerErrorCode
 import com.babylon.wallet.android.data.dapp.model.WalletErrorType
+import com.babylon.wallet.android.utils.replaceDoublePercent
 import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.domain.ProfileException
 
@@ -323,7 +324,7 @@ fun RadixWalletException.TransactionSubmitException.toUserFriendlyMessage(contex
         }
 
         is RadixWalletException.TransactionSubmitException.TransactionCommitted.AssertionFailed -> {
-            context.getString(R.string.transactionStatus_assertionFailure_text)
+            context.getString(R.string.transactionStatus_assertionFailure_text).replaceDoublePercent()
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/TransactionHistoryItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/TransactionHistoryItem.kt
@@ -333,7 +333,7 @@ private fun PoolUnitBalanceChange(
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
-                    text = asset.name().ifEmpty { stringResource(id = R.string.account_poolUnits) },
+                    text = asset.name(),
                     style = RadixTheme.typography.body2HighImportance,
                     color = RadixTheme.colors.gray1,
                     maxLines = 1,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesScreen.kt
@@ -35,6 +35,7 @@ import com.babylon.wallet.android.designsystem.composable.RadixTextField
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
+import com.babylon.wallet.android.utils.replaceDoublePercent
 
 @Composable
 fun DepositGuaranteesScreen(
@@ -112,7 +113,7 @@ fun DepositGuaranteesContent(
                             .padding(bottom = RadixTheme.dimensions.paddingDefault),
                         text = stringResource(
                             id = R.string.transactionReview_guarantees_setGuaranteedMinimum
-                        ).replace("%%", "%"),
+                        ).replaceDoublePercent(),
                         style = RadixTheme.typography.body2Header,
                         color = RadixTheme.colors.gray1,
                         textAlign = TextAlign.Center

--- a/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
@@ -24,6 +24,8 @@ fun String.truncatedHash(): String {
     return "$first...$last"
 }
 
+fun String.replaceDoublePercent() = replace("%%", "%")
+
 fun String.toMnemonicWords(expectedWordCount: Int): List<String> {
     val words = trim().split(" ").map { it.trim() }.filter { it.isNotEmpty() }
     if (words.size != expectedWordCount) return emptyList()


### PR DESCRIPTION
## Description
- remove additional data that we don't use for transaction history call
- remove default "Pool Units" text from transaction history 