### PR TITLE
[ABW-3285] Display incorrect seed phrase warning only if input is non empty

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/seedphrase/SeedPhraseInputDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/seedphrase/SeedPhraseInputDelegate.kt
@@ -140,15 +140,19 @@ class SeedPhraseInputDelegate(
         val wordAutocompleteCandidates: ImmutableList<String> = persistentListOf(),
     ) : UiState {
 
-        private val seedPhraseInputValid: Boolean
+        private val isInputEmpty: Boolean
+            get() = seedPhraseWords.all { it.state == SeedPhraseWord.State.Empty }
+
+        private val isSeedPhraseInputValid: Boolean
             get() = seedPhraseWords.all { it.valid }
 
-        fun isSeedPhraseValid(): Boolean {
-            val mnemonic = runCatching {
+        fun shouldDisplayInvalidSeedPhraseWarning(): Boolean {
+            if (isInputEmpty) {
+                return false
+            }
+            return !isSeedPhraseInputValid || runCatching {
                 Mnemonic.init(phrase = seedPhraseWords.joinToString(separator = " ") { it.value })
-            }.getOrNull()
-
-            return seedPhraseInputValid && mnemonic != null
+            }.getOrNull() == null
         }
 
         fun toMnemonicWithPassphrase(): MnemonicWithPassphrase = MnemonicWithPassphrase(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
@@ -161,7 +161,7 @@ private fun AddSingleMnemonicsContent(
                         .fillMaxWidth()
                 ) {
                     val isEnabled = remember(state.seedPhraseState) {
-                        state.seedPhraseState.isSeedPhraseValid()
+                        state.seedPhraseState.shouldDisplayInvalidSeedPhraseWarning()
                     }
                     RadixPrimaryButton(
                         modifier = Modifier
@@ -314,7 +314,7 @@ private fun SeedPhraseView(
         )
 
         val isInvalid = remember(seedPhraseState) {
-            !seedPhraseState.isSeedPhraseValid()
+            !seedPhraseState.shouldDisplayInvalidSeedPhraseWarning()
         }
 
         if (isInvalid) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -207,7 +207,7 @@ private fun RestoreMnemonicsContent(
                     }
 
                     val isSeedPhraseValid = remember(state.seedPhraseState) {
-                        state.seedPhraseState.isSeedPhraseValid()
+                        state.seedPhraseState.shouldDisplayInvalidSeedPhraseWarning()
                     }
                     RadixPrimaryButton(
                         modifier = Modifier
@@ -430,10 +430,10 @@ private fun SeedPhraseView(
             onPassphraseChanged = onPassphraseChanged,
             onFocusedWordIndexChanged = onFocusedWordIndexChanged
         )
-        val isSeedPhraseInvalid = remember(state.seedPhraseState) {
-            !state.seedPhraseState.isSeedPhraseValid()
+        val shouldDisplaySeedPhraseWarning = remember(state.seedPhraseState) {
+            state.seedPhraseState.shouldDisplayInvalidSeedPhraseWarning()
         }
-        if (isSeedPhraseInvalid) {
+        if (shouldDisplaySeedPhraseWarning) {
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
             RedWarningText(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/SettingsScreen.kt
@@ -71,7 +71,7 @@ private fun SettingsContent(
         modifier = modifier,
         topBar = {
             RadixCenteredTopAppBar(
-                title = stringResource(R.string.appSettings_title),
+                title = stringResource(R.string.walletSettings_title),
                 onBackClick = onBackClick,
                 contentColor = RadixTheme.colors.gray1,
                 windowInsets = WindowInsets.statusBars,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -833,7 +833,7 @@ private fun VerifyWithYourSeedPhrasePage(
         )
 
         val isSeedPhraseValid = remember(seedPhraseInputState) {
-            seedPhraseInputState.isSeedPhraseValid()
+            seedPhraseInputState.shouldDisplayInvalidSeedPhraseWarning()
         }
         if (!isSeedPhraseValid) {
             RedWarningText(


### PR DESCRIPTION
## Description


## How to test

1. Verify that warning is not shown on seed phrase entry screen if all inputs are empty

## Screenshot

## PR submission checklist
- [ ] I have tested that warning is only displayed when input is not empty
