### PR TITLE
Fix string to decimal conversion in guarantees sheet

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/Transferable.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/Transferable.kt
@@ -1,6 +1,5 @@
 package com.babylon.wallet.android.domain.model
 
-import androidx.annotation.FloatRange
 import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.NonFungibleLocalId
 import com.radixdlt.sargon.ResourceAddress
@@ -29,15 +28,15 @@ sealed interface Transferable {
 
                     when (val transferable = transferable) {
                         is TransferableAsset.Fungible.Token -> GuaranteeAssertion.ForAmount(
-                            amount = transferable.amount * predicted.guaranteeOffset.toDecimal192(),
+                            amount = transferable.amount * predicted.guaranteeOffset,
                             instructionIndex = predicted.instructionIndex
                         )
                         is TransferableAsset.Fungible.PoolUnitAsset -> GuaranteeAssertion.ForAmount(
-                            amount = transferable.amount * predicted.guaranteeOffset.toDecimal192(),
+                            amount = transferable.amount * predicted.guaranteeOffset,
                             instructionIndex = predicted.instructionIndex
                         )
                         is TransferableAsset.Fungible.LSUAsset -> GuaranteeAssertion.ForAmount(
-                            amount = transferable.amount * predicted.guaranteeOffset.toDecimal192(),
+                            amount = transferable.amount * predicted.guaranteeOffset,
                             instructionIndex = predicted.instructionIndex
                         )
                         is TransferableAsset.NonFungible.NFTAssets -> GuaranteeAssertion.ForNFT(
@@ -71,8 +70,7 @@ sealed interface Transferable {
     ) : Transferable
 
     fun updateGuarantee(
-        @FloatRange(from = 0.0)
-        guaranteeOffset: Double
+        guaranteeOffset: Decimal192
     ): Transferable {
         return when (this) {
             is Depositing -> {
@@ -103,13 +101,12 @@ sealed interface GuaranteeType {
     data object Guaranteed : GuaranteeType
     data class Predicted(
         val instructionIndex: Long,
-        @FloatRange(from = 0.0, to = 1.0)
-        val guaranteeOffset: Double
+        val guaranteeOffset: Decimal192
     ) : GuaranteeType {
 
         @Suppress("MagicNumber")
-        val guaranteePercent: Double
-            get() = guaranteeOffset * 100
+        val guaranteePercent: Decimal192
+            get() = guaranteeOffset * 100.toDecimal192()
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/accountsecurity/depositguarantees/DepositGuaranteesViewModel.kt
@@ -32,7 +32,7 @@ class DepositGuaranteesViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            updateDepositGuarantee(depositGuarantee = getProfileUseCase.defaultDepositGuarantee().toDecimal192())
+            updateDepositGuarantee(depositGuarantee = getProfileUseCase.defaultDepositGuarantee())
         }
     }
 
@@ -62,14 +62,14 @@ class DepositGuaranteesViewModel @Inject constructor(
     fun onDepositGuaranteeIncreased() {
         viewModelScope.launch {
             changeAndUpdateDepositGuarantee(
-                updatedDepositGuarantee = getProfileUseCase.defaultDepositGuarantee().toDecimal192() + DEPOSIT_CHANGE_THRESHOLD
+                updatedDepositGuarantee = getProfileUseCase.defaultDepositGuarantee() + DEPOSIT_CHANGE_THRESHOLD
             )
         }
     }
 
     fun onDepositGuaranteeDecreased() {
         viewModelScope.launch {
-            val updatedDepositGuarantee = (getProfileUseCase.defaultDepositGuarantee().toDecimal192() - DEPOSIT_CHANGE_THRESHOLD).clamped
+            val updatedDepositGuarantee = (getProfileUseCase.defaultDepositGuarantee() - DEPOSIT_CHANGE_THRESHOLD).clamped
             changeAndUpdateDepositGuarantee(
                 updatedDepositGuarantee = updatedDepositGuarantee
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolContributionProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolContributionProcessor.kt
@@ -5,11 +5,13 @@ import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddressUseCase
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
 import com.babylon.wallet.android.presentation.transaction.PreviewType
+import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.DetailedManifestClass
 import com.radixdlt.sargon.ExecutionSummary
 import com.radixdlt.sargon.extensions.address
 import com.radixdlt.sargon.extensions.orZero
 import com.radixdlt.sargon.extensions.sumOf
+import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.flow.first
 import rdx.works.core.domain.assets.Asset
 import rdx.works.core.domain.assets.PoolUnit
@@ -28,7 +30,7 @@ class PoolContributionProcessor @Inject constructor(
             fungibleAddresses = summary.involvedFungibleAddresses(),
             nonFungibleIds = summary.involvedNonFungibleIds()
         ).getOrThrow()
-        val defaultDepositGuarantee = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee
+        val defaultDepositGuarantee = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee.toDecimal192()
         val involvedOwnedAccounts = summary.involvedOwnedAccounts(getProfileUseCase.accountsOnCurrentNetwork())
         val from = summary.toWithdrawingAccountsWithTransferableAssets(assets, involvedOwnedAccounts)
         val to = summary.extractDeposits(
@@ -47,7 +49,7 @@ class PoolContributionProcessor @Inject constructor(
     private fun ExecutionSummary.extractDeposits(
         classification: DetailedManifestClass.PoolContribution,
         assets: List<Asset>,
-        defaultDepositGuarantee: Double,
+        defaultDepositGuarantee: Decimal192,
         involvedOwnedAccounts: List<Network.Account>
     ): List<AccountWithTransferableResources> {
         val to = deposits.map { depositsPerAddress ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolRedemptionProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolRedemptionProcessor.kt
@@ -10,6 +10,7 @@ import com.radixdlt.sargon.ExecutionSummary
 import com.radixdlt.sargon.extensions.address
 import com.radixdlt.sargon.extensions.orZero
 import com.radixdlt.sargon.extensions.sumOf
+import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.flow.first
 import rdx.works.core.domain.assets.PoolUnit
 import rdx.works.profile.domain.GetProfileUseCase
@@ -25,7 +26,7 @@ class PoolRedemptionProcessor @Inject constructor(
             fungibleAddresses = summary.involvedFungibleAddresses(),
             nonFungibleIds = summary.involvedNonFungibleIds()
         ).getOrThrow()
-        val defaultDepositGuarantees = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee
+        val defaultDepositGuarantees = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee.toDecimal192()
         val involvedOwnedAccounts = summary.involvedOwnedAccounts(getProfileUseCase.accountsOnCurrentNetwork())
         val to = summary.toDepositingAccountsWithTransferableAssets(
             allOwnedAccounts = involvedOwnedAccounts,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransactionTypeExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransactionTypeExtensions.kt
@@ -82,7 +82,7 @@ val ResourceIndicator.amount: Decimal192
         }
     }
 
-fun ResourceIndicator.guaranteeType(defaultGuarantee: Double) = when (this) {
+fun ResourceIndicator.guaranteeType(defaultGuarantee: Decimal192) = when (this) {
     is ResourceIndicator.Fungible -> when (val indicator = indicator) {
         is FungibleResourceIndicator.Guaranteed -> GuaranteeType.Guaranteed
         is FungibleResourceIndicator.Predicted -> GuaranteeType.Predicted(
@@ -350,7 +350,7 @@ fun ExecutionSummary.toWithdrawingAccountsWithTransferableAssets(
 fun ExecutionSummary.resolveDepositingAsset(
     resourceIndicator: ResourceIndicator,
     involvedAssets: List<Asset>,
-    defaultDepositGuarantee: Double,
+    defaultDepositGuarantee: Decimal192,
     aggregateAmount: Decimal192? = null
 ): Transferable.Depositing {
     val asset = resourceIndicator.newlyCreatedResource(summary = this)?.let { newlyCreatedResource ->
@@ -366,7 +366,7 @@ fun ExecutionSummary.resolveDepositingAsset(
 fun ExecutionSummary.toDepositingAccountsWithTransferableAssets(
     involvedAssets: List<Asset>,
     allOwnedAccounts: List<Network.Account>,
-    defaultGuarantee: Double
+    defaultGuarantee: Decimal192
 ) = deposits.map { depositEntry ->
     depositEntry.value.map { resource ->
         resolveDepositingAsset(resource, involvedAssets, defaultGuarantee)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorClaimProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorClaimProcessor.kt
@@ -5,11 +5,13 @@ import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddressUseCase
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
 import com.babylon.wallet.android.presentation.transaction.PreviewType
+import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.DetailedManifestClass
 import com.radixdlt.sargon.ExecutionSummary
 import com.radixdlt.sargon.ResourceIndicator
 import com.radixdlt.sargon.extensions.address
 import com.radixdlt.sargon.extensions.orZero
+import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.flow.first
 import rdx.works.core.domain.assets.Asset
 import rdx.works.core.domain.assets.LiquidStakeUnit
@@ -33,7 +35,7 @@ class ValidatorClaimProcessor @Inject constructor(
             fungibleAddresses = summary.involvedFungibleAddresses() + xrdAddress,
             nonFungibleIds = summary.involvedNonFungibleIds()
         ).getOrThrow()
-        val defaultDepositGuarantees = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee
+        val defaultDepositGuarantees = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee.toDecimal192()
         val involvedValidators = assets.filterIsInstance<LiquidStakeUnit>().map {
             it.validator
         }.toSet() + assets.filterIsInstance<StakeClaim>().map {
@@ -62,7 +64,7 @@ class ValidatorClaimProcessor @Inject constructor(
     private fun extractWithdrawals(
         executionSummary: ExecutionSummary,
         assets: List<Asset>,
-        defaultDepositGuarantees: Double,
+        defaultDepositGuarantees: Decimal192,
         involvedOwnedAccounts: List<Network.Account>
     ): List<AccountWithTransferableResources> {
         val stakeClaimNfts = assets.filterIsInstance<Asset.NonFungible>().map { it.resource.items }.flatten()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorStakeProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorStakeProcessor.kt
@@ -5,6 +5,7 @@ import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddressUseCase
 import com.babylon.wallet.android.presentation.transaction.AccountWithTransferableResources
 import com.babylon.wallet.android.presentation.transaction.PreviewType
+import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.DetailedManifestClass
 import com.radixdlt.sargon.ExecutionSummary
 import com.radixdlt.sargon.ResourceIndicator
@@ -12,6 +13,7 @@ import com.radixdlt.sargon.extensions.address
 import com.radixdlt.sargon.extensions.div
 import com.radixdlt.sargon.extensions.sumOf
 import com.radixdlt.sargon.extensions.times
+import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.flow.first
 import rdx.works.core.domain.assets.Asset
 import rdx.works.core.domain.assets.LiquidStakeUnit
@@ -58,7 +60,7 @@ class ValidatorStakeProcessor @Inject constructor(
         assets: List<Asset>,
         involvedOwnedAccounts: List<Network.Account>
     ) = executionSummary.deposits.map { depositsPerAccount ->
-        val defaultDepositGuarantees = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee
+        val defaultDepositGuarantees = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee.toDecimal192()
         depositsPerAccount.value.map { depositedResource ->
             val asset = assets.find {
                 it.resource.address == depositedResource.address
@@ -74,7 +76,7 @@ class ValidatorStakeProcessor @Inject constructor(
     private fun DetailedManifestClass.ValidatorStake.resolveLSU(
         asset: LiquidStakeUnit,
         depositedResource: ResourceIndicator,
-        defaultDepositGuarantees: Double
+        defaultDepositGuarantees: Decimal192
     ): Transferable.Depositing {
         val relatedStakes = validatorStakes.filter { it.liquidStakeUnitAddress == asset.resourceAddress }
         val totalStakedLsuForAccount = relatedStakes.sumOf { it.liquidStakeUnitAmount }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorUnstakeProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorUnstakeProcessor.kt
@@ -11,6 +11,7 @@ import com.radixdlt.sargon.NonFungibleGlobalId
 import com.radixdlt.sargon.ResourceIndicator
 import com.radixdlt.sargon.extensions.address
 import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.flow.first
 import rdx.works.core.domain.assets.Asset
 import rdx.works.core.domain.assets.LiquidStakeUnit
@@ -60,7 +61,7 @@ class ValidatorUnstakeProcessor @Inject constructor(
         assets: List<Asset>,
         involvedOwnedAccounts: List<Network.Account>
     ) = executionSummary.deposits.map { claimsPerAddress ->
-        val defaultDepositGuarantees = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee
+        val defaultDepositGuarantees = getProfileUseCase.invoke().first().appPreferences.transaction.defaultDepositGuarantee.toDecimal192()
         claimsPerAddress.value.map { claimedResource ->
             val asset = assets.find { it.resource.address == claimedResource.address } ?: error("No resource found")
             if (asset is StakeClaim) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/guarantees/TransactionGuaranteesDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/guarantees/TransactionGuaranteesDelegate.kt
@@ -9,6 +9,7 @@ import com.babylon.wallet.android.presentation.transaction.AccountWithTransferab
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel.State.Sheet
+import com.radixdlt.sargon.extensions.formatted
 import kotlinx.coroutines.flow.update
 import rdx.works.core.mapWhen
 import javax.inject.Inject
@@ -35,7 +36,7 @@ class TransactionGuaranteesDelegate @Inject constructor() : ViewModelDelegate<Tr
                                 address = depositing.address,
                                 transferable = amount.key,
                                 instructionIndex = amount.value.instructionIndex,
-                                guaranteeAmountString = amount.value.guaranteePercent.toString()
+                                guaranteeAmountString = amount.value.guaranteePercent.formatted()
                             )
                         )
                     }
@@ -48,7 +49,7 @@ class TransactionGuaranteesDelegate @Inject constructor() : ViewModelDelegate<Tr
                                 account = depositing.account,
                                 transferable = amount.key,
                                 instructionIndex = amount.value.instructionIndex,
-                                guaranteeAmountString = amount.value.guaranteePercent.toString()
+                                guaranteeAmountString = amount.value.guaranteePercent.formatted()
                             )
                         )
                     }

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -4,6 +4,7 @@ package rdx.works.profile.domain
 
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -182,7 +183,7 @@ val GetProfileUseCase.isBalanceVisible
  * Default deposit guarantee
  */
 suspend fun GetProfileUseCase.defaultDepositGuarantee() =
-    invoke().map { it.appPreferences.transaction.defaultDepositGuarantee }.first()
+    invoke().map { it.appPreferences.transaction.defaultDepositGuarantee.toDecimal192() }.first()
 
 fun Collection<Network.Account>.notHiddenAccounts(): List<Network.Account> {
     return filter { it.flags.contains(EntityFlag.DeletedByUser).not() }


### PR DESCRIPTION
## Description
The bug was due to the previous usage of `toString` upon the double value. Since the value has changed to `Decimal192` we need to use the `formatted()` method to convert it to a human readable string.
Some places were still used double for guarantee have now been changed to use `Decimal192`.


## How to test

1. Open any transaction that uses guarantees, such as gumball club or sandbox's pool contribution/redemption

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
