### PR TITLE
Fix request/current network name in error message

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -266,8 +266,8 @@ fun RadixWalletException.DappRequestException.toUserFriendlyMessage(context: Con
         is RadixWalletException.DappRequestException.WrongNetwork -> {
             context.getString(
                 R.string.dAppRequest_requestWrongNetworkAlert_message,
-                currentNetworkName,
-                requestNetworkName
+                requestNetworkName,
+                currentNetworkName
             )
         }
 


### PR DESCRIPTION
## Description
The error message misleading since the parameters were reverted. The request network name should be first and the current network name should be second. Since the string is `dApp made a request intended for network %s, but you are currently connected to %s.`


## How to test

1. Change wallet to stokenet
2. Try to login from any dapp in mainnet
3. You should see the correct error message 