### PR TITLE
`ExecutionSummary` & `Blake2Hash` (Batch 6)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -226,7 +226,6 @@ dependencies {
     implementation libs.kotlinxSerialization
 
     //Kotlin toolkit
-    implementation libs.retAndroid
     implementation libs.slip10
 
     //Retrofit & OkHttp
@@ -274,7 +273,6 @@ dependencies {
     testImplementation libs.mockitoKotlin
     testImplementation libs.mockitoInline
     testImplementation libs.turbine
-    testImplementation libs.retKotlin
 
     androidTestImplementation libs.androidXJunit
     androidTestImplementation libs.espresso

--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/PeerdroidClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/PeerdroidClient.kt
@@ -11,7 +11,8 @@ import com.babylon.wallet.android.data.dapp.model.toDomainModel
 import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.model.MessageFromDataChannel
 import com.babylon.wallet.android.utils.parseEncryptionKeyFromConnectionPassword
-import com.radixdlt.hex.extensions.toHexString
+import com.radixdlt.sargon.extensions.hash
+import com.radixdlt.sargon.extensions.hex
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.cancellable
@@ -22,7 +23,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import rdx.works.core.blake2Hash
+import rdx.works.core.hash
 import rdx.works.peerdroid.data.PeerdroidConnector
 import rdx.works.peerdroid.di.IoDispatcher
 import rdx.works.peerdroid.domain.ConnectionIdHolder
@@ -115,7 +116,7 @@ class PeerdroidClientImpl @Inject constructor(
             connectionPassword = connectionPassword
         )
         encryptionKey?.let {
-            val connectionIdHolder = ConnectionIdHolder(id = it.blake2Hash().toHexString())
+            val connectionIdHolder = ConnectionIdHolder(id = it.hash().hex)
             peerdroidConnector.deleteConnector(connectionIdHolder)
         } ?: Timber.e("\uD83E\uDD16 Failed to delete connector because connection password is wrong")
     }

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/cache/HttpCache.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/cache/HttpCache.kt
@@ -1,13 +1,14 @@
 package com.babylon.wallet.android.data.repository.cache
 
+import com.radixdlt.sargon.extensions.hash
+import com.radixdlt.sargon.extensions.hex
 import kotlinx.serialization.KSerializer
 import okhttp3.HttpUrl
 import okhttp3.RequestBody
 import okio.Buffer
 import okio.IOException
 import rdx.works.core.InstantGenerator
-import rdx.works.core.blake2Hash
-import rdx.works.core.toHexString
+import rdx.works.core.hash
 import rdx.works.profile.domain.gateway.GetCurrentGatewayUseCase
 import retrofit2.Call
 import timber.log.Timber
@@ -138,7 +139,7 @@ class HttpCacheImpl @Inject constructor(
             method,
             url.toString(),
             body?.readUtf8().orEmpty()
-        ).contentToString().blake2Hash().toHexString()
+        ).contentToString().toByteArray().hash().hex
 
         @Suppress("SwallowedException")
         private fun RequestBody.readUtf8(): String = try {

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/ResolveNotaryAndSignersUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/ResolveNotaryAndSignersUseCase.kt
@@ -2,6 +2,9 @@ package com.babylon.wallet.android.domain.usecases
 
 import com.babylon.wallet.android.data.transaction.NotaryAndSigners
 import com.babylon.wallet.android.domain.RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities
+import com.radixdlt.sargon.AccountAddress
+import com.radixdlt.sargon.IdentityAddress
+import com.radixdlt.sargon.extensions.string
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.accountsOnCurrentNetwork
 import rdx.works.profile.domain.personasOnCurrentNetwork
@@ -13,17 +16,17 @@ class ResolveNotaryAndSignersUseCase @Inject constructor(
 ) {
 
     suspend operator fun invoke(
-        accountsAddressesRequiringAuth: List<String>,
-        personaAddressesRequiringAuth: List<String>,
+        accountsAddressesRequiringAuth: List<AccountAddress>,
+        personaAddressesRequiringAuth: List<IdentityAddress>,
         notary: PrivateKey
     ) = runCatching {
         val accounts = profileUseCase.accountsOnCurrentNetwork()
         val personas = profileUseCase.personasOnCurrentNetwork()
 
         accountsAddressesRequiringAuth.map { address ->
-            accounts.find { it.address == address } ?: throw FailedToFindSigningEntities
+            accounts.find { it.address == address.string } ?: throw FailedToFindSigningEntities
         } + personaAddressesRequiringAuth.map { address ->
-            personas.find { it.address == address } ?: throw FailedToFindSigningEntities
+            personas.find { it.address == address.string } ?: throw FailedToFindSigningEntities
         }
     }.map {
         NotaryAndSigners(

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
-import rdx.works.core.blake2Hash
 import rdx.works.core.decodeHex
+import rdx.works.core.hash
 import rdx.works.core.toByteArray
 import rdx.works.profile.data.model.factorsources.DeviceFactorSource
 import rdx.works.profile.data.model.factorsources.FactorSourceKind
@@ -138,7 +138,7 @@ sealed interface SignRequest {
             get() = dataToSign.toHexString()
 
         override val hashedDataToSign: ByteArray
-            get() = dataToSign.blake2Hash()
+            get() = dataToSign.hash().bytes.toByteArray()
 
         companion object {
             const val ROLA_PAYLOAD_PREFIX = 0x52

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/FeesResolver.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/FeesResolver.kt
@@ -4,7 +4,7 @@ import com.babylon.wallet.android.data.transaction.NotaryAndSigners
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.babylon.wallet.android.presentation.transaction.fees.TransactionFees
 import com.babylon.wallet.android.presentation.transaction.guaranteesCount
-import com.radixdlt.ret.ExecutionSummary
+import com.radixdlt.sargon.ExecutionSummary
 import com.radixdlt.sargon.extensions.compareTo
 import com.radixdlt.sargon.extensions.toDecimal192
 
@@ -15,11 +15,11 @@ object FeesResolver {
         previewType: PreviewType
     ): TransactionFees {
         return TransactionFees(
-            nonContingentFeeLock = summary.feeLocks.lock.asStr().toDecimal192(),
-            networkExecution = summary.feeSummary.executionCost.asStr().toDecimal192(),
-            networkFinalization = summary.feeSummary.finalizationCost.asStr().toDecimal192(),
-            networkStorage = summary.feeSummary.storageExpansionCost.asStr().toDecimal192(),
-            royalties = summary.feeSummary.royaltyCost.asStr().toDecimal192(),
+            nonContingentFeeLock = summary.feeLocks.lock,
+            networkExecution = summary.feeSummary.executionCost,
+            networkFinalization = summary.feeSummary.finalizationCost,
+            networkStorage = summary.feeSummary.storageExpansionCost,
+            royalties = summary.feeSummary.royaltyCost,
             guaranteesCount = (previewType as? PreviewType.Transfer)?.to?.guaranteesCount() ?: 0,
             notaryIsSignatory = notaryAndSigners.notaryIsSignatory,
             includeLockFee = false, // First its false because we don't know if lock fee is applicable or not yet

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -16,7 +16,7 @@ import com.babylon.wallet.android.presentation.transaction.TransactionErrorMessa
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel
 import com.babylon.wallet.android.presentation.transaction.analysis.processor.PreviewTypeAnalyzer
 import com.radixdlt.hex.extensions.toHexString
-import com.radixdlt.ret.ExecutionSummary
+import com.radixdlt.sargon.ExecutionSummary
 import com.radixdlt.sargon.Nonce
 import com.radixdlt.sargon.extensions.secureRandom
 import com.radixdlt.sargon.extensions.value

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/AccountDepositSettingsProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/AccountDepositSettingsProcessor.kt
@@ -3,13 +3,14 @@ package com.babylon.wallet.android.presentation.transaction.analysis.processor
 import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddressUseCase
 import com.babylon.wallet.android.presentation.transaction.AccountWithDepositSettingsChanges
 import com.babylon.wallet.android.presentation.transaction.PreviewType
-import com.radixdlt.ret.AccountDefaultDepositRule
-import com.radixdlt.ret.DetailedManifestClass
-import com.radixdlt.ret.ExecutionSummary
-import com.radixdlt.ret.ResourceOrNonFungible
-import com.radixdlt.ret.ResourcePreference
-import com.radixdlt.ret.ResourcePreferenceUpdate
-import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.AccountAddress
+import com.radixdlt.sargon.DepositRule
+import com.radixdlt.sargon.DetailedManifestClass
+import com.radixdlt.sargon.ExecutionSummary
+import com.radixdlt.sargon.ResourceOrNonFungible
+import com.radixdlt.sargon.ResourcePreference
+import com.radixdlt.sargon.ResourcePreferenceUpdate
+import com.radixdlt.sargon.extensions.init
 import rdx.works.core.domain.assets.Asset
 import rdx.works.profile.data.model.pernetwork.Network
 import rdx.works.profile.data.model.pernetwork.Network.Account.OnLedgerSettings.ThirdPartyDeposits
@@ -33,17 +34,19 @@ class AccountDepositSettingsProcessor @Inject constructor(
             classification.resourcePreferencesUpdates.keys +
             classification.authorizedDepositorsAdded.keys +
             classification.authorizedDepositorsRemoved.keys
-        val involvedAccounts = getProfileUseCase.accountsOnCurrentNetwork().filter { involvedAccountAddresses.contains(it.address) }
+        val involvedAccounts = getProfileUseCase.accountsOnCurrentNetwork().filter {
+            involvedAccountAddresses.contains(AccountAddress.init(it.address))
+        }
         val result = involvedAccounts.map { involvedAccount ->
-            val defaultDepositRule = classification.depositModeUpdates[involvedAccount.address]
+            val defaultDepositRule = classification.depositModeUpdates[AccountAddress.init(involvedAccount.address)]
             val assetChanges = classification.resolveAssetChanges(involvedAccount, assets)
             val depositorChanges = classification.resolveDepositorChanges(involvedAccount, assets)
             AccountWithDepositSettingsChanges(
                 account = involvedAccount,
                 defaultDepositRule = when (defaultDepositRule) {
-                    AccountDefaultDepositRule.ACCEPT -> ThirdPartyDeposits.DepositRule.AcceptAll
-                    AccountDefaultDepositRule.REJECT -> ThirdPartyDeposits.DepositRule.DenyAll
-                    AccountDefaultDepositRule.ALLOW_EXISTING -> ThirdPartyDeposits.DepositRule.AcceptKnown
+                    DepositRule.ACCEPT_ALL -> ThirdPartyDeposits.DepositRule.AcceptAll
+                    DepositRule.DENY_ALL -> ThirdPartyDeposits.DepositRule.DenyAll
+                    DepositRule.ACCEPT_KNOWN -> ThirdPartyDeposits.DepositRule.AcceptKnown
                     null -> null
                 },
                 assetChanges = assetChanges,
@@ -56,11 +59,11 @@ class AccountDepositSettingsProcessor @Inject constructor(
     private fun DetailedManifestClass.AccountDepositSettingsUpdate.resolveDepositorChanges(
         involvedAccount: Network.Account,
         assets: List<Asset>
-    ) = authorizedDepositorsAdded[involvedAccount.address]?.let { authorizedDepositorsChangeForAccount ->
+    ) = authorizedDepositorsAdded[AccountAddress.init(involvedAccount.address)]?.let { authorizedDepositorsChangeForAccount ->
         val added = authorizedDepositorsChangeForAccount.map { added ->
             when (added) {
                 is ResourceOrNonFungible.NonFungible -> {
-                    val resource = assets.find { it.resource.address.string == added.value.resourceAddress().addressString() }?.resource
+                    val resource = assets.find { it.resource.address == added.value.resourceAddress }?.resource
                     AccountWithDepositSettingsChanges.DepositorPreferenceChange(
                         change = AccountWithDepositSettingsChanges.DepositorPreferenceChange.ChangeType.Add,
                         resource = resource
@@ -68,7 +71,7 @@ class AccountDepositSettingsProcessor @Inject constructor(
                 }
 
                 is ResourceOrNonFungible.Resource -> {
-                    val resource = assets.find { it.resource.address.string == added.value.addressString() }?.resource
+                    val resource = assets.find { it.resource.address == added.value }?.resource
                     AccountWithDepositSettingsChanges.DepositorPreferenceChange(
                         change = AccountWithDepositSettingsChanges.DepositorPreferenceChange.ChangeType.Add,
                         resource = resource
@@ -76,7 +79,7 @@ class AccountDepositSettingsProcessor @Inject constructor(
                 }
             }
         }
-        val removed = authorizedDepositorsRemoved[involvedAccount.address]?.map { removed ->
+        val removed = authorizedDepositorsRemoved[AccountAddress.init(involvedAccount.address)]?.map { removed ->
             when (removed) {
                 is ResourceOrNonFungible.NonFungible -> {
                     AccountWithDepositSettingsChanges.DepositorPreferenceChange(
@@ -85,7 +88,7 @@ class AccountDepositSettingsProcessor @Inject constructor(
                 }
 
                 is ResourceOrNonFungible.Resource -> {
-                    val resource = assets.find { it.resource.address.string == removed.value.addressString() }?.resource
+                    val resource = assets.find { it.resource.address == removed.value }?.resource
                     AccountWithDepositSettingsChanges.DepositorPreferenceChange(
                         change = AccountWithDepositSettingsChanges.DepositorPreferenceChange.ChangeType.Remove,
                         resource = resource
@@ -99,9 +102,9 @@ class AccountDepositSettingsProcessor @Inject constructor(
     private fun DetailedManifestClass.AccountDepositSettingsUpdate.resolveAssetChanges(
         involvedAccount: Network.Account,
         allResources: List<Asset>
-    ) = resourcePreferencesUpdates[involvedAccount.address]?.let { resourcePreferenceChangeForAccount ->
+    ) = resourcePreferencesUpdates[AccountAddress.init(involvedAccount.address)]?.let { resourcePreferenceChangeForAccount ->
         resourcePreferenceChangeForAccount.map { resourcePreferenceChange ->
-            val resource = allResources.find { it.resource.address.string == resourcePreferenceChange.key }?.resource
+            val resource = allResources.find { it.resource.address == resourcePreferenceChange.key }?.resource
             val assetPreferenceChange = when (val action = resourcePreferenceChange.value) {
                 ResourcePreferenceUpdate.Remove -> AccountWithDepositSettingsChanges.AssetPreferenceChange.ChangeType.Clear
                 is ResourcePreferenceUpdate.Set -> when (action.value) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolRedemptionProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolRedemptionProcessor.kt
@@ -5,15 +5,11 @@ import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddressUseCase
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
 import com.babylon.wallet.android.presentation.transaction.PreviewType
-import com.radixdlt.ret.DetailedManifestClass
-import com.radixdlt.ret.ExecutionSummary
-import com.radixdlt.sargon.AccountAddress
-import com.radixdlt.sargon.ResourceAddress
-import com.radixdlt.sargon.extensions.init
-import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.DetailedManifestClass
+import com.radixdlt.sargon.ExecutionSummary
+import com.radixdlt.sargon.extensions.address
+import com.radixdlt.sargon.extensions.orZero
 import com.radixdlt.sargon.extensions.sumOf
-import com.radixdlt.sargon.extensions.toDecimal192
-import com.radixdlt.sargon.extensions.toDecimal192OrNull
 import kotlinx.coroutines.flow.first
 import rdx.works.core.domain.assets.PoolUnit
 import rdx.works.profile.domain.GetProfileUseCase
@@ -36,35 +32,34 @@ class PoolRedemptionProcessor @Inject constructor(
             involvedAssets = assets,
             defaultGuarantee = defaultDepositGuarantees
         )
-        val from = summary.accountWithdraws.map { withdrawsPerAddress ->
+        val from = summary.withdrawals.map { withdrawsPerAddress ->
             withdrawsPerAddress.value.map { withdraw ->
-                val resourceAddress = withdraw.resourceAddress
-                val poolUnit = assets.find { it.resource.address == resourceAddress } as? PoolUnit
+                val poolUnit = assets.find { it.resource.address == withdraw.address } as? PoolUnit
                 if (poolUnit == null) {
                     summary.resolveDepositingAsset(withdraw, assets, defaultDepositGuarantees)
                 } else {
-                    val redemptions = classification.poolRedemptions.filter {
-                        it.poolUnitsResourceAddress.addressString() == resourceAddress.string
+                    val redemptions = classification.poolContributions.filter {
+                        it.poolUnitsResourceAddress == withdraw.address
                     }
                     val redemptionResourceAddresses = redemptions.first().redeemedResources.keys
                     val poolUnitAmount = redemptions.find {
-                        it.poolUnitsResourceAddress.addressString() == poolUnit.resourceAddress.string
-                    }?.poolUnitsAmount?.asStr()?.toDecimal192OrNull()
+                        it.poolUnitsResourceAddress == poolUnit.resourceAddress
+                    }?.poolUnitsAmount.orZero()
                     Transferable.Withdrawing(
                         transferable = TransferableAsset.Fungible.PoolUnitAsset(
-                            amount = redemptions.map { it.poolUnitsAmount.asStr().toDecimal192() }.sumOf { it },
+                            amount = redemptions.map { it.poolUnitsAmount }.sumOf { it },
                             unit = poolUnit.copy(
                                 stake = poolUnit.stake.copy(ownedAmount = poolUnitAmount)
                             ),
-                            redemptionResourceAddresses.associate { contributedResourceAddress ->
-                                ResourceAddress.init(contributedResourceAddress) to redemptions.mapNotNull {
-                                    it.redeemedResources[contributedResourceAddress]?.asStr()?.toDecimal192()
+                            redemptionResourceAddresses.associateWith { contributedResourceAddress ->
+                                redemptions.mapNotNull {
+                                    it.redeemedResources[contributedResourceAddress]
                                 }.sumOf { it }
                             }
                         )
                     )
                 }
-            }.toAccountWithTransferableResources(AccountAddress.init(withdrawsPerAddress.key), involvedOwnedAccounts)
+            }.toAccountWithTransferableResources(withdrawsPerAddress.key, involvedOwnedAccounts)
         }.sortedWith(AccountWithTransferableResources.Companion.Sorter(involvedOwnedAccounts))
         return PreviewType.Transfer.Pool(
             from = from,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolRedemptionProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolRedemptionProcessor.kt
@@ -38,7 +38,7 @@ class PoolRedemptionProcessor @Inject constructor(
                 if (poolUnit == null) {
                     summary.resolveDepositingAsset(withdraw, assets, defaultDepositGuarantees)
                 } else {
-                    val redemptions = classification.poolContributions.filter {
+                    val redemptions = classification.poolRedemptions.filter {
                         it.poolUnitsResourceAddress == withdraw.address
                     }
                     val redemptionResourceAddresses = redemptions.first().redeemedResources.keys

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PreviewTypeProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PreviewTypeProcessor.kt
@@ -1,8 +1,8 @@
 package com.babylon.wallet.android.presentation.transaction.analysis.processor
 
 import com.babylon.wallet.android.presentation.transaction.PreviewType
-import com.radixdlt.ret.DetailedManifestClass
-import com.radixdlt.ret.ExecutionSummary
+import com.radixdlt.sargon.DetailedManifestClass
+import com.radixdlt.sargon.ExecutionSummary
 import javax.inject.Inject
 
 @Suppress("LongParameterList")

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransferProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransferProcessor.kt
@@ -2,8 +2,10 @@ package com.babylon.wallet.android.presentation.transaction.analysis.processor
 
 import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddressUseCase
 import com.babylon.wallet.android.presentation.transaction.PreviewType
-import com.radixdlt.ret.DetailedManifestClass
-import com.radixdlt.ret.ExecutionSummary
+import com.radixdlt.sargon.AccountAddress
+import com.radixdlt.sargon.DetailedManifestClass
+import com.radixdlt.sargon.ExecutionSummary
+import com.radixdlt.sargon.extensions.init
 import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.accountsOnCurrentNetwork
 import rdx.works.profile.domain.defaultDepositGuarantee
@@ -19,9 +21,9 @@ class TransferProcessor @Inject constructor(
             nonFungibleIds = summary.involvedNonFungibleIds()
         ).getOrThrow()
 
-        val involvedAccountAddresses = summary.accountDeposits.keys + summary.accountWithdraws.keys
+        val involvedAccountAddresses = summary.deposits.keys + summary.withdrawals.keys
         val allOwnedAccounts = getProfileUseCase.accountsOnCurrentNetwork().filter {
-            involvedAccountAddresses.contains(it.address)
+            involvedAccountAddresses.contains(AccountAddress.init(it.address))
         }
 
         return PreviewType.Transfer.GeneralTransfer(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorUnstakeProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorUnstakeProcessor.kt
@@ -5,15 +5,12 @@ import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddressUseCase
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
 import com.babylon.wallet.android.presentation.transaction.PreviewType
-import com.radixdlt.ret.DetailedManifestClass
-import com.radixdlt.ret.ExecutionSummary
-import com.radixdlt.ret.ResourceIndicator
-import com.radixdlt.sargon.AccountAddress
+import com.radixdlt.sargon.DetailedManifestClass
+import com.radixdlt.sargon.ExecutionSummary
 import com.radixdlt.sargon.NonFungibleGlobalId
-import com.radixdlt.sargon.ResourceAddress
-import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.ResourceIndicator
+import com.radixdlt.sargon.extensions.address
 import com.radixdlt.sargon.extensions.string
-import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.flow.first
 import rdx.works.core.domain.assets.Asset
 import rdx.works.core.domain.assets.LiquidStakeUnit
@@ -62,25 +59,23 @@ class ValidatorUnstakeProcessor @Inject constructor(
         getProfileUseCase: GetProfileUseCase,
         assets: List<Asset>,
         involvedOwnedAccounts: List<Network.Account>
-    ) = executionSummary.accountDeposits.map { claimsPerAddress ->
+    ) = executionSummary.deposits.map { claimsPerAddress ->
         val defaultDepositGuarantees = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee
         claimsPerAddress.value.map { claimedResource ->
-            val resourceAddress = claimedResource.resourceAddress
-            val asset = assets.find { it.resource.address == resourceAddress } ?: error("No resource found")
+            val asset = assets.find { it.resource.address == claimedResource.address } ?: error("No resource found")
             if (asset is StakeClaim) {
                 claimedResource as? ResourceIndicator.NonFungible
                     ?: error("No non-fungible indicator found")
                 val stakeClaimNftItems = claimedResource.nonFungibleLocalIds.map { localId ->
                     val globalId = NonFungibleGlobalId(
-                        resourceAddress = ResourceAddress.init(claimedResource.resourceAddress.asStr()),
+                        resourceAddress = claimedResource.resourceAddress,
                         nonFungibleLocalId = localId,
                     )
-                    val claimNFTData = claimsNonFungibleData.find { it.nonFungibleGlobalId.asStr() == globalId.string }?.data
-                        ?: error("No claim data found")
-                    val claimAmount = claimNFTData.claimAmount.asStr().toDecimal192()
+                    val claimNFTData = claimsNonFungibleData[globalId] ?: error("No claim data found")
+                    val claimAmount = claimNFTData.claimAmount
                     val claimEpoch = claimNFTData.claimEpoch
                     Resource.NonFungibleResource.Item(
-                        collectionAddress = resourceAddress,
+                        collectionAddress = claimedResource.resourceAddress,
                         localId = localId,
                         metadata = listOf(
                             Metadata.Primitive(
@@ -113,6 +108,6 @@ class ValidatorUnstakeProcessor @Inject constructor(
             } else {
                 executionSummary.resolveDepositingAsset(claimedResource, assets, defaultDepositGuarantees)
             }
-        }.toAccountWithTransferableResources(AccountAddress.init(claimsPerAddress.key), involvedOwnedAccounts)
+        }.toAccountWithTransferableResources(claimsPerAddress.key, involvedOwnedAccounts)
     }
 }

--- a/app/src/test/java/com/babylon/wallet/android/data/repository/cache/HttpCacheTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/data/repository/cache/HttpCacheTest.kt
@@ -1,5 +1,8 @@
 package com.babylon.wallet.android.data.repository.cache
 
+import com.radixdlt.sargon.extensions.hash
+import com.radixdlt.sargon.extensions.hex
+import com.radixdlt.sargon.extensions.toBagOfBytes
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -12,8 +15,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
 import rdx.works.core.InstantGenerator
-import rdx.works.core.blake2Hash
-import rdx.works.core.toHexString
+import rdx.works.core.hash
 import rdx.works.profile.data.model.apppreferences.Radix
 import rdx.works.profile.domain.gateway.GetCurrentGatewayUseCase
 import retrofit2.Call
@@ -38,7 +40,7 @@ internal class HttpCacheTest {
         coEvery { getCurrentGatewayUseCaseMock() } returns Radix.Gateway(url, Radix.Network.nebunet)
         val mockApiCall = mockApiCall(method = method, url = url)
         val mockSerializer = mockk<KSerializer<FakeResponse>>()
-        val key = arrayOf(method, url, "").contentToString().blake2Hash().toHexString()
+        val key = arrayOf(method, url, "").contentToString().toByteArray().hash().hex
 
         testedClass.store(mockApiCall, value, mockSerializer)
 

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/FeesResolverTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/FeesResolverTest.kt
@@ -3,14 +3,14 @@ package com.babylon.wallet.android.presentation.transaction
 import com.babylon.wallet.android.data.transaction.NotaryAndSigners
 import com.babylon.wallet.android.domain.SampleDataProvider
 import com.babylon.wallet.android.presentation.transaction.analysis.FeesResolver
-import com.radixdlt.ret.Decimal
-import com.radixdlt.ret.DetailedManifestClass
-import com.radixdlt.ret.ExecutionSummary
-import com.radixdlt.ret.FeeLocks
-import com.radixdlt.ret.FeeSummary
-import com.radixdlt.ret.NewEntities
+import com.radixdlt.sargon.DetailedManifestClass
+import com.radixdlt.sargon.ExecutionSummary
+import com.radixdlt.sargon.FeeLocks
+import com.radixdlt.sargon.FeeSummary
+import com.radixdlt.sargon.NewEntities
 import com.radixdlt.sargon.extensions.formatted
 import com.radixdlt.sargon.extensions.formattedPlain
+import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -21,29 +21,26 @@ class FeesResolverTest {
 
     private val emptyExecutionSummary = ExecutionSummary(
         feeLocks = FeeLocks(
-            lock = Decimal.zero(),
-            contingentLock = Decimal.zero()
+            lock = 0.toDecimal192(),
+            contingentLock = 0.toDecimal192()
         ),
         feeSummary = FeeSummary(
-            executionCost = Decimal.zero(),
-            finalizationCost = Decimal.zero(),
-            storageExpansionCost = Decimal.zero(),
-            royaltyCost = Decimal.zero()
+            executionCost = 0.toDecimal192(),
+            finalizationCost = 0.toDecimal192(),
+            storageExpansionCost = 0.toDecimal192(),
+            royaltyCost = 0.toDecimal192()
         ),
         detailedClassification = listOf(),
         reservedInstructions = listOf(),
-        accountDeposits = mapOf(),
-        accountsRequiringAuth = listOf(),
-        accountWithdraws = mapOf(),
-        encounteredEntities = listOf(),
-        identitiesRequiringAuth = listOf(),
+        deposits = mapOf(),
+        withdrawals = mapOf(),
+        addressesOfAccountsRequiringAuth = listOf(),
+        addressesOfIdentitiesRequiringAuth = listOf(),
+        encounteredComponentAddresses = listOf(),
         newEntities = NewEntities(
-            componentAddresses = listOf(),
-            resourceAddresses = listOf(),
-            packageAddresses = listOf(),
             metadata = mapOf()
         ),
-        presentedProofs = mapOf(),
+        presentedProofs = listOf(),
         newlyCreatedNonFungibles = listOf()
     )
     private val notaryAndSigners = NotaryAndSigners(
@@ -55,14 +52,14 @@ class FeesResolverTest {
     fun `verify network fee royalty and total fee is displayed correctly on default screen 1`() {
         val summary = emptyExecutionSummary.copy(
             feeLocks = FeeLocks(
-                lock = Decimal("0.9"),
-                contingentLock = Decimal.zero()
+                lock = 0.9.toDecimal192(),
+                contingentLock = 0.toDecimal192()
             ),
             feeSummary = FeeSummary(
-                executionCost = Decimal("0.3"),
-                finalizationCost = Decimal("0.3"),
-                storageExpansionCost = Decimal("0.2"),
-                royaltyCost = Decimal("0.2")
+                executionCost = 0.3.toDecimal192(),
+                finalizationCost = 0.3.toDecimal192(),
+                storageExpansionCost = 0.2.toDecimal192(),
+                royaltyCost = 0.2.toDecimal192()
             ),
             detailedClassification = listOf(
                 DetailedManifestClass.General
@@ -81,14 +78,14 @@ class FeesResolverTest {
     fun `verify network fee royalty and total fee is displayed correctly on default screen 2`() = runTest {
         val summary = emptyExecutionSummary.copy(
             feeLocks = FeeLocks(
-                lock = Decimal("0.5"),
-                contingentLock = Decimal.zero()
+                lock = 0.5.toDecimal192(),
+                contingentLock = 0.toDecimal192()
             ),
             feeSummary = FeeSummary(
-                executionCost = Decimal("0.3"),
-                finalizationCost = Decimal("0.3"),
-                storageExpansionCost = Decimal("0.2"),
-                royaltyCost = Decimal("0.2")
+                executionCost = 0.3.toDecimal192(),
+                finalizationCost = 0.3.toDecimal192(),
+                storageExpansionCost = 0.2.toDecimal192(),
+                royaltyCost = 0.2.toDecimal192()
             ),
             detailedClassification = listOf(
                 DetailedManifestClass.General
@@ -107,14 +104,14 @@ class FeesResolverTest {
     fun `verify network fee royalty and total fee is displayed correctly on default screen 3`() = runTest {
         val summary = emptyExecutionSummary.copy(
             feeLocks = FeeLocks(
-                lock = Decimal("1.0"),
-                contingentLock = Decimal.zero()
+                lock = 1.0.toDecimal192(),
+                contingentLock = 0.toDecimal192()
             ),
             feeSummary = FeeSummary(
-                executionCost = Decimal("0.3"),
-                finalizationCost = Decimal("0.3"),
-                storageExpansionCost = Decimal("0.2"),
-                royaltyCost = Decimal("0.2")
+                executionCost = 0.3.toDecimal192(),
+                finalizationCost = 0.3.toDecimal192(),
+                storageExpansionCost = 0.2.toDecimal192(),
+                royaltyCost = 0.2.toDecimal192()
             ),
             detailedClassification = listOf(
                 DetailedManifestClass.General
@@ -133,14 +130,14 @@ class FeesResolverTest {
     fun `verify network fee royalty and total fee is displayed correctly on default screen 4`() = runTest {
         val summary = emptyExecutionSummary.copy(
             feeLocks = FeeLocks(
-                lock = Decimal("1.5"),
-                contingentLock = Decimal.zero()
+                lock = 1.5.toDecimal192(),
+                contingentLock = 0.toDecimal192()
             ),
             feeSummary = FeeSummary(
-                executionCost = Decimal("0.3"),
-                finalizationCost = Decimal("0.3"),
-                storageExpansionCost = Decimal("0.2"),
-                royaltyCost = Decimal("0.2")
+                executionCost = 0.3.toDecimal192(),
+                finalizationCost = 0.3.toDecimal192(),
+                storageExpansionCost = 0.2.toDecimal192(),
+                royaltyCost = 0.2.toDecimal192()
             ),
             detailedClassification = listOf(
                 DetailedManifestClass.General
@@ -159,14 +156,14 @@ class FeesResolverTest {
     fun `verify network fee royalty and total fee is displayed correctly on default screen 4 with one signer account`() = runTest {
         val summary = emptyExecutionSummary.copy(
             feeLocks = FeeLocks(
-                lock = Decimal.zero(),
-                contingentLock = Decimal.zero()
+                lock = 0.toDecimal192(),
+                contingentLock = 0.toDecimal192()
             ),
             feeSummary = FeeSummary(
-                executionCost = Decimal("0.3"),
-                finalizationCost = Decimal("0.3"),
-                storageExpansionCost = Decimal("0.2"),
-                royaltyCost = Decimal("0.2")
+                executionCost = 0.3.toDecimal192(),
+                finalizationCost = 0.3.toDecimal192(),
+                storageExpansionCost = 0.2.toDecimal192(),
+                royaltyCost = 0.2.toDecimal192()
             ),
             detailedClassification = listOf(
                 DetailedManifestClass.General

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
@@ -41,16 +41,15 @@ import com.babylon.wallet.android.presentation.transaction.submit.TransactionSub
 import com.babylon.wallet.android.utils.AppEventBus
 import com.babylon.wallet.android.utils.DeviceCapabilityHelper
 import com.babylon.wallet.android.utils.ExceptionMessageProvider
-import com.radixdlt.ret.Decimal
-import com.radixdlt.ret.DetailedManifestClass
-import com.radixdlt.ret.ExecutionSummary
-import com.radixdlt.ret.FeeLocks
-import com.radixdlt.ret.FeeSummary
-import com.radixdlt.ret.NewEntities
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.CompiledNotarizedIntent
+import com.radixdlt.sargon.DetailedManifestClass
+import com.radixdlt.sargon.ExecutionSummary
+import com.radixdlt.sargon.FeeLocks
+import com.radixdlt.sargon.FeeSummary
 import com.radixdlt.sargon.IntentHash
 import com.radixdlt.sargon.NetworkId
+import com.radixdlt.sargon.NewEntities
 import com.radixdlt.sargon.ResourceAddress
 import com.radixdlt.sargon.extensions.discriminant
 import com.radixdlt.sargon.extensions.rounded
@@ -204,29 +203,26 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
 
     private val emptyExecutionSummary = ExecutionSummary(
         feeLocks = FeeLocks(
-            lock = Decimal.zero(),
-            contingentLock = Decimal.zero()
+            lock = 0.toDecimal192(),
+            contingentLock = 0.toDecimal192()
         ),
         feeSummary = FeeSummary(
-            executionCost = Decimal.zero(),
-            finalizationCost = Decimal.zero(),
-            storageExpansionCost = Decimal.zero(),
-            royaltyCost = Decimal.zero()
+            executionCost = 0.toDecimal192(),
+            finalizationCost = 0.toDecimal192(),
+            storageExpansionCost = 0.toDecimal192(),
+            royaltyCost = 0.toDecimal192()
         ),
         detailedClassification = listOf(),
         reservedInstructions = listOf(),
-        accountDeposits = mapOf(),
-        accountsRequiringAuth = listOf(),
-        accountWithdraws = mapOf(),
-        encounteredEntities = listOf(),
-        identitiesRequiringAuth = listOf(),
+        deposits = mapOf(),
+        withdrawals = mapOf(),
+        addressesOfAccountsRequiringAuth = listOf(),
+        addressesOfIdentitiesRequiringAuth = listOf(),
+        encounteredComponentAddresses = listOf(),
         newEntities = NewEntities(
-            componentAddresses = listOf(),
-            resourceAddresses = listOf(),
-            packageAddresses = listOf(),
             metadata = mapOf()
         ),
-        presentedProofs = mapOf(),
+        presentedProofs = listOf(),
         newlyCreatedNonFungibles = listOf()
     )
 
@@ -379,14 +375,14 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
         val expectedFeeLock = "1.10842739440"
         every { sampleTransactionManifestData.executionSummary(any()) } returns emptyExecutionSummary.copy(
             feeLocks = FeeLocks(
-                lock = Decimal("1.5"),
-                contingentLock = Decimal.zero()
+                lock = 1.5.toDecimal192(),
+                contingentLock = 0.toDecimal192()
             ),
             feeSummary = FeeSummary(
-                executionCost = Decimal("0.3"),
-                finalizationCost = Decimal("0.3"),
-                storageExpansionCost = Decimal("0.2"),
-                royaltyCost = Decimal("0.2")
+                executionCost = 0.3.toDecimal192(),
+                finalizationCost = 0.3.toDecimal192(),
+                storageExpansionCost = 0.2.toDecimal192(),
+                royaltyCost = 0.2.toDecimal192()
             ),
             detailedClassification = listOf(
                 DetailedManifestClass.General
@@ -409,14 +405,14 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
 
         every { sampleTransactionManifestData.executionSummary(any()) } returns emptyExecutionSummary.copy(
             feeLocks = FeeLocks(
-                lock = Decimal("0.5"),
-                contingentLock = Decimal.zero()
+                lock = 0.5.toDecimal192(),
+                contingentLock = 0.toDecimal192()
             ),
             feeSummary = FeeSummary(
-                executionCost = Decimal("0.3"),
-                finalizationCost = Decimal("0.3"),
-                storageExpansionCost = Decimal("0.2"),
-                royaltyCost = Decimal("0.2")
+                executionCost = 0.3.toDecimal192(),
+                finalizationCost = 0.3.toDecimal192(),
+                storageExpansionCost = 0.2.toDecimal192(),
+                royaltyCost = 0.2.toDecimal192()
             ),
             detailedClassification = listOf(
                 DetailedManifestClass.General
@@ -440,14 +436,14 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
 
         every { sampleTransactionManifestData.executionSummary(any()) } returns emptyExecutionSummary.copy(
             feeLocks = FeeLocks(
-                lock = Decimal("0.5"),
-                contingentLock = Decimal.zero()
+                lock = 0.5.toDecimal192(),
+                contingentLock = 0.toDecimal192()
             ),
             feeSummary = FeeSummary(
-                executionCost = Decimal("0.3"),
-                finalizationCost = Decimal("0.3"),
-                storageExpansionCost = Decimal("0.2"),
-                royaltyCost = Decimal("0.2")
+                executionCost = 0.3.toDecimal192(),
+                finalizationCost = 0.3.toDecimal192(),
+                storageExpansionCost = 0.2.toDecimal192(),
+                royaltyCost = 0.2.toDecimal192()
             ),
             detailedClassification = listOf(
                 DetailedManifestClass.General

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -44,7 +44,6 @@ android {
 }
 
 dependencies {
-    implementation libs.retAndroid
     implementation libs.slip10
     api libs.sargonAndroid
     implementation libs.ktorCore
@@ -61,7 +60,6 @@ dependencies {
     ksp libs.hiltCompiler
 
     testImplementation libs.junit
-    testImplementation libs.retKotlin
     testRuntimeOnly libs.sargonDesktop
     androidTestImplementation libs.androidXJunit
     androidTestImplementation libs.espresso

--- a/core/src/main/java/rdx/works/core/HashExtensions.kt
+++ b/core/src/main/java/rdx/works/core/HashExtensions.kt
@@ -1,12 +1,12 @@
 package rdx.works.core
 
-import com.radixdlt.ret.hash
+import com.radixdlt.sargon.Exactly32Bytes
+import com.radixdlt.sargon.extensions.hash
+import com.radixdlt.sargon.extensions.toBagOfBytes
 
 @OptIn(ExperimentalUnsignedTypes::class)
 fun List<UByte>.toByteArray() = toUByteArray().toByteArray()
 
-fun ByteArray.blake2Hash(): ByteArray = hash(data = this).bytes()
-
-fun String.blake2Hash(): ByteArray = toByteArray().blake2Hash()
+fun ByteArray.hash(): Exactly32Bytes = toBagOfBytes().hash()
 
 fun ByteArray.toHexString(): String = joinToString(separator = "") { eachByte -> "%02x".format(eachByte) }

--- a/core/src/main/java/rdx/works/core/domain/TransactionManifestData.kt
+++ b/core/src/main/java/rdx/works/core/domain/TransactionManifestData.kt
@@ -1,25 +1,25 @@
 package rdx.works.core.domain
 
-import com.radixdlt.ret.ExecutionSummary
-import com.radixdlt.ret.Instructions
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.Blob
 import com.radixdlt.sargon.Blobs
+import com.radixdlt.sargon.ExecutionSummary
+import com.radixdlt.sargon.IdentityAddress
 import com.radixdlt.sargon.Message
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.TransactionManifest
 import com.radixdlt.sargon.extensions.blobs
 import com.radixdlt.sargon.extensions.bytes
 import com.radixdlt.sargon.extensions.discriminant
+import com.radixdlt.sargon.extensions.executionSummary
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.instructionsString
 import com.radixdlt.sargon.extensions.networkId
 import com.radixdlt.sargon.extensions.plaintext
+import com.radixdlt.sargon.extensions.summary
 import com.radixdlt.sargon.extensions.toBagOfBytes
 import com.radixdlt.sargon.extensions.toList
 import rdx.works.core.toByteArray
-
-private typealias EngineManifest = com.radixdlt.ret.TransactionManifest
 
 data class TransactionManifestData(
     val instructions: String,
@@ -28,16 +28,6 @@ data class TransactionManifestData(
     val blobs: List<ByteArray> = emptyList(),
     val version: Long = TransactionVersion.Default.value
 ) {
-
-    val engineManifest: EngineManifest by lazy {
-        EngineManifest(
-            instructions = Instructions.fromString(
-                string = instructions,
-                networkId = networkId.toUByte()
-            ),
-            blobs = blobs
-        )
-    }
 
     val manifestSargon: TransactionManifest by lazy {
         TransactionManifest.init(
@@ -56,23 +46,23 @@ data class TransactionManifestData(
         get() = NetworkId.init(discriminant = networkId.toUByte())
 
     fun entitiesRequiringAuth(): EntitiesRequiringAuth {
-        val summary = engineManifest.summary(networkId = networkId.toUByte())
+        val summary = manifestSargon.summary
 
         return EntitiesRequiringAuth(
-            accounts = summary.accountsRequiringAuth.map { it.addressString() },
-            identities = summary.identitiesRequiringAuth.map { it.addressString() }
+            accounts = summary.addressesOfAccountsRequiringAuth,
+            identities = summary.addressesOfPersonasRequiringAuth
         )
     }
 
     fun feePayerCandidates(): List<AccountAddress> {
-        val summary = engineManifest.summary(networkId.toUByte())
-        return (summary.accountsWithdrawnFrom + summary.accountsDepositedInto + summary.accountsRequiringAuth).map {
-            AccountAddress.init(it.addressString())
-        }
+        val summary = manifestSargon.summary
+        return summary.addressesOfAccountsWithdrawnFrom +
+            summary.addressesOfAccountsDepositedInto +
+            summary.addressesOfAccountsRequiringAuth
     }
 
     // Currently the only method that exposes RET
-    fun executionSummary(encodedReceipt: ByteArray): ExecutionSummary = engineManifest.executionSummary(networkId.toUByte(), encodedReceipt)
+    fun executionSummary(encodedReceipt: ByteArray): ExecutionSummary = manifestSargon.executionSummary(encodedReceipt.toBagOfBytes())
 
     sealed interface TransactionMessage {
 
@@ -87,8 +77,8 @@ data class TransactionManifestData(
     }
 
     data class EntitiesRequiringAuth(
-        val accounts: List<String>,
-        val identities: List<String>
+        val accounts: List<AccountAddress>,
+        val identities: List<IdentityAddress>
     )
 
     companion object {

--- a/gradle/libraries.versions.toml
+++ b/gradle/libraries.versions.toml
@@ -20,8 +20,7 @@ hiltNavigation = "1.1.0"
 biometricKtx = "1.2.0-alpha05"
 coilCompose = "2.5.0"
 kotlinxSerialization = "1.6.2"
-ret = "v1.0.12"
-sargon = "0.6.9-70d0eeb"
+sargon = "0.6.9-d97adbd"
 slip10 = "1.2-snapshot"
 crypto = "1.72"
 okhttpBom = "5.0.0-alpha.11"
@@ -109,8 +108,6 @@ coilCompose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" 
 coilComposeSvg = { module = "io.coil-kt:coil-svg", version.ref = "coilCompose" }
 coilComposeGif = { module = "io.coil-kt:coil-gif", version.ref = "coilCompose" }
 kotlinxSerialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
-retAndroid = { module = "com.radixdlt:radix-engine-toolkit-android", version.ref = "ret" }
-retKotlin = { module = "com.radixdlt:radix-engine-toolkit-kotlin", version.ref = "ret" }
 sargonAndroid = { module = "com.radixdlt.sargon:sargon-android", version.ref = "sargon" }
 sargonDesktop = { module = "com.radixdlt.sargon:sargon-desktop-bins", version.ref = "sargon" }
 slip10 = { module = "com.radixdlt:slip10-android", version.ref = "slip10" }

--- a/peerdroid/build.gradle
+++ b/peerdroid/build.gradle
@@ -64,7 +64,6 @@ dependencies {
     implementation libs.timber
     
     testImplementation libs.junit
-    testImplementation libs.retKotlin
     testImplementation libs.kotlinTestJunit
     testImplementation libs.coroutinesTest
     testRuntimeOnly libs.sargonDesktop

--- a/peerdroid/build.gradle
+++ b/peerdroid/build.gradle
@@ -67,4 +67,5 @@ dependencies {
     testImplementation libs.retKotlin
     testImplementation libs.kotlinTestJunit
     testImplementation libs.coroutinesTest
+    testRuntimeOnly libs.sargonDesktop
 }

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidConnector.kt
@@ -3,6 +3,8 @@
 package rdx.works.peerdroid.data
 
 import android.content.Context
+import com.radixdlt.sargon.extensions.hash
+import com.radixdlt.sargon.extensions.hex
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
@@ -29,8 +31,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import rdx.works.core.blake2Hash
-import rdx.works.core.toHexString
+import rdx.works.core.hash
 import rdx.works.peerdroid.data.webrtc.WebRtcManager
 import rdx.works.peerdroid.data.webrtc.model.PeerConnectionEvent
 import rdx.works.peerdroid.data.webrtc.model.SessionDescriptionWrapper
@@ -108,7 +109,7 @@ internal class PeerdroidConnectorImpl(
         get() = _peerConnectionStatus
 
     override suspend fun connectToConnectorExtension(encryptionKey: ByteArray): Result<Unit> {
-        val connectionId = encryptionKey.blake2Hash().toHexString()
+        val connectionId = encryptionKey.hash().hex
 
         return withContext(ioDispatcher) {
             if (mapOfWebSockets.containsKey(ConnectionIdHolder(id = connectionId))) {

--- a/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/data/PeerdroidLink.kt
@@ -1,6 +1,7 @@
 package rdx.works.peerdroid.data
 
 import android.content.Context
+import com.radixdlt.sargon.extensions.hex
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
@@ -14,8 +15,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withContext
-import rdx.works.core.blake2Hash
-import rdx.works.core.toHexString
+import rdx.works.core.hash
 import rdx.works.peerdroid.data.webrtc.WebRtcManager
 import rdx.works.peerdroid.data.webrtc.model.PeerConnectionEvent
 import rdx.works.peerdroid.data.webrtc.model.SessionDescriptionWrapper
@@ -62,7 +62,7 @@ internal class PeerdroidLinkImpl(
         addConnectionDeferred = CompletableDeferred()
         peerConnectionDeferred = CompletableDeferred()
         // get connection id from encryption key
-        val connectionId = encryptionKey.blake2Hash().toHexString()
+        val connectionId = encryptionKey.hash().hex
         Timber.d("\uD83D\uDDFC️ start process to add a new link connector with connectionId: $connectionId")
 
         withContext(ioDispatcher) {

--- a/peerdroid/src/main/java/rdx/works/peerdroid/messagechunking/MessageChunkingManager.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/messagechunking/MessageChunkingManager.kt
@@ -1,7 +1,7 @@
 package rdx.works.peerdroid.messagechunking
 
-import rdx.works.core.blake2Hash
-import rdx.works.core.toHexString
+import com.radixdlt.sargon.extensions.hex
+import rdx.works.core.hash
 import rdx.works.peerdroid.data.PackageDto
 import timber.log.Timber
 
@@ -22,7 +22,7 @@ fun verifyAssembledMessage(
     expectedHashOfMessage: String
 ): Result<Unit> {
     return try {
-        if (!expectedHashOfMessage.contentEquals(assembledMessage.blake2Hash().toHexString())) {
+        if (!expectedHashOfMessage.contentEquals(assembledMessage.hash().hex)) {
             Timber.d("📯 🧱 failed to verify hash of assembled message: hash mismatch")
             Result.failure<Throwable>(
                 Throwable(ERROR_MESSAGE_HASHES_MISMATCH)

--- a/peerdroid/src/main/java/rdx/works/peerdroid/messagechunking/MessageSplitter.kt
+++ b/peerdroid/src/main/java/rdx/works/peerdroid/messagechunking/MessageSplitter.kt
@@ -1,9 +1,9 @@
 package rdx.works.peerdroid.messagechunking
 
+import com.radixdlt.sargon.extensions.hex
 import io.ktor.util.encodeBase64
 import rdx.works.core.UUIDGenerator
-import rdx.works.core.blake2Hash
-import rdx.works.core.toHexString
+import rdx.works.core.hash
 import rdx.works.peerdroid.data.PackageDto
 import timber.log.Timber
 
@@ -30,7 +30,7 @@ fun ByteArray.splitMessage(chunkSize: Int): List<PackageDto> {
             PackageDto.MetaData(
                 messageId = messageId,
                 chunkCount = packages.count(),
-                hashOfMessage = blake2Hash().toHexString(),
+                hashOfMessage = hash().hex,
                 messageByteCount = messageSize
             )
         )
@@ -39,7 +39,7 @@ fun ByteArray.splitMessage(chunkSize: Int): List<PackageDto> {
             PackageDto.MetaData(
                 messageId = messageId,
                 chunkCount = 1,
-                hashOfMessage = blake2Hash().toHexString(),
+                hashOfMessage = hash().hex,
                 messageByteCount = messageSize
             )
         )

--- a/peerdroid/src/test/java/rdx/works/peerdroid/messagechunking/MessageAssemblerTest.kt
+++ b/peerdroid/src/test/java/rdx/works/peerdroid/messagechunking/MessageAssemblerTest.kt
@@ -1,10 +1,10 @@
 package rdx.works.peerdroid.messagechunking
 
+import com.radixdlt.sargon.extensions.hex
 import io.ktor.util.encodeBase64
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
-import rdx.works.core.blake2Hash
-import rdx.works.core.toHexString
+import rdx.works.core.hash
 import rdx.works.peerdroid.data.PackageDto
 import kotlin.test.assertEquals
 
@@ -16,7 +16,7 @@ class MessageAssemblerTest {
         val actualHashOfMessageInHexString = "afa5476b53c5a84d311c3ed8ff8f77e4990fe190e52cfeba745df6f67c83b7c6"
         val actualChunkData = "dGhpcyBpcyBhIHRlc3QgbWVzc2FnZQ=="
 
-        val expectedHashOfMessage = textMessage.blake2Hash().toHexString()
+        val expectedHashOfMessage = textMessage.toByteArray().hash().hex
         assertEquals(expectedHashOfMessage, actualHashOfMessageInHexString)
 
         val expectedChunkData = textMessage.encodeBase64()

--- a/peerdroid/src/test/java/rdx/works/peerdroid/messagechunking/MessageChunkingTest.kt
+++ b/peerdroid/src/test/java/rdx/works/peerdroid/messagechunking/MessageChunkingTest.kt
@@ -1,10 +1,10 @@
 package rdx.works.peerdroid.messagechunking
 
+import com.radixdlt.sargon.extensions.hex
 import org.junit.Assert
 import org.junit.Ignore
 import org.junit.Test
-import rdx.works.core.blake2Hash
-import rdx.works.core.toHexString
+import rdx.works.core.hash
 import rdx.works.peerdroid.data.PackageDto
 import kotlin.random.Random
 
@@ -16,7 +16,7 @@ class MessageChunkingTest {
         // given
         val oneMb = 1024 * 1024
         val oneMbByteArray = Random.nextBytes(oneMb)
-        val hashOfMessage = "abc".toByteArray().blake2Hash().toHexString()
+        val hashOfMessage = "abc".toByteArray().hash().hex
 
         // when
         val chunks = splitMessage(oneMbByteArray)

--- a/peerdroid/src/test/java/rdx/works/peerdroid/messagechunking/MessageSplitterTest.kt
+++ b/peerdroid/src/test/java/rdx/works/peerdroid/messagechunking/MessageSplitterTest.kt
@@ -1,11 +1,11 @@
 package rdx.works.peerdroid.messagechunking
 
+import com.radixdlt.sargon.extensions.hex
 import io.ktor.util.decodeBase64String
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
-import rdx.works.core.blake2Hash
-import rdx.works.core.toHexString
+import rdx.works.core.hash
 import rdx.works.peerdroid.data.PackageDto
 import kotlin.random.Random
 import kotlin.test.assertEquals
@@ -71,7 +71,7 @@ class MessageSplitterTest {
         // then
         val metadataPackage = result.first() as PackageDto.MetaData
 
-        Assert.assertTrue(metadataPackage.hashOfMessage.contentEquals(byteArray.blake2Hash().toHexString()))
+        Assert.assertTrue(metadataPackage.hashOfMessage.contentEquals(byteArray.hash().hex))
     }
 
     @Test
@@ -119,7 +119,7 @@ class MessageSplitterTest {
         // then
         val metadataPackage = result.first() as PackageDto.MetaData
 
-        Assert.assertTrue(metadataPackage.hashOfMessage.contentEquals(byteArray.blake2Hash().toHexString()))
+        Assert.assertTrue(metadataPackage.hashOfMessage.contentEquals(byteArray.hash().hex))
     }
 
     @Test

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -63,7 +63,6 @@ dependencies {
     implementation libs.timber
 
     implementation libs.slip10
-    implementation libs.retAndroid
     implementation libs.crypto
 
     testImplementation libs.junit
@@ -72,7 +71,6 @@ dependencies {
     testImplementation libs.mockk
     testImplementation libs.mockitoKotlin
     testImplementation libs.mockitoInline
-    testImplementation libs.retKotlin
     testImplementation libs.jsonAssert
     testRuntimeOnly libs.sargonDesktop
 }

--- a/profile/src/main/java/rdx/works/profile/data/utils/FactorSourceID.kt
+++ b/profile/src/main/java/rdx/works/profile/data/utils/FactorSourceID.kt
@@ -1,8 +1,8 @@
 package rdx.works.profile.data.utils
 
 import com.radixdlt.extensions.removeLeadingZero
-import com.radixdlt.hex.extensions.toHexString
-import rdx.works.core.blake2Hash
+import com.radixdlt.sargon.extensions.hex
+import rdx.works.core.hash
 
 /**
  * Return Strong and unique identifier for FactorSourceID / FactorInstanceID
@@ -12,4 +12,4 @@ import rdx.works.core.blake2Hash
  * (by adding zero byte at front, to be the same size as for Secp256k1 elliptic curve)
  * Then we use blake2 hash and get hex version.
 */
-fun ByteArray.hashToFactorId(): String = removeLeadingZero().blake2Hash().toHexString()
+fun ByteArray.hashToFactorId(): String = removeLeadingZero().hash().hex


### PR DESCRIPTION
## Description
* All processors have been refactored to use Sargon's `ExecutionSummary`
* `blake2hash()` method has been replaced with sargon's `hash()` method on `ByteArray`
* This PR removes the ret dependency once and for all 🎉 !!!

## How to test
* Run different kinds of transactions like simple transfers, stake claims, pool redemption/contribution
* Connect to connector extension

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
- [X] I have written unit tests
