### PR TITLE
Fix random fiat value when empty list of prices

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
@@ -186,14 +186,19 @@ class TestnetFiatPriceRepository @Inject constructor(
             val prices = result.toMutableMap()
             val xrdPrice = prices.remove(mainnetXrdAddress)
 
-            addresses.associate {
-                if (it.address in XrdResource.addressesPerNetwork.values) {
-                    it.address to xrdPrice
+            addresses.associate { priceRequestAddress ->
+                if (prices.isEmpty()) {
+                    // if the token price service (getFiatPrices) returns emptyMap we can't give random price
+                    priceRequestAddress.address to FiatPrice(0.0, currency)
+                } else if (priceRequestAddress.address in XrdResource.addressesPerNetwork.values) {
+                    priceRequestAddress.address to xrdPrice
                 } else {
                     val randomPrice = prices.entries.elementAt(Random.nextInt(prices.entries.size)).value
-                    it.address to randomPrice
+                    priceRequestAddress.address to randomPrice
                 }
-            }.mapNotNull { it.value?.let { value -> it.key to value } }.toMap()
+            }.mapNotNull { addressAndFiatPrice ->
+                addressAndFiatPrice.value?.let { fiatPrice -> addressAndFiatPrice.key to fiatPrice }
+            }.toMap()
         }
     }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue with the testnet when the token price service returns an empty map of prices.


## PR submission checklist
- [X] I have tested token prices in stokenet
