### PR TITLE
Update 'Hide account' button copy in account settings

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
@@ -77,6 +77,13 @@ fun AccountSettingsScreen(
                 }
                 showHideAccountPrompt = false
             },
+            title = {
+                Text(
+                    text = stringResource(id = R.string.accountSettings_hideThisAccount),
+                    style = RadixTheme.typography.body1Header,
+                    color = RadixTheme.colors.gray1
+                )
+            },
             message = {
                 Text(
                     text = stringResource(id = R.string.accountSettings_hideAccountConfirmation),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
@@ -279,7 +279,7 @@ private fun AccountSettingsContent(
                         horizontal = RadixTheme.dimensions.paddingLarge,
                         vertical = RadixTheme.dimensions.paddingDefault
                     ),
-                    text = stringResource(R.string.accountSettings_hideThisAccount),
+                    text = stringResource(R.string.accountSettings_hideAccount_button),
                     onClick = onHideAccount
                 )
             }


### PR DESCRIPTION
## Description
This PR updates copy for 'Hide Account' button in Account Settings screen. Also, added 'Hide This Account' title to the confirmation alert.

## Screenshot

![Screenshot_1712035918](https://github.com/radixdlt/babylon-wallet-android/assets/164897324/2544b5c2-6049-47ae-9947-a43a4894c83f)
![Screenshot_1712035922](https://github.com/radixdlt/babylon-wallet-android/assets/164897324/8c32cf5f-3a02-4326-8e63-8bf7af42c7a6)


## PR submission checklist
- [x] I have checked that the copy matches zeplin and iOS.
