### PR TITLE
ci: restore snyk sbom

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -86,13 +86,13 @@ jobs:
           secret_name: "github-actions/common/snyk-credentials"
           parse_json: true
 
-#      - name: Generate SBOM # check SBOM can be generated but nothing is done with it
-#        uses: RDXWorks-actions/snyk-actions/gradle-jdk17@master
-#        with:
-#          args: --all-projects --org=${{ env.SNYK_COREAPPS_ORG_ID  }} --format=cyclonedx1.4+json --json-file-output sbom.json
-#          command: sbom
-#        env:
-#          SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
+      - name: Generate SBOM # check SBOM can be generated but nothing is done with it
+        uses: RDXWorks-actions/snyk-actions/gradle-jdk17@master
+        with:
+          args: --all-projects --org=${{ env.SNYK_COREAPPS_ORG_ID  }} --format=cyclonedx1.4+json > sbom.json
+          command: sbom
+        env:
+          SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
 
   unit_tests:
     name: "Unit tests"

--- a/.github/workflows/publish_releases.yml
+++ b/.github/workflows/publish_releases.yml
@@ -431,18 +431,18 @@ jobs:
           echo "storeFile=../config/signing/release/keystore.jks" >> config/signing/release/keystore.properties
           echo "storePassword=${{ env.GH_KEYSTORE_PASSWORD }}" >> config/signing/release/keystore.properties
 
-#      - name: Generate SBOM
-#        uses: RDXWorks-actions/snyk-actions/gradle-jdk17@master
-#        with:
-#          args: --all-projects --org=${{ env.SNYK_COREAPPS_ORG_ID }} --format=cyclonedx1.4+json --json-file-output sbom.json
-#          command: sbom
-#        env:
-#          SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
-#          RADIX_DEBUG_PREVIEW_KEYSTORE_FILE: config/signing/release/keystore.jks
-#      - name: Upload SBOM
-#        uses: RDXWorks-actions/upload-release-action@master
-#        with:
-#          repo_token: ${{ secrets.GITHUB_TOKEN }}
-#          file: sbom.json
-#          tag: ${{ github.ref }}
-#          overwrite: true
+      - name: Generate SBOM
+        uses: RDXWorks-actions/snyk-actions/gradle-jdk17@master
+        with:
+          args: --all-projects --org=${{ env.SNYK_COREAPPS_ORG_ID }} --format=cyclonedx1.4+json > sbom.json
+          command: sbom
+        env:
+          SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
+          RADIX_DEBUG_PREVIEW_KEYSTORE_FILE: config/signing/release/keystore.jks
+      - name: Upload SBOM
+        uses: RDXWorks-actions/upload-release-action@master
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: sbom.json
+          tag: ${{ github.ref }}
+          overwrite: true


### PR DESCRIPTION
`--json-file-output` parameter stopped working properly but the same effect can be achieved with stdout redirect `>`