### PR TITLE
[ABW-3245] Fix empty history crash

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/history/HistoryViewModel.kt
@@ -78,17 +78,19 @@ class HistoryViewModel @Inject constructor(
                         it.copy(uiMessage = UiMessage.ErrorMessage(error = error))
                     }
                 }.firstOrNull().let { genesisTxInstant ->
-                    _state.update { state ->
-                        state.copy(
-                            filters = state.filters.copy(
-                                genesisTxDate = ZonedDateTime.ofInstant(
-                                    genesisTxInstant,
-                                    ZoneId.systemDefault()
+                    genesisTxInstant?.let {
+                        computeTimeFilters(it)
+                        _state.update { state ->
+                            state.copy(
+                                filters = state.filters.copy(
+                                    genesisTxDate = ZonedDateTime.ofInstant(
+                                        genesisTxInstant,
+                                        ZoneId.systemDefault()
+                                    )
                                 )
                             )
-                        )
+                        }
                     }
-                    genesisTxInstant?.let { computeTimeFilters(it) }
                     loadHistory()
                 }
             }


### PR DESCRIPTION
## Description
- in case there is no transaction (and no initial timestamp) we don't compute time filters and don't set timestamp in filters


## How to test

1. Open history of an empty account - you should see empty state

## PR submission checklist
- [x] I have tested empty history is displayed correctly
