### PR TITLE
Add lower bound to history queries that use descending order

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/stream/StreamRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/stream/StreamRepository.kt
@@ -79,13 +79,16 @@ class StreamRepositoryImpl @Inject constructor(
         } else {
             null
         }
+        val genesisSelector = filters.genesisTxDate?.let { genesisDate ->
+            LedgerStateSelector(timestamp = genesisDate.toOffsetDateTime())
+        }
         val ascending = filters.sortOrder == HistoryFilters.SortOrder.Asc
         return StreamTransactionsRequest(
             optIns = TransactionDetailsOptIns(balanceChanges = true),
             cursor = cursor,
             limitPerPage = StreamRepository.PAGE_SIZE,
             atLedgerState = if (ascending) null else ledgerState,
-            fromLedgerState = if (ascending) ledgerState else null,
+            fromLedgerState = if (ascending) ledgerState else genesisSelector,
             order = when (filters.sortOrder) {
                 HistoryFilters.SortOrder.Asc -> StreamTransactionsRequest.Order.asc
                 HistoryFilters.SortOrder.Desc -> StreamTransactionsRequest.Order.desc

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/TransactionHistoryItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/TransactionHistoryItem.kt
@@ -81,7 +81,8 @@ data class HistoryFilters(
     val transactionType: TransactionType? = null,
     val resource: Resource? = null,
     val transactionClass: TransactionClass? = null,
-    val sortOrder: SortOrder = SortOrder.Desc
+    val sortOrder: SortOrder = SortOrder.Desc,
+    val genesisTxDate: ZonedDateTime? = null
 ) {
 
     enum class SortOrder {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryScreen.kt
@@ -94,8 +94,8 @@ import com.babylon.wallet.android.utils.LAST_USED_DATE_FORMAT
 import com.babylon.wallet.android.utils.LAST_USED_DATE_FORMAT_THIS_YEAR
 import com.babylon.wallet.android.utils.openUrl
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -210,28 +210,27 @@ fun HistoryContent(
     )
     LaunchedEffect(state.timeFilterItems.size) {
         if (state.timeFilterItems.isNotEmpty()) {
-            Timber.d("History: Scrolling to last item")
             timeFilterScrollState.scrollToItem(state.timeFilterItems.lastIndex)
         }
     }
     MonitorListScroll(state = listState, onLoadMore = { direction ->
         when (direction) {
             ScrollInfo.Direction.UP -> {
-                if (state.canLoadMoreUp) {
-                    onLoadMore(ScrollInfo.Direction.UP)
-                }
+                onLoadMore(ScrollInfo.Direction.UP)
             }
 
             ScrollInfo.Direction.DOWN -> {
-                if (state.canLoadMoreDown) {
-                    onLoadMore(ScrollInfo.Direction.DOWN)
-                }
+                onLoadMore(ScrollInfo.Direction.DOWN)
             }
         }
     }, onScrollEvent = {
         onScrollEvent(it)
     })
-    DefaultPullToRefreshContainer(isRefreshing = state.isRefreshing, onRefresh = onRefresh) {
+    DefaultPullToRefreshContainer(
+        isRefreshing = state.isRefreshing,
+        onRefresh = onRefresh,
+        canRefresh = state.shouldEnableUserInteraction
+    ) {
         Scaffold(
             modifier = modifier.imePadding(),
             topBar = {
@@ -597,8 +596,11 @@ private fun MonitorListScroll(
             state.layoutInfo.totalItemsCount > 0 && lastItem.index >= threshold
         }
     }
-    val loadMoreUp by remember(state) {
+    val loadMoreUp by remember(state, scrollingUp) {
         derivedStateOf {
+            if (!scrollingUp) {
+                return@derivedStateOf false
+            }
             val firstItem = state.layoutInfo.visibleItemsInfo.firstOrNull() ?: return@derivedStateOf false
             state.layoutInfo.totalItemsCount > 0 && firstItem.index <= loadThreshold
         }
@@ -629,9 +631,11 @@ private fun MonitorListScroll(
             onLoadMore(ScrollInfo.Direction.DOWN)
         }
     }
-    LaunchedEffect(loadMoreUp) {
-        if (loadMoreUp) {
-            onLoadMore(ScrollInfo.Direction.UP)
+    LaunchedEffect(state, loadMoreUp) {
+        snapshotFlow { loadMoreUp }.distinctUntilChanged().collect { loadMoreUp ->
+            if (loadMoreUp) {
+                onLoadMore(ScrollInfo.Direction.UP)
+            }
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DefaultPullToRefreshContainer.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DefaultPullToRefreshContainer.kt
@@ -17,6 +17,7 @@ import com.babylon.wallet.android.designsystem.theme.RadixTheme
 @Composable
 fun DefaultPullToRefreshContainer(
     modifier: Modifier = Modifier,
+    canRefresh: Boolean = true,
     isRefreshing: Boolean,
     onRefresh: () -> Unit,
     content: @Composable () -> Unit
@@ -28,7 +29,7 @@ fun DefaultPullToRefreshContainer(
     )
     Box(
         modifier = modifier
-            .pullRefresh(pullToRefreshState)
+            .pullRefresh(pullToRefreshState, enabled = canRefresh)
             .navigationBarsPadding()
             .statusBarsPadding()
     ) {


### PR DESCRIPTION
## Description
- re-organize history loading code to load initial account transaction first, and after that history. Previously, it was loaded in paralel since we didn't use first transaction in history request
- add `from_ledger_state` as lower bound for queries that use desc order.
- disable pull to refresh component when data is loading
- update list monitoring to be more accurate in detecting scrolling to the top


## How to test

1. Play with history and make sure all the txes are loaded same as before that change.

## PR submission checklist
- [ ] I have tested tx history loading and verified it works
