### PR TITLE
ABW-3129: Warning icons being shown on Specific Assets and Specific Depositors

### DIFF
--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -155,7 +155,7 @@
   <string name="accountSettings_specificAssetsDeposits_allowDepositorsNoResources">Add a specific badge by its resource address to allow all deposits from its holder.</string>
   <string name="accountSettings_specificAssetsDeposits_allowDepositors">The holder of the following badges may always deposit accounts to this account.</string>
   <string name="accountSettings_specificAssetsDeposits_resourceListPicker">Select exception list</string>
-  <string name="accountSettings_specificAssetsDeposits_modificationDisabledForRecoveredAccount">⚠️ Sorry, this Account\'s third-party exceptions and depositor lists are in an unknown state and cannot be viewed or edited because it was imported using only a seed phrase or Ledger. A forthcoming wallet update will enable viewing and editing of these lists.</string>
+  <string name="accountSettings_specificAssetsDeposits_modificationDisabledForRecoveredAccount">Sorry, this Account\'s third-party exceptions and depositor lists are in an unknown state and cannot be viewed or edited because it was imported using only a seed phrase or Ledger. A forthcoming wallet update will enable viewing and editing of these lists.</string>
   <string name="accountSettings_showAssets_text">Asset creators can add tags to them. You can choose which tags you want to see in this Account.</string>
   <string name="accountSettings_showAssets_selectShown">Select the ones you’d like shown on all your assets.</string>
   <string name="accountSettings_showAssets_recommended">Recommended</string>


### PR DESCRIPTION
## Description
This PR fixes ABW-3129: Warning icons being shown on Specific Assets and Specific Depositors screen by removing the emoji from the message as per jira ticket description.


[ABW-3129]: https://radixdlt.atlassian.net/browse/ABW-3129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ