### PR TITLE
Authenticate first when creating first ledger account (and BDFS)

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/derivepublickey/DerivePublicKeyViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/derivepublickey/DerivePublicKeyViewModel.kt
@@ -47,10 +47,16 @@ class DerivePublicKeyViewModel @Inject constructor(
             input = accessFactorSourcesUiProxy.getInput() as AccessFactorSourcesInput.ToDerivePublicKey
             when (input.factorSource) {
                 is LedgerHardwareWalletFactorSource -> {
-                    derivePublicKey().onSuccess {
-                        sendEvent(Event.AccessingFactorSourceCompleted)
+                    if (ensureBabylonFactorSourceExistUseCase.babylonFactorSourceExist()) {
+                        derivePublicKey().onSuccess {
+                            sendEvent(Event.AccessingFactorSourceCompleted)
+                        }
+                    } else {
+                        // 1st account created with ledger, so we need to create BDFS too and authenticate first
+                        sendEvent(Event.RequestBiometricPrompt)
                     }
                 }
+
                 is DeviceFactorSource,
                 null -> {
                     sendEvent(Event.RequestBiometricPrompt)


### PR DESCRIPTION
## Description
When creating first account (ledger or device) we need to authenticate since BDFS will be created. This was probably missed during FS refactor.

## How to test

1. Fresh wallet install, create account with ledger.
2. Before the change app will crash when selecting ledger

## PR submission checklist
- [x] I have tested account creation with ledger 
