### PR TITLE
[ABW-3233] Properly set curve of account public key for legacy olympia accounts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,7 @@ android {
         minSdk rootProject.ext.minSdk
         targetSdk rootProject.ext.targetSdk
         versionCode 38
-        versionName "1.5.3"
+        versionName "1.5.4"
         buildConfigField "boolean", "DEBUG_MODE", "true"
         buildConfigField "boolean", "CRASH_REPORTING_AVAILABLE", "false"
         buildConfigField "boolean", "EXPERIMENTAL_FEATURES_ENABLED", "true"

--- a/profile/src/main/java/rdx/works/profile/data/model/extensions/CreateAccountExtensions.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/extensions/CreateAccountExtensions.kt
@@ -45,8 +45,13 @@ fun Profile.createAccount(
         ).addressString()
     }
 
+    val curve = if (isForLegacyOlympia) {
+        Slip10Curve.SECP_256K1
+    } else {
+        Slip10Curve.CURVE_25519
+    }
     val unsecuredSecurityState = SecurityState.unsecured(
-        publicKey = FactorInstance.PublicKey(compressedPublicKey.toHexString(), Slip10Curve.CURVE_25519),
+        publicKey = FactorInstance.PublicKey(compressedPublicKey.toHexString(), curve),
         derivationPath = derivationPath,
         factorSourceId = (factorSource as FactorSource).id as FactorSource.FactorSourceID.FromHash
     )

--- a/profile/src/main/java/rdx/works/profile/data/model/extensions/FactorInstanceExtensions.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/extensions/FactorInstanceExtensions.kt
@@ -1,0 +1,11 @@
+package rdx.works.profile.data.model.extensions
+
+import rdx.works.core.decodeHex
+import rdx.works.profile.data.model.factorsources.Slip10Curve
+import rdx.works.profile.data.model.pernetwork.FactorInstance
+
+@Suppress("MagicNumber")
+val FactorInstance.PublicKey.isInvalidCurve25519Key: Boolean
+    get() {
+        return curve == Slip10Curve.CURVE_25519 && compressedData.decodeHex().size != 32
+    }

--- a/profile/src/main/java/rdx/works/profile/data/model/pernetwork/FactorInstance.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/pernetwork/FactorInstance.kt
@@ -44,7 +44,7 @@ data class FactorInstance(
         }
     }
 
-    @Serializable
+    @Serializable(with = HDPublicKeySerializer::class)
     data class PublicKey(
         @SerialName("compressedData")
         val compressedData: String,

--- a/profile/src/main/java/rdx/works/profile/data/model/pernetwork/FactorInstanceSerializers.kt
+++ b/profile/src/main/java/rdx/works/profile/data/model/pernetwork/FactorInstanceSerializers.kt
@@ -1,11 +1,14 @@
 package rdx.works.profile.data.model.pernetwork
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import rdx.works.profile.data.model.extensions.isInvalidCurve25519Key
 import rdx.works.profile.data.model.factorsources.FactorSourceSurrogate
+import rdx.works.profile.data.model.factorsources.Slip10Curve
 
 @Serializable
 data class BadgeSurrogate(
@@ -38,6 +41,54 @@ object BadgeSerializer : KSerializer<FactorInstance.Badge> {
             else -> {
                 error("not supported Badge discriminator")
             }
+        }
+    }
+}
+
+object HDPublicKeySerializer : KSerializer<FactorInstance.PublicKey> {
+    private val surrogate = PublicKeySurrogate.serializer()
+    override val descriptor: SerialDescriptor = surrogate.descriptor
+
+    override fun serialize(encoder: Encoder, value: FactorInstance.PublicKey) {
+        val validPublicKey = if (value.isInvalidCurve25519Key) {
+            value.copy(curve = Slip10Curve.SECP_256K1)
+        } else {
+            value
+        }
+        surrogate.serialize(encoder, PublicKeySurrogate.fromPublicKey(validPublicKey))
+    }
+
+    override fun deserialize(decoder: Decoder): FactorInstance.PublicKey {
+        val decoded = surrogate.deserialize(decoder).toPublicKey()
+        return if (decoded.isInvalidCurve25519Key) {
+            decoded.copy(curve = Slip10Curve.SECP_256K1)
+        } else {
+            decoded
+        }
+    }
+}
+
+@Serializable
+data class PublicKeySurrogate(
+    @SerialName("compressedData")
+    val compressedData: String,
+
+    @SerialName("curve")
+    val curve: Slip10Curve
+) {
+    fun toPublicKey(): FactorInstance.PublicKey {
+        return FactorInstance.PublicKey(
+            compressedData = compressedData,
+            curve = curve
+        )
+    }
+
+    companion object {
+        fun fromPublicKey(publicKey: FactorInstance.PublicKey): PublicKeySurrogate {
+            return PublicKeySurrogate(
+                compressedData = publicKey.compressedData,
+                curve = publicKey.curve
+            )
         }
     }
 }

--- a/profile/src/test/java/rdx/works/profile/Secp256k1PublicKeyWithWrongCurveTest.kt
+++ b/profile/src/test/java/rdx/works/profile/Secp256k1PublicKeyWithWrongCurveTest.kt
@@ -1,0 +1,34 @@
+package rdx.works.profile
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import rdx.works.profile.data.model.factorsources.Slip10Curve
+import rdx.works.profile.data.model.pernetwork.FactorInstance
+import rdx.works.profile.data.model.pernetwork.PublicKeySurrogate
+import java.io.File
+import kotlin.test.assertEquals
+
+class Secp256k1PublicKeyWithWrongCurveTest {
+
+    @Test
+    fun `test secp256k1 public key with curve25519 decoding`() {
+        val publicKey = Json.decodeFromString<PublicKeySurrogate>(File(TEST_FILE).readText())
+        assertEquals(publicKey.curve, Slip10Curve.CURVE_25519) // error state
+        val publicKeyCorrect = Json.decodeFromString<FactorInstance.PublicKey>(File(TEST_FILE).readText())
+        assertEquals(publicKeyCorrect.curve, Slip10Curve.SECP_256K1) // correct state after decoding fix
+    }
+
+    @Test
+    fun `test secp256k1 public key with curve25519 encoding`() {
+        val publicKeyWithWrongCurve =
+            FactorInstance.PublicKey("023a41f437972033fa83c3c4df08dc7d68212ccac07396a29aca971ad5ba3c27c8", Slip10Curve.CURVE_25519)
+        val json = Json.encodeToString<FactorInstance.PublicKey>(publicKeyWithWrongCurve) // we encode with custom parser
+        val publicKeySurrogate = Json.decodeFromString<PublicKeySurrogate>(json) // decode with surrogate as is, no correction
+        assertEquals(publicKeySurrogate.curve, Slip10Curve.SECP_256K1) // error state
+    }
+
+    companion object {
+        private const val TEST_FILE = "src/test/resources/raw/secp256k1_public_key_with_curve25519_error.json"
+    }
+}

--- a/profile/src/test/resources/raw/secp256k1_public_key_with_curve25519_error.json
+++ b/profile/src/test/resources/raw/secp256k1_public_key_with_curve25519_error.json
@@ -1,0 +1,4 @@
+{
+  "curve": "curve25519",
+  "compressedData": "023a41f437972033fa83c3c4df08dc7d68212ccac07396a29aca971ad5ba3c27c8"
+}


### PR DESCRIPTION
## Description
Here is the issue https://radixdlt.atlassian.net/browse/ABW-3233


## How to test
- setup wallet
- do account recovery scan for olympia seed phrase that will result with at least 1 account added to profile
- on next wallet run you will see bdfs, and when you will try to execute transaction with this account as signer (for example transfer from that account), preview will return error

Executing above after the fix should not fire bdfs error and transactions with this account should be possible now

## PR submission checklist
- [x] I have importing olympia account before/after the fix and confirm that it works
