### PR TITLE
[ABW-3133] Account settings XRD faucet placement

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
@@ -34,11 +34,11 @@ import javax.inject.Inject
 
 @HiltViewModel
 class AccountSettingsViewModel @Inject constructor(
+    private val getFreeXrdUseCase: GetFreeXrdUseCase,
     private val getProfileUseCase: GetProfileUseCase,
     private val renameAccountDisplayNameUseCase: RenameAccountDisplayNameUseCase,
     savedStateHandle: SavedStateHandle,
     private val changeEntityVisibilityUseCase: ChangeEntityVisibilityUseCase,
-    private val getFreeXrdUseCase: GetFreeXrdUseCase,
     @ApplicationScope private val appScope: CoroutineScope,
     private val appEventBus: AppEventBus
 ) : StateViewModel<AccountPreferenceUiState>(), OneOffEventHandler<Event> by OneOffEventHandlerImpl() {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
@@ -33,6 +33,7 @@ import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
+@Suppress("LongParameterList")
 class AccountSettingsViewModel @Inject constructor(
     private val getFreeXrdUseCase: GetFreeXrdUseCase,
     private val getProfileUseCase: GetProfileUseCase,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/devsettings/DevSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/devsettings/DevSettingsScreen.kt
@@ -11,11 +11,8 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -26,11 +23,7 @@ import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixSecondaryButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
-import com.babylon.wallet.android.domain.usecases.FaucetState
-import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
-import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
-import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 
@@ -45,12 +38,7 @@ fun DevSettingsScreen(
     DevSettingsContent(
         modifier = modifier.navigationBarsPadding(),
         onBackClick = onBackClick,
-        onGetFreeXrdClick = viewModel::onGetFreeXrdClick,
-        faucetState = state.faucetState,
-        isXrdLoading = state.isFreeXRDLoading,
         isAuthSigningLoading = state.isLoading,
-        onMessageShown = viewModel::onMessageShown,
-        error = state.error,
         hasAuthKey = state.hasAuthKey,
         onCreateAndUploadAuthKey = {
             context.biometricAuthenticate { result ->
@@ -65,22 +53,11 @@ fun DevSettingsScreen(
 @Composable
 private fun DevSettingsContent(
     onBackClick: () -> Unit,
-    onGetFreeXrdClick: () -> Unit,
-    faucetState: FaucetState,
-    isXrdLoading: Boolean,
     isAuthSigningLoading: Boolean,
-    onMessageShown: () -> Unit,
-    error: UiMessage?,
     modifier: Modifier = Modifier,
     hasAuthKey: Boolean,
     onCreateAndUploadAuthKey: () -> Unit
 ) {
-    val snackBarHostState = remember { SnackbarHostState() }
-    SnackbarUIMessage(
-        message = error,
-        snackbarHostState = snackBarHostState,
-        onMessageShown = onMessageShown
-    )
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -90,50 +67,14 @@ private fun DevSettingsContent(
                 windowInsets = WindowInsets.statusBars
             )
         },
-        snackbarHost = {
-            RadixSnackbarHost(
-                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
-                hostState = snackBarHostState
-            )
-        },
         containerColor = RadixTheme.colors.gray5
     ) { padding ->
-        val context = LocalContext.current
         Column(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize()
                 .background(RadixTheme.colors.gray5)
         ) {
-            if (faucetState is FaucetState.Available) {
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
-                RadixSecondaryButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = RadixTheme.dimensions.paddingLarge),
-                    text = stringResource(R.string.accountSettings_getXrdTestTokens),
-                    onClick = {
-                        context.biometricAuthenticate { result ->
-                            if (result == BiometricAuthenticationResult.Succeeded) {
-                                onGetFreeXrdClick()
-                            }
-                        }
-                    },
-                    isLoading = isXrdLoading,
-                    enabled = !isXrdLoading && faucetState.isEnabled
-                )
-            }
-            if (isXrdLoading) {
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
-                Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = RadixTheme.dimensions.paddingLarge),
-                    text = stringResource(R.string.accountSettings_loadingPrompt),
-                    style = RadixTheme.typography.body2Regular,
-                    color = RadixTheme.colors.gray1,
-                )
-            }
             if (BuildConfig.EXPERIMENTAL_FEATURES_ENABLED && !hasAuthKey) {
                 Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
                 RadixSecondaryButton(
@@ -157,12 +98,7 @@ fun DevSettingsPreview() {
     RadixWalletTheme {
         DevSettingsContent(
             onBackClick = {},
-            onGetFreeXrdClick = {},
-            faucetState = FaucetState.Available(isEnabled = true),
-            isXrdLoading = false,
             isAuthSigningLoading = false,
-            onMessageShown = {},
-            error = null,
             hasAuthKey = false,
             onCreateAndUploadAuthKey = {}
         )

--- a/app/src/test/java/com/babylon/wallet/android/presentation/accountsettings/DevSettingsViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/accountsettings/DevSettingsViewModelTest.kt
@@ -4,109 +4,45 @@ import androidx.lifecycle.SavedStateHandle
 import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
 import com.babylon.wallet.android.data.repository.TransactionStatusClient
 import com.babylon.wallet.android.data.transaction.ROLAClient
-import com.babylon.wallet.android.domain.usecases.FaucetState
-import com.babylon.wallet.android.domain.usecases.GetFreeXrdUseCase
 import com.babylon.wallet.android.presentation.StateViewModelTest
 import com.babylon.wallet.android.presentation.account.settings.ARG_ACCOUNT_SETTINGS_ADDRESS
 import com.babylon.wallet.android.presentation.account.settings.devsettings.DevSettingsViewModel
-import com.babylon.wallet.android.utils.AppEvent
-import com.babylon.wallet.android.utils.AppEventBus
-import io.mockk.Runs
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
 import org.junit.Before
-import org.junit.Test
 import rdx.works.profile.data.model.currentNetwork
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.account.AddAuthSigningFactorInstanceUseCase
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class DevSettingsViewModelTest : StateViewModelTest<DevSettingsViewModel>() {
 
-    private val getFreeXrdUseCase = mockk<GetFreeXrdUseCase>()
     private val savedStateHandle = mockk<SavedStateHandle>()
     private val getProfileUseCase = mockk<GetProfileUseCase>()
     private val incomingRequestRepository = mockk<IncomingRequestRepository>()
     private val addAuthSigningFactorInstanceUseCase = mockk<AddAuthSigningFactorInstanceUseCase>()
     private val transactionStatusClient = mockk<TransactionStatusClient>()
     private val rolaClient = mockk<ROLAClient>()
-    private val eventBus = mockk<AppEventBus>()
-    private val sampleTxId = "txId1"
     private val sampleProfile = sampleDataProvider.sampleProfile()
     private val sampleAddress = sampleProfile.currentNetwork!!.accounts.first().address
 
     override fun initVM(): DevSettingsViewModel {
         return DevSettingsViewModel(
-            getFreeXrdUseCase,
             getProfileUseCase,
             rolaClient,
             incomingRequestRepository,
             addAuthSigningFactorInstanceUseCase,
             transactionStatusClient,
-            TestScope(),
-            savedStateHandle,
-            eventBus
+            savedStateHandle
         )
     }
 
     @Before
     override fun setUp() {
         super.setUp()
-        every { getFreeXrdUseCase.getFaucetState(any()) } returns flowOf(FaucetState.Available(true))
         every { getProfileUseCase() } returns flowOf(sampleDataProvider.sampleProfile())
-        coEvery { getFreeXrdUseCase(any()) } returns Result.success(sampleTxId)
         every { savedStateHandle.get<String>(ARG_ACCOUNT_SETTINGS_ADDRESS) } returns sampleAddress
-        coEvery { eventBus.sendEvent(any()) } just Runs
         every { rolaClient.signingState } returns emptyFlow()
-    }
-
-    @Test
-    fun `initial state is correct when free xrd enabled`() = runTest {
-        val vm = vm.value
-        advanceUntilIdle()
-        val state = vm.state.first()
-        assert(state.faucetState is FaucetState.Available)
-    }
-
-    @Test
-    fun `initial state is correct when free xrd not enabled`() = runTest {
-        every { getFreeXrdUseCase.getFaucetState(any()) } returns flow { emit(FaucetState.Available(false)) }
-        val vm = vm.value
-        advanceUntilIdle()
-        val state = vm.state.first()
-        assert(state.faucetState is FaucetState.Available && !(state.faucetState as FaucetState.Available).isEnabled)
-    }
-
-    @Test
-    fun `get free xrd success sets proper state`() = runTest {
-        val vm = vm.value
-        advanceUntilIdle()
-        vm.onGetFreeXrdClick()
-        advanceUntilIdle()
-        coVerify(exactly = 1) { eventBus.sendEvent(AppEvent.RefreshResourcesNeeded) }
-        coVerify(exactly = 1) { getFreeXrdUseCase(sampleAddress) }
-    }
-
-    @Test
-    fun `get free xrd failure sets proper state`() = runTest {
-        coEvery { getFreeXrdUseCase(any()) } returns Result.failure(Exception())
-        val vm = vm.value
-        advanceUntilIdle()
-        vm.onGetFreeXrdClick()
-        advanceUntilIdle()
-        val state = vm.state.first()
-        coVerify(exactly = 1) { getFreeXrdUseCase(sampleAddress) }
-        assert(state.error != null)
     }
 }


### PR DESCRIPTION
## Description

[Jira Ticket](https://radixdlt.atlassian.net/browse/ABW-3133)

Hidden dev settings section for non-debug builds. 
Moved XRD test tokens to Account settings screen

## Screenshot

Account Settings screen on a non-debug build:

![Screenshot_20240404-142525](https://github.com/radixdlt/babylon-wallet-android/assets/164897324/7032b71b-8958-48e7-8a63-73443a122c40)

## Video

Video showcasing XRD test tokens button being moved from Dev Preferences to Account Settings screen and being shown only for stokenet gateway.

https://github.com/radixdlt/babylon-wallet-android/assets/164897324/dcfaa156-7fa6-4de3-9857-c346c7d91d20

## PR submission checklist
- [x] I have checked that Dev Preferences section is hidden on non-debug builds
- [x] I have checked that XRD test tokens button has been moved from Dev Preferences to Account Settings screen
- [x] I have checked that XRD test tokens button is being shown only when the stokenet gateway is selected
- [x] I have tested XRD test tokens functionality and have confirmed that it works