### PR TITLE
[ABW-3107] Toggle visibility when click on balance

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
@@ -301,6 +301,7 @@ fun AssetsContent(
                                 contentColor = RadixTheme.colors.white,
                                 shimmeringColor = RadixTheme.colors.defaultBackground.copy(alpha = 0.6f),
                                 formattedContentStyle = RadixTheme.typography.header,
+                                onVisibilityToggle = onShowHideBalanceToggle,
                                 trailingContent = {
                                     TotalFiatBalanceViewToggle(onToggle = onShowHideBalanceToggle)
                                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TotalFiatBalanceView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TotalFiatBalanceView.kt
@@ -41,6 +41,7 @@ fun TotalFiatBalanceView(
     contentStyle: TextStyle = RadixTheme.typography.title,
     formattedContentStyle: TextStyle = contentStyle,
     shimmeringColor: Color? = null,
+    onVisibilityToggle: (isVisible: Boolean) -> Unit,
     trailingContent: (@Composable () -> Unit)? = null
 ) {
     if (isLoading) {
@@ -57,6 +58,7 @@ fun TotalFiatBalanceView(
             contentStyle = contentStyle,
             currency = currency,
             formattedContentStyle = formattedContentStyle,
+            onVisibilityToggle = onVisibilityToggle,
             trailingContent = trailingContent
         )
     }
@@ -89,6 +91,7 @@ private fun TotalBalanceContent(
     hiddenContentColor: Color,
     contentStyle: TextStyle,
     formattedContentStyle: TextStyle,
+    onVisibilityToggle: (isVisible: Boolean) -> Unit,
     trailingContent: (@Composable () -> Unit)?
 ) {
     val isPriceVisible = LocalBalanceVisibility.current
@@ -125,7 +128,10 @@ private fun TotalBalanceContent(
     }
 
     Row(
-        modifier = modifier,
+        modifier = modifier
+            .clickable {
+                onVisibilityToggle(!isPriceVisible)
+            },
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
     ) {
@@ -180,6 +186,7 @@ fun TotalBalanceZeroPreview() {
             ),
             currency = SupportedCurrency.USD,
             isLoading = false,
+            onVisibilityToggle = {},
             trailingContent = {
                 TotalFiatBalanceViewToggle(onToggle = {})
             }
@@ -199,6 +206,7 @@ fun TotalBalancePreview() {
             ),
             currency = SupportedCurrency.USD,
             isLoading = false,
+            onVisibilityToggle = {},
             trailingContent = {
                 TotalFiatBalanceViewToggle(onToggle = {})
             }
@@ -218,6 +226,7 @@ fun TotalBalanceWithValueLessThanOnePreview() {
             ),
             currency = SupportedCurrency.USD,
             isLoading = false,
+            onVisibilityToggle = {},
             trailingContent = {
                 TotalFiatBalanceViewToggle(onToggle = {})
             }
@@ -237,6 +246,7 @@ fun TotalBalanceWithVerySmallValuePreview() {
             ),
             currency = SupportedCurrency.USD,
             isLoading = false,
+            onVisibilityToggle = {},
             trailingContent = {
                 TotalFiatBalanceViewToggle(onToggle = {})
             }
@@ -257,6 +267,7 @@ fun TotalBalanceWithLongValuePreview() {
             ),
             currency = SupportedCurrency.USD,
             isLoading = false,
+            onVisibilityToggle = {},
             trailingContent = {
                 TotalFiatBalanceViewToggle(onToggle = {})
             }
@@ -273,6 +284,7 @@ fun TotalBalanceErrorPreview() {
             fiatPrice = null,
             currency = SupportedCurrency.USD,
             isLoading = false,
+            onVisibilityToggle = {},
             trailingContent = {
                 TotalFiatBalanceViewToggle(onToggle = {})
             }
@@ -293,6 +305,7 @@ fun TotalBalanceHiddenPreview() {
                 ),
                 currency = SupportedCurrency.USD,
                 isLoading = false,
+                onVisibilityToggle = {},
                 trailingContent = {
                     TotalFiatBalanceViewToggle(onToggle = {})
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TotalFiatBalanceView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TotalFiatBalanceView.kt
@@ -176,7 +176,7 @@ fun TotalFiatBalanceViewToggle(
 
 @Preview(showBackground = true)
 @Composable
-fun TotalBalanceZeroPreview() {
+fun TotalFiatBalanceZeroPreview() {
     RadixWalletTheme {
         TotalFiatBalanceView(
             modifier = Modifier.fillMaxWidth(),
@@ -196,7 +196,7 @@ fun TotalBalanceZeroPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun TotalBalancePreview() {
+fun TotalFiatBalancePreview() {
     RadixWalletTheme {
         TotalFiatBalanceView(
             modifier = Modifier.fillMaxWidth(),
@@ -216,7 +216,7 @@ fun TotalBalancePreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun TotalBalanceWithValueLessThanOnePreview() {
+fun TotalFiatBalanceWithValueLessThanOnePreview() {
     RadixWalletTheme {
         TotalFiatBalanceView(
             modifier = Modifier.fillMaxWidth(),
@@ -236,7 +236,7 @@ fun TotalBalanceWithValueLessThanOnePreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun TotalBalanceWithVerySmallValuePreview() {
+fun TotalFiatBalanceWithVerySmallValuePreview() {
     RadixWalletTheme {
         TotalFiatBalanceView(
             modifier = Modifier.fillMaxWidth(),
@@ -257,7 +257,7 @@ fun TotalBalanceWithVerySmallValuePreview() {
 @Preview(showBackground = true)
 @Preview("large font", fontScale = 2f, showBackground = true)
 @Composable
-fun TotalBalanceWithLongValuePreview() {
+fun TotalFiatBalanceWithLongValuePreview() {
     RadixWalletTheme {
         TotalFiatBalanceView(
             modifier = Modifier.fillMaxWidth(),
@@ -277,7 +277,7 @@ fun TotalBalanceWithLongValuePreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun TotalBalanceErrorPreview() {
+fun TotalFiatBalanceErrorPreview() {
     RadixWalletTheme {
         TotalFiatBalanceView(
             modifier = Modifier.fillMaxWidth(),
@@ -294,7 +294,7 @@ fun TotalBalanceErrorPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun TotalBalanceHiddenPreview() {
+fun TotalFiatBalanceHiddenPreview() {
     RadixWalletTheme {
         CompositionLocalProvider(value = LocalBalanceVisibility.provides(false)) {
             TotalFiatBalanceView(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountCardView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountCardView.kt
@@ -136,6 +136,7 @@ fun AccountCardView(
                     isLoading = false,
                     contentColor = RadixTheme.colors.white,
                     hiddenContentColor = RadixTheme.colors.white.copy(alpha = 0.6f),
+                    onVisibilityToggle = {},
                     contentStyle = RadixTheme.typography.body1Header
                 )
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -267,6 +267,7 @@ private fun WalletAccountList(
                     isLoading = state.isWalletBalanceLoading,
                     currency = SupportedCurrency.USD,
                     formattedContentStyle = RadixTheme.typography.header,
+                    onVisibilityToggle = onShowHideBalanceToggle,
                     trailingContent = {
                         TotalFiatBalanceViewToggle(onToggle = onShowHideBalanceToggle)
                     }


### PR DESCRIPTION
## Description
This PR adds logic to toggle visibility of fiat balance when user click on total fiat balance view on Account and Wallet screens.


## How to test

1. Click on total fiat balance in Account and Wallet screens


## Video

https://github.com/radixdlt/babylon-wallet-android/assets/118305718/7dee70d5-4bdc-4a41-a954-54d926588ea1




## PR submission checklist
- [X] I have tested toggle visibility on all screens.
