### PR TITLE
update history state with genesis tx instant

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
@@ -79,6 +79,16 @@ class HistoryViewModel @Inject constructor(
                         it.copy(uiMessage = UiMessage.ErrorMessage(error = error))
                     }
                 }.firstOrNull().let { genesisTxInstant ->
+                    _state.update { state ->
+                        state.copy(
+                            filters = state.filters.copy(
+                                genesisTxDate = ZonedDateTime.ofInstant(
+                                    genesisTxInstant,
+                                    ZoneId.systemDefault()
+                                )
+                            )
+                        )
+                    }
                     genesisTxInstant?.let { computeTimeFilters(it) }
                     loadHistory()
                 }


### PR DESCRIPTION
## Description
- update history state with genesis tx instant. After that it is used in history calls. Probably removed that during the rebases

## PR submission checklist
- [ ] I have checked in http logs that lower bounds for history query is used
