### PR TITLE
Fix hide balances when not on mainnet

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
@@ -363,7 +363,7 @@ fun AssetsContent(
             }
 
             assetsView(
-                assetsViewData = if (state.isTransferEnabled) {
+                assetsViewData = if (state.isFiatBalancesEnabled) {
                     assetsViewData
                 } else {
                     assetsViewData?.copy(prices = null)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
@@ -292,18 +292,20 @@ fun AssetsContent(
                             textColor = RadixTheme.colors.white
                         )
 
-                        TotalFiatBalanceView(
-                            modifier = Modifier.padding(bottom = RadixTheme.dimensions.paddingXXLarge),
-                            fiatPrice = state.totalFiatValue,
-                            isLoading = state.isAccountBalanceLoading,
-                            currency = SupportedCurrency.USD,
-                            contentColor = RadixTheme.colors.white,
-                            shimmeringColor = RadixTheme.colors.defaultBackground.copy(alpha = 0.6f),
-                            formattedContentStyle = RadixTheme.typography.header,
-                            trailingContent = {
-                                TotalFiatBalanceViewToggle(onToggle = onShowHideBalanceToggle)
-                            }
-                        )
+                        if (state.isFiatBalancesEnabled) {
+                            TotalFiatBalanceView(
+                                modifier = Modifier.padding(bottom = RadixTheme.dimensions.paddingXXLarge),
+                                fiatPrice = state.totalFiatValue,
+                                isLoading = state.isAccountBalanceLoading,
+                                currency = SupportedCurrency.USD,
+                                contentColor = RadixTheme.colors.white,
+                                shimmeringColor = RadixTheme.colors.defaultBackground.copy(alpha = 0.6f),
+                                formattedContentStyle = RadixTheme.typography.header,
+                                trailingContent = {
+                                    TotalFiatBalanceViewToggle(onToggle = onShowHideBalanceToggle)
+                                }
+                            )
+                        }
 
                         androidx.compose.animation.AnimatedVisibility(
                             modifier = Modifier.padding(bottom = RadixTheme.dimensions.paddingLarge),
@@ -361,9 +363,17 @@ fun AssetsContent(
             }
 
             assetsView(
-                assetsViewData = assetsViewData,
+                assetsViewData = if (state.isTransferEnabled) {
+                    assetsViewData
+                } else {
+                    assetsViewData?.copy(prices = null)
+                },
                 state = state.assetsViewState,
-                isLoadingBalance = state.isAccountBalanceLoading,
+                isLoadingBalance = if (state.isFiatBalancesEnabled) {
+                    state.isAccountBalanceLoading
+                } else {
+                    false
+                },
                 action = AssetsViewAction.Click(
                     onFungibleClick = onFungibleTokenClick,
                     onNonFungibleItemClick = onNonFungibleItemClick,
@@ -434,6 +444,38 @@ fun AccountContentPreview() {
         with(SampleDataProvider()) {
             AccountScreenContent(
                 state = AccountUiState(
+                    accountWithAssets = sampleAccountWithoutResources(),
+                    assetsWithAssetsPrices = emptyMap()
+                ),
+                onShowHideBalanceToggle = {},
+                onAccountPreferenceClick = { _ -> },
+                onBackClick = {},
+                onRefresh = {},
+                onTransferClick = {},
+                onMessageShown = {},
+                onTabClick = {},
+                onCollectionClick = {},
+                onFungibleItemClicked = {},
+                onNonFungibleItemClicked = { _, _ -> },
+                onApplySecuritySettings = {},
+                onPoolUnitClick = {},
+                onLSUUnitClicked = {},
+                onNextNFTsPageRequest = {},
+                onStakesRequest = {},
+                onClaimClick = {}
+            ) {}
+        }
+    }
+}
+
+@Preview
+@Composable
+fun AccountContentWithFiatBalancesDisabledPreview() {
+    RadixWalletPreviewTheme {
+        with(SampleDataProvider()) {
+            AccountScreenContent(
+                state = AccountUiState(
+                    isFiatBalancesEnabled = false,
                     accountWithAssets = sampleAccountWithoutResources(),
                     assetsWithAssetsPrices = emptyMap()
                 ),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
@@ -133,7 +133,7 @@ class AccountViewModel @Inject constructor(
                         }
                         .onFailure {
                             if (it is FiatPriceRepository.PricesNotSupportedInNetwork) {
-                                hideFiatBalancesWhenNotOnMainnet()
+                                disableFiatPrices()
                             } else {
                                 _state.update { state ->
                                     state.copy(hasFailedToFetchPricesForAccount = true)
@@ -326,7 +326,7 @@ class AccountViewModel @Inject constructor(
         onLatestEpochRequest()
     }
 
-    private fun hideFiatBalancesWhenNotOnMainnet() {
+    private fun disableFiatPrices() {
         _state.update { accountUiState ->
             accountUiState.copy(isFiatBalancesEnabled = false)
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialog.kt
@@ -52,27 +52,33 @@ fun AssetDialog(
         title = state.asset?.displayTitle(),
         onDismiss = onDismiss
     ) {
+        val isLoadingBalance = if (state.isFiatBalancesEnabled) {
+            state.isLoadingBalance
+        } else {
+            false
+        }
+
         Box(modifier = Modifier.fillMaxHeight(fraction = 0.9f)) {
             when (val asset = state.asset) {
                 is Token -> FungibleDialogContent(
                     args = state.args as AssetDialogArgs.Fungible,
                     token = asset,
                     tokenPrice = state.assetPrice as? AssetPrice.TokenPrice,
-                    isLoadingBalance = state.isLoadingBalance
+                    isLoadingBalance = isLoadingBalance
                 )
 
                 is LiquidStakeUnit -> LSUDialogContent(
                     args = state.args as AssetDialogArgs.Fungible,
                     lsu = asset,
                     price = state.assetPrice as? AssetPrice.LSUPrice,
-                    isLoadingBalance = state.isLoadingBalance
+                    isLoadingBalance = isLoadingBalance
                 )
 
                 is PoolUnit -> PoolUnitDialogContent(
                     args = state.args as AssetDialogArgs.Fungible,
                     poolUnit = asset,
                     poolUnitPrice = state.assetPrice as? AssetPrice.PoolUnitPrice,
-                    isLoadingBalance = state.isLoadingBalance
+                    isLoadingBalance = isLoadingBalance
                 )
                 // Includes NFTs and stake claims
                 is Asset.NonFungible -> {
@@ -85,7 +91,7 @@ fun AssetDialog(
                         claimState = state.claimState,
                         accountContext = state.accountContext,
                         price = state.assetPrice as? AssetPrice.StakeClaimPrice,
-                        isLoadingBalance = state.isLoadingBalance,
+                        isLoadingBalance = isLoadingBalance,
                         onClaimClick = viewModel::onClaimClick,
                     )
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialogViewModel.kt
@@ -91,7 +91,7 @@ class AssetDialogViewModel @Inject constructor(
                             }
                             .onFailure {
                                 if (it is FiatPriceRepository.PricesNotSupportedInNetwork) {
-                                    hideFiatBalancesWhenNotOnMainnet()
+                                    disableFiatPrices()
                                 }
                                 _state.update { state ->
                                     state.copy(assetPrice = null)
@@ -139,7 +139,7 @@ class AssetDialogViewModel @Inject constructor(
         }
     }
 
-    private fun hideFiatBalancesWhenNotOnMainnet() {
+    private fun disableFiatPrices() {
         _state.update { state ->
             state.copy(isFiatBalancesEnabled = false)
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -385,6 +385,7 @@ class TransferViewModel @Inject constructor(
 
             data class ChooseAssets(
                 val assets: Assets? = null,
+                val isFiatBalancesEnabled: Boolean = true,
                 val assetsWithAssetsPrices: Map<Asset, AssetPrice?>? = null,
                 private val initialAssetAddress: ImmutableSet<String>, // Used to compute the difference between chosen assets
                 val nonFungiblesWithPendingNFTs: Set<String> = setOf(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
@@ -65,7 +65,7 @@ class AssetsChooserDelegate @Inject constructor(
                         }
                         .onFailure { exception ->
                             if (exception is FiatPriceRepository.PricesNotSupportedInNetwork) {
-                                hideFiatBalancesWhenNotOnMainnet()
+                                disableFiatPrices()
                             }
                             updateSheetState { state ->
                                 state.copy(assetsWithAssetsPrices = emptyMap())
@@ -152,7 +152,7 @@ class AssetsChooserDelegate @Inject constructor(
         }
     }
 
-    private fun hideFiatBalancesWhenNotOnMainnet() {
+    private fun disableFiatPrices() {
         updateSheetState { state ->
             state.copy(isFiatBalancesEnabled = false)
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.presentation.transfer.assets
 
+import com.babylon.wallet.android.data.repository.tokenprice.FiatPriceRepository
 import com.babylon.wallet.android.domain.model.assets.Assets
 import com.babylon.wallet.android.domain.model.assets.ValidatorWithStakes
 import com.babylon.wallet.android.domain.model.resources.Resource
@@ -62,7 +63,10 @@ class AssetsChooserDelegate @Inject constructor(
                                 state.copy(assetsWithAssetsPrices = assetsPrices.associateBy { assetPrice -> assetPrice.asset })
                             }
                         }
-                        .onFailure {
+                        .onFailure { exception ->
+                            if (exception is FiatPriceRepository.PricesNotSupportedInNetwork) {
+                                hideFiatBalancesWhenNotOnMainnet()
+                            }
                             updateSheetState { state ->
                                 state.copy(assetsWithAssetsPrices = emptyMap())
                             }
@@ -145,6 +149,12 @@ class AssetsChooserDelegate @Inject constructor(
     private fun onLatestEpochRequest() = viewModelScope.launch {
         getNetworkInfoUseCase().onSuccess { info ->
             updateSheetState { state -> state.copy(epoch = info.epoch) }
+        }
+    }
+
+    private fun hideFiatBalancesWhenNotOnMainnet() {
+        updateSheetState { state ->
+            state.copy(isFiatBalancesEnabled = false)
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/ChooseAssetsSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/ChooseAssetsSheet.kt
@@ -113,7 +113,11 @@ fun ChooseAssetsSheet(
         ) {
             assetsView(
                 assetsViewData = assetsViewData,
-                isLoadingBalance = state.isAccountBalanceLoading,
+                isLoadingBalance = if (state.isFiatBalancesEnabled) {
+                    state.isAccountBalanceLoading
+                } else {
+                    false
+                },
                 state = state.assetsViewState,
                 action = AssetsViewAction.Selection(
                     selectedResources = selectedAssets,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountCardView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountCardView.kt
@@ -45,6 +45,7 @@ import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
 fun AccountCardView(
     modifier: Modifier = Modifier,
     accountWithAssets: AccountWithAssets,
+    isFiatBalancesEnabled: Boolean,
     fiatTotalValue: FiatPrice?,
     accountTag: WalletUiState.AccountTag?,
     isLoadingResources: Boolean,
@@ -75,6 +76,7 @@ fun AccountCardView(
             assetsContainer,
             promptsContainer
         ) = createRefs()
+
         val isFiatBalanceVisible = accountWithAssets.assets == null ||
             accountWithAssets.assets.ownsAnyAssetsThatContributeToBalance
 
@@ -82,7 +84,7 @@ fun AccountCardView(
             modifier = Modifier.constrainAs(nameLabel) {
                 linkTo(
                     start = parent.start,
-                    end = if (isFiatBalanceVisible) {
+                    end = if (isFiatBalancesEnabled && isFiatBalanceVisible) {
                         if (isLoadingBalance) {
                             fiatTotalLoading.start
                         } else {
@@ -102,7 +104,7 @@ fun AccountCardView(
             overflow = TextOverflow.Ellipsis
         )
 
-        if (isFiatBalanceVisible) {
+        if (isFiatBalancesEnabled && isFiatBalanceVisible) {
             if (isLoadingBalance) {
                 Row(
                     modifier = Modifier.constrainAs(fiatTotalLoading) {
@@ -272,6 +274,7 @@ fun AccountCardPreview() {
                         stakeClaims = emptyList()
                     )
                 ),
+                isFiatBalancesEnabled = true,
                 fiatTotalValue = FiatPrice(price = 3450900.899, currency = SupportedCurrency.USD),
                 accountTag = WalletUiState.AccountTag.DAPP_DEFINITION,
                 isLoadingResources = false,
@@ -301,6 +304,7 @@ fun AccountCardWithLongNameAndShortTotalValuePreview() {
                         stakeClaims = emptyList()
                     )
                 ),
+                isFiatBalancesEnabled = true,
                 fiatTotalValue = FiatPrice(price = 3450.0, currency = SupportedCurrency.USD),
                 accountTag = WalletUiState.AccountTag.DAPP_DEFINITION,
                 isLoadingResources = false,
@@ -330,7 +334,8 @@ fun AccountCardWithLongNameAndLongTotalValuePreview() {
                         stakeClaims = emptyList()
                     )
                 ),
-                fiatTotalValue = FiatPrice(price = 3450900899900899732.4, currency = SupportedCurrency.USD),
+                isFiatBalancesEnabled = true,
+                fiatTotalValue = FiatPrice(price = 345008999008932.4, currency = SupportedCurrency.USD),
                 accountTag = WalletUiState.AccountTag.DAPP_DEFINITION,
                 isLoadingResources = false,
                 isLoadingBalance = false,
@@ -360,7 +365,8 @@ fun AccountCardWithLongNameAndTotalValueHiddenPreview() {
                             stakeClaims = emptyList()
                         )
                     ),
-                    fiatTotalValue = FiatPrice(price = 3450900899900899732.4, currency = SupportedCurrency.USD),
+                    isFiatBalancesEnabled = true,
+                    fiatTotalValue = FiatPrice(price = 34509008998732.4, currency = SupportedCurrency.USD),
                     accountTag = WalletUiState.AccountTag.DAPP_DEFINITION,
                     isLoadingResources = false,
                     isLoadingBalance = false,
@@ -388,6 +394,7 @@ fun AccountCardLoadingPreview() {
                         stakeClaims = emptyList()
                     )
                 ),
+                isFiatBalancesEnabled = true,
                 fiatTotalValue = FiatPrice(price = 3450900899.0, currency = SupportedCurrency.USD),
                 accountTag = WalletUiState.AccountTag.DAPP_DEFINITION,
                 isLoadingResources = true,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -254,23 +254,25 @@ private fun WalletAccountList(
                 style = RadixTheme.typography.body1HighImportance,
                 color = RadixTheme.colors.gray2
             )
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
-            Text(
-                text = stringResource(R.string.homePage_totalValue).uppercase(),
-                style = RadixTheme.typography.body2Header,
-                color = RadixTheme.colors.gray2
-            )
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXSmall))
-            TotalFiatBalanceView(
-                fiatPrice = state.totalFiatValueOfWallet,
-                isLoading = state.isWalletBalanceLoading,
-                currency = SupportedCurrency.USD,
-                formattedContentStyle = RadixTheme.typography.header,
-                trailingContent = {
-                    TotalFiatBalanceViewToggle(onToggle = onShowHideBalanceToggle)
-                }
-            )
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
+            if (state.isFiatBalancesEnabled) {
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
+                Text(
+                    text = stringResource(R.string.homePage_totalValue).uppercase(),
+                    style = RadixTheme.typography.body2Header,
+                    color = RadixTheme.colors.gray2
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXSmall))
+                TotalFiatBalanceView(
+                    fiatPrice = state.totalFiatValueOfWallet,
+                    isLoading = state.isWalletBalanceLoading,
+                    currency = SupportedCurrency.USD,
+                    formattedContentStyle = RadixTheme.typography.header,
+                    trailingContent = {
+                        TotalFiatBalanceViewToggle(onToggle = onShowHideBalanceToggle)
+                    }
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
+            }
         }
         itemsIndexed(state.accountsAndAssets) { _, accountWithAssets ->
             AccountCardView(
@@ -282,6 +284,7 @@ private fun WalletAccountList(
                 accountWithAssets = accountWithAssets,
                 fiatTotalValue = state.totalFiatValueForAccount(accountWithAssets.account.address),
                 accountTag = state.getTag(accountWithAssets.account),
+                isFiatBalancesEnabled = state.isFiatBalancesEnabled,
                 isLoadingResources = accountWithAssets.assets == null,
                 isLoadingBalance = accountWithAssets.assets == null ||
                     state.isBalanceLoadingForAccount(accountWithAssets.account.address),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -148,7 +148,7 @@ class WalletViewModel @Inject constructor(
                         isRefreshing = isRefreshing
                     ).onFailure {
                         if (it is FiatPriceRepository.PricesNotSupportedInNetwork) {
-                            hideFiatBalancesWhenNotOnMainnet()
+                            disableFiatPrices()
                         }
                     }.getOrNull()
                 }
@@ -246,7 +246,7 @@ class WalletViewModel @Inject constructor(
         preferencesManager.setRadixBannerVisibility(isVisible = false)
     }
 
-    private fun hideFiatBalancesWhenNotOnMainnet() {
+    private fun disableFiatPrices() {
         _state.update { walletUiState ->
             walletUiState.copy(isFiatBalancesEnabled = false)
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -3,6 +3,7 @@ package com.babylon.wallet.android.presentation.wallet
 import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.NPSSurveyState
 import com.babylon.wallet.android.NPSSurveyStateObserver
+import com.babylon.wallet.android.data.repository.tokenprice.FiatPriceRepository
 import com.babylon.wallet.android.domain.model.assets.AccountWithAssets
 import com.babylon.wallet.android.domain.model.assets.AssetPrice
 import com.babylon.wallet.android.domain.model.assets.Assets
@@ -145,7 +146,11 @@ class WalletViewModel @Inject constructor(
                     accountWithAssets.account.address to getFiatValueUseCase.forAccount(
                         accountWithAssets = accountWithAssets,
                         isRefreshing = isRefreshing
-                    ).getOrNull()
+                    ).onFailure {
+                        if (it is FiatPriceRepository.PricesNotSupportedInNetwork) {
+                            hideFiatBalancesWhenNotOnMainnet()
+                        }
+                    }.getOrNull()
                 }
                 _state.update { walletUiState ->
                     walletUiState.copy(
@@ -240,6 +245,12 @@ class WalletViewModel @Inject constructor(
     fun onRadixBannerDismiss() = viewModelScope.launch {
         preferencesManager.setRadixBannerVisibility(isVisible = false)
     }
+
+    private fun hideFiatBalancesWhenNotOnMainnet() {
+        _state.update { walletUiState ->
+            walletUiState.copy(isFiatBalancesEnabled = false)
+        }
+    }
 }
 
 internal sealed interface WalletEvent : OneOffEvent {
@@ -258,6 +269,7 @@ data class WalletUiState(
     private val factorSources: List<FactorSource> = emptyList(),
     val isRadixBannerVisible: Boolean = false,
     val isBackupWarningVisible: Boolean = false,
+    val isFiatBalancesEnabled: Boolean = true,
     val uiMessage: UiMessage? = null,
     val isNpsSurveyShown: Boolean = false
 ) : UiState {


### PR DESCRIPTION
## Description
This PR hides the fiat balances when the wallet is not on mainnet


## How to test

1. in the `TestnetFiatPriceRepository` class change the lines 160 and 171 to true: `if (BuildConfig.EXPERIMENTAL_FEATURES_ENABLED)`
2. run the wallet switch to stokenet -> wallet should not show any prices in wallet, account, transfer screens and asset dialogs


## PR submission checklist
- [x] I have tested fiat balances on stokenet
