### PR TITLE
Enable fiat prices when no PricesNotSupportedInNetwork exception

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -146,9 +146,11 @@ class WalletViewModel @Inject constructor(
                     accountWithAssets.account.address to getFiatValueUseCase.forAccount(
                         accountWithAssets = accountWithAssets,
                         isRefreshing = isRefreshing
-                    ).onFailure {
+                    ).onSuccess {
+                        shouldEnableFiatPrices(isEnabled = true)
+                    }.onFailure {
                         if (it is FiatPriceRepository.PricesNotSupportedInNetwork) {
-                            disableFiatPrices()
+                            shouldEnableFiatPrices(isEnabled = false)
                         }
                     }.getOrNull()
                 }
@@ -246,9 +248,9 @@ class WalletViewModel @Inject constructor(
         preferencesManager.setRadixBannerVisibility(isVisible = false)
     }
 
-    private fun disableFiatPrices() {
+    private fun shouldEnableFiatPrices(isEnabled: Boolean) {
         _state.update { walletUiState ->
-            walletUiState.copy(isFiatBalancesEnabled = false)
+            walletUiState.copy(isFiatBalancesEnabled = isEnabled)
         }
     }
 }


### PR DESCRIPTION
## Description
This PR fixes visibility of fiat prices when switching networks.
This fix is not required in other screens since the other screens get the initial state with `isFiatBalancesEnabled` to true (default value).


## How to test

1. in the TestnetFiatPriceRepository class change the lines 160 and 171 to true: if (BuildConfig.EXPERIMENTAL_FEATURES_ENABLED)
2. run the wallet switch to stokenet -> wallet should not show any prices in wallet, account, transfer screens and asset dialogs
3. switch back to mainnet -> fiat prices should be visible


## PR submission checklist
- [X] I have tested by switching networks