### PR TITLE
[ABW-3285] Split state of seed phrase warning & and it's validity

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/seedphrase/SeedPhraseInputDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/seedphrase/SeedPhraseInputDelegate.kt
@@ -150,9 +150,16 @@ class SeedPhraseInputDelegate(
             if (isInputEmpty) {
                 return false
             }
-            return !isSeedPhraseInputValid || runCatching {
+            return !isValidSeedPhrase()
+        }
+
+        fun isValidSeedPhrase(): Boolean {
+            if (isInputEmpty) {
+                return false
+            }
+            return isSeedPhraseInputValid && runCatching {
                 Mnemonic.init(phrase = seedPhraseWords.joinToString(separator = " ") { it.value })
-            }.getOrNull() == null
+            }.getOrNull() != null
         }
 
         fun toMnemonicWithPassphrase(): MnemonicWithPassphrase = MnemonicWithPassphrase(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
@@ -161,7 +161,7 @@ private fun AddSingleMnemonicsContent(
                         .fillMaxWidth()
                 ) {
                     val isEnabled = remember(state.seedPhraseState) {
-                        state.seedPhraseState.shouldDisplayInvalidSeedPhraseWarning()
+                        state.seedPhraseState.isValidSeedPhrase()
                     }
                     RadixPrimaryButton(
                         modifier = Modifier
@@ -313,11 +313,11 @@ private fun SeedPhraseView(
             showAdvancedMode = isOlympia
         )
 
-        val isInvalid = remember(seedPhraseState) {
-            !seedPhraseState.shouldDisplayInvalidSeedPhraseWarning()
+        val shouldDisplayInvalidSeedPhraseWarning = remember(seedPhraseState) {
+            seedPhraseState.shouldDisplayInvalidSeedPhraseWarning()
         }
 
-        if (isInvalid) {
+        if (shouldDisplayInvalidSeedPhraseWarning) {
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
             RedWarningText(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -207,7 +207,7 @@ private fun RestoreMnemonicsContent(
                     }
 
                     val isSeedPhraseValid = remember(state.seedPhraseState) {
-                        state.seedPhraseState.shouldDisplayInvalidSeedPhraseWarning()
+                        state.seedPhraseState.isValidSeedPhrase()
                     }
                     RadixPrimaryButton(
                         modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -832,10 +832,10 @@ private fun VerifyWithYourSeedPhrasePage(
             onFocusedWordIndexChanged = onFocusedWordIndexChanged
         )
 
-        val isSeedPhraseValid = remember(seedPhraseInputState) {
+        val shouldDisplayInvalidSeedPhraseWarning = remember(seedPhraseInputState) {
             seedPhraseInputState.shouldDisplayInvalidSeedPhraseWarning()
         }
-        if (!isSeedPhraseValid) {
+        if (shouldDisplayInvalidSeedPhraseWarning) {
             RedWarningText(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -850,7 +850,7 @@ private fun VerifyWithYourSeedPhrasePage(
             },
             modifier = Modifier.fillMaxWidth(),
             throttleClicks = true,
-            enabled = isSeedPhraseValid
+            enabled = seedPhraseInputState.isValidSeedPhrase()
         )
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
     }


### PR DESCRIPTION
## Description
- with previous Seed phrase validation fix https://github.com/radixdlt/babylon-wallet-android/pull/909 I actually missed that same flag was controlling both warning visibility & "Continue" button enabled state. Additionally those flags are used in 3 places, which needed update as well.