### PR TITLE
Transaction fees fixes

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/SearchFeePayersUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/SearchFeePayersUseCase.kt
@@ -4,6 +4,7 @@ import com.babylon.wallet.android.data.repository.state.StateRepository
 import com.babylon.wallet.android.data.transaction.model.TransactionFeePayers
 import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.extensions.compareTo
+import com.radixdlt.sargon.extensions.isZero
 import rdx.works.core.domain.TransactionManifestData
 import rdx.works.core.sargon.activeAccountsOnCurrentNetwork
 import rdx.works.profile.domain.GetProfileUseCase
@@ -17,7 +18,9 @@ class SearchFeePayersUseCase @Inject constructor(
     suspend operator fun invoke(manifestData: TransactionManifestData, lockFee: Decimal192): Result<TransactionFeePayers> {
         val allAccounts = profileUseCase().activeAccountsOnCurrentNetwork
         return stateRepository.getOwnedXRD(accounts = allAccounts).map { accountsWithXRD ->
-            val candidates = accountsWithXRD.map { entry ->
+            val candidates = accountsWithXRD.mapNotNull { entry ->
+                if (entry.value.isZero) return@mapNotNull null
+
                 TransactionFeePayers.FeePayerCandidate(
                     account = entry.key,
                     xrdAmount = entry.value

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -364,6 +364,7 @@ private fun TransactionPreviewContent(
         DefaultModalSheetLayout(
             modifier = modifier.fillMaxSize(),
             sheetState = modalBottomSheetState,
+            enableImePadding = true,
             sheetContent = {
                 BottomSheetContent(
                     modifier = Modifier.navigationBarsPadding(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -286,6 +286,7 @@ class TransactionReviewViewModel @Inject constructor(
             transactionFees = transactionFees,
             sheetState = Sheet.CustomizeFees(
                 feePayerMode = Sheet.CustomizeFees.FeePayerMode.SelectFeePayer(
+                    preselectedCandidate = feePayers?.selectedAccountAddress,
                     candidates = feePayers?.candidates.orEmpty()
                 ),
                 feesMode = latestFeesMode
@@ -402,6 +403,7 @@ class TransactionReviewViewModel @Inject constructor(
                     ) : FeePayerMode
 
                     data class SelectFeePayer(
+                        val preselectedCandidate: AccountAddress?,
                         val candidates: List<TransactionFeePayers.FeePayerCandidate>
                     ) : FeePayerMode
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
@@ -45,6 +45,7 @@ import com.radixdlt.sargon.samples.sampleMainnet
 import rdx.works.core.domain.resources.XrdResource
 import kotlin.random.Random
 
+@Suppress("LongMethod")
 fun LazyListScope.feePayerSelectionContent(
     candidates: List<TransactionFeePayers.FeePayerCandidate>,
     selectedCandidateAddress: AccountAddress? = null,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
@@ -45,7 +45,6 @@ import com.radixdlt.sargon.samples.sampleMainnet
 import rdx.works.core.domain.resources.XrdResource
 import kotlin.random.Random
 
-@Suppress("LongMethod")
 fun LazyListScope.feePayerSelectionContent(
     candidates: List<TransactionFeePayers.FeePayerCandidate>,
     selectedCandidateAddress: AccountAddress? = null,
@@ -67,93 +66,107 @@ fun LazyListScope.feePayerSelectionContent(
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
     }
     items(candidates) { candidate ->
-        Card(
+        FeePayerCard(
+            candidate = candidate,
+            onPayerSelected = onPayerSelected,
+            selectedCandidateAddress = selectedCandidateAddress
+        )
+    }
+}
+
+@Composable
+private fun FeePayerCard(
+    modifier: Modifier = Modifier,
+    candidate: TransactionFeePayers.FeePayerCandidate,
+    onPayerSelected: (Account) -> Unit,
+    selectedCandidateAddress: AccountAddress?
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(RadixTheme.dimensions.paddingDefault),
+        shape = RadixTheme.shapes.roundedRectMedium,
+        colors = CardDefaults.cardColors(containerColor = RadixTheme.colors.defaultBackground),
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = 6.dp
+        )
+    ) {
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .background(
+                    brush = candidate.account.appearanceId.gradient(),
+                    shape = RadixTheme.shapes.roundedRectTopMedium
+                )
                 .padding(RadixTheme.dimensions.paddingDefault),
-            shape = RadixTheme.shapes.roundedRectMedium,
-            colors = CardDefaults.cardColors(containerColor = RadixTheme.colors.defaultBackground),
-            elevation = CardDefaults.elevatedCardElevation(
-                defaultElevation = 6.dp
-            )
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Row(
+            Text(
+                text = candidate.account.displayName.value,
+                textAlign = TextAlign.Start,
+                maxLines = 2,
+                style = RadixTheme.typography.body1Header,
+                color = Color.White
+            )
+
+            ActionableAddressView(
+                address = remember(candidate) {
+                    candidate.account.address.asGeneral()
+                },
+                textStyle = RadixTheme.typography.body2HighImportance,
+                textColor = RadixTheme.colors.white.copy(alpha = 0.8f)
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .throttleClickable {
+                    onPayerSelected(candidate.account)
+                }
+                .padding(start = RadixTheme.dimensions.paddingDefault)
+                .padding(vertical = RadixTheme.dimensions.paddingSmall),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_xrd_token),
+                contentDescription = null,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .background(
-                        brush = candidate.account.appearanceId.gradient(),
-                        shape = RadixTheme.shapes.roundedRectTopMedium
-                    )
-                    .padding(RadixTheme.dimensions.paddingDefault),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = candidate.account.displayName.value,
-                    textAlign = TextAlign.Start,
-                    maxLines = 2,
-                    style = RadixTheme.typography.body1Header,
-                    color = Color.White
-                )
+                    .size(24.dp)
+                    .clip(RadixTheme.shapes.circle),
+                tint = Color.Unspecified
+            )
 
-                ActionableAddressView(
-                    address = remember(candidate) {
-                        candidate.account.address.asGeneral()
-                    },
-                    textStyle = RadixTheme.typography.body2HighImportance,
-                    textColor = RadixTheme.colors.white.copy(alpha = 0.8f)
-                )
-            }
+            Spacer(modifier = Modifier.padding(RadixTheme.dimensions.paddingSmall))
+            Text(
+                modifier = Modifier.weight(1f),
+                text = XrdResource.SYMBOL,
+                style = RadixTheme.typography.body2HighImportance,
+                color = RadixTheme.colors.gray1,
+                maxLines = 1
+            )
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .throttleClickable {
-                        onPayerSelected(candidate.account)
-                    }
-                    .padding(start = RadixTheme.dimensions.paddingDefault)
-                    .padding(vertical = RadixTheme.dimensions.paddingSmall),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_xrd_token),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(24.dp)
-                        .clip(RadixTheme.shapes.circle),
-                    tint = Color.Unspecified
-                )
+            Text(
+                text = remember(candidate) {
+                    candidate.xrdAmount.formatted()
+                },
+                style = RadixTheme.typography.secondaryHeader,
+                color = RadixTheme.colors.gray1,
+                maxLines = 2
+            )
 
-                Spacer(modifier = Modifier.padding(RadixTheme.dimensions.paddingSmall))
-                Text(
-                    modifier = Modifier.weight(1f),
-                    text = XrdResource.SYMBOL,
-                    style = RadixTheme.typography.body2HighImportance,
-                    color = RadixTheme.colors.gray1,
-                    maxLines = 1
-                )
-
-                Text(
-                    text = remember(candidate) {
-                        candidate.xrdAmount.formatted()
-                    },
-                    style = RadixTheme.typography.secondaryHeader,
-                    color = RadixTheme.colors.gray1,
-                    maxLines = 2
-                )
-
-                RadioButton(
-                    selected = candidate.account.address == selectedCandidateAddress,
-                    colors = RadioButtonDefaults.colors(
-                        selectedColor = RadixTheme.colors.gray1,
-                        unselectedColor = RadixTheme.colors.gray3,
-                        disabledSelectedColor = Color.White
-                    ),
-                    onClick = {
-                        onPayerSelected(candidate.account)
-                    },
-                )
-            }
+            RadioButton(
+                selected = candidate.account.address == selectedCandidateAddress,
+                colors = RadioButtonDefaults.colors(
+                    selectedColor = RadixTheme.colors.gray1,
+                    unselectedColor = RadixTheme.colors.gray3,
+                    disabledSelectedColor = Color.White
+                ),
+                onClick = {
+                    onPayerSelected(candidate.account)
+                },
+            )
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
@@ -1,27 +1,53 @@
 package com.babylon.wallet.android.presentation.transaction.composables
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.data.transaction.model.TransactionFeePayers
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.gradient
-import com.babylon.wallet.android.presentation.dapp.authorized.account.AccountSelectionCard
+import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
+import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.ActionableAddressView
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.radixdlt.sargon.Account
+import com.radixdlt.sargon.AccountAddress
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.extensions.asGeneral
+import com.radixdlt.sargon.extensions.formatted
+import com.radixdlt.sargon.extensions.toDecimal192
+import com.radixdlt.sargon.samples.sampleMainnet
+import rdx.works.core.domain.resources.XrdResource
+import kotlin.random.Random
 
 fun LazyListScope.feePayerSelectionContent(
     candidates: List<TransactionFeePayers.FeePayerCandidate>,
+    selectedCandidateAddress: AccountAddress? = null,
     onPayerSelected: (Account) -> Unit
 ) {
     item {
@@ -40,26 +66,113 @@ fun LazyListScope.feePayerSelectionContent(
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
     }
     items(candidates) { candidate ->
-        AccountSelectionCard(
+        Card(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = RadixTheme.dimensions.paddingLarge)
-                .background(
-                    brush = candidate.account.appearanceId.gradient(),
-                    shape = RadixTheme.shapes.roundedRectMedium
+                .padding(RadixTheme.dimensions.paddingDefault),
+            shape = RadixTheme.shapes.roundedRectMedium,
+            colors = CardDefaults.cardColors(containerColor = RadixTheme.colors.defaultBackground),
+            elevation = CardDefaults.elevatedCardElevation(
+                defaultElevation = 6.dp
+            )
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        brush = candidate.account.appearanceId.gradient(),
+                        shape = RadixTheme.shapes.roundedRectTopMedium
+                    )
+                    .padding(RadixTheme.dimensions.paddingDefault),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = candidate.account.displayName.value,
+                    textAlign = TextAlign.Start,
+                    maxLines = 2,
+                    style = RadixTheme.typography.body1Header,
+                    color = Color.White
                 )
-                .clip(RadixTheme.shapes.roundedRectMedium)
-                .throttleClickable {
-                    onPayerSelected(candidate.account)
-                },
-            accountName = candidate.account.displayName.value,
-            address = candidate.account.address,
-            checked = false,
-            isSingleChoice = true,
-            radioButtonClicked = {
-                onPayerSelected(candidate.account)
+
+                ActionableAddressView(
+                    address = remember(candidate) {
+                        candidate.account.address.asGeneral()
+                    },
+                    textStyle = RadixTheme.typography.body2HighImportance,
+                    textColor = RadixTheme.colors.white.copy(alpha = 0.8f)
+                )
             }
-        )
-        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .throttleClickable {
+                        onPayerSelected(candidate.account)
+                    }
+                    .padding(start = RadixTheme.dimensions.paddingDefault)
+                    .padding(vertical = RadixTheme.dimensions.paddingSmall),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_xrd_token),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clip(RadixTheme.shapes.circle),
+                    tint = Color.Unspecified
+                )
+
+                Spacer(modifier = Modifier.padding(RadixTheme.dimensions.paddingSmall))
+                Text(
+                    modifier = Modifier.weight(1f),
+                    text = XrdResource.SYMBOL,
+                    style = RadixTheme.typography.body2HighImportance,
+                    color = RadixTheme.colors.gray1,
+                    maxLines = 1
+                )
+
+                Text(
+                    text = remember(candidate) {
+                        candidate.xrdAmount.formatted()
+                    },
+                    style = RadixTheme.typography.secondaryHeader,
+                    color = RadixTheme.colors.gray1,
+                    maxLines = 2
+                )
+
+                RadioButton(
+                    selected = candidate.account.address == selectedCandidateAddress,
+                    colors = RadioButtonDefaults.colors(
+                        selectedColor = RadixTheme.colors.gray1,
+                        unselectedColor = RadixTheme.colors.gray3,
+                        disabledSelectedColor = Color.White
+                    ),
+                    onClick = {
+                        onPayerSelected(candidate.account)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@UsesSampleValues
+@Preview
+@Composable
+fun FeesPayersSelectionContentPreview() {
+    val candidates = remember {
+        Account.sampleMainnet.all.map {
+            TransactionFeePayers.FeePayerCandidate(account = it, xrdAmount = Random.nextDouble(10000.0).toDecimal192())
+        }
+    }
+    RadixWalletPreviewTheme {
+        LazyColumn(modifier = Modifier.background(RadixTheme.colors.defaultBackground)) {
+            feePayerSelectionContent(
+                candidates = candidates,
+                selectedCandidateAddress = null,
+                onPayerSelected = {}
+            )
+        }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
@@ -53,9 +53,7 @@ fun FeesSheet(
     onViewAdvancedModeClick: () -> Unit
 ) {
     LazyColumn(
-        modifier = modifier
-            .fillMaxSize()
-            .imePadding()
+        modifier = modifier.fillMaxSize()
     ) {
         stickyHeader {
             BottomDialogHeader(
@@ -254,6 +252,7 @@ fun FeesSheet(
             is TransactionReviewViewModel.State.Sheet.CustomizeFees.FeePayerMode.SelectFeePayer -> {
                 feePayerSelectionContent(
                     candidates = feePayer.candidates,
+                    selectedCandidateAddress = feePayer.preselectedCandidate,
                     onPayerSelected = onPayerSelected
                 )
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardOptions

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/GuaranteesSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/GuaranteesSheet.kt
@@ -34,7 +34,7 @@ fun GuaranteesSheet(
     onGuaranteeValueDecreased: (AccountWithPredictedGuarantee) -> Unit,
 ) {
     Column(
-        modifier = modifier.imePadding()
+        modifier = modifier
     ) {
         BottomDialogHeader(
             modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/GuaranteesSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/GuaranteesSheet.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/SearchFeePayersUseCaseTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/SearchFeePayersUseCaseTest.kt
@@ -68,8 +68,7 @@ class SearchFeePayersUseCaseTest {
                 TransactionFeePayers(
                     selectedAccountAddress = account1.address,
                     candidates = listOf(
-                        TransactionFeePayers.FeePayerCandidate(account1, 100.toDecimal192()),
-                        TransactionFeePayers.FeePayerCandidate(account2, 0.toDecimal192())
+                        TransactionFeePayers.FeePayerCandidate(account1, 100.toDecimal192())
                     )
                 ),
                 result
@@ -87,8 +86,7 @@ class SearchFeePayersUseCaseTest {
                 TransactionFeePayers(
                     selectedAccountAddress = null,
                     candidates = listOf(
-                        TransactionFeePayers.FeePayerCandidate(account1, 100.toDecimal192()),
-                        TransactionFeePayers.FeePayerCandidate(account2, 0.toDecimal192())
+                        TransactionFeePayers.FeePayerCandidate(account1, 100.toDecimal192())
                     )
                 ),
                 result


### PR DESCRIPTION
## Description
* Fee payers include the amount of XRD on each account
* Transaction fee message changed
* Accounts with 0 XRD are filtered out from fee payers list as iOS does.


## How to test
1. Create 3 accounts
2. Put all xrd in one account
3. Transfer 0,1 XRD to the second account
4. Leave the third account empty
5. Do a transfer of any XRD from 1st to any account. 
6. Then in the list you should see fee payers as:
 * 1st Account
 * 2nd Account (which has insufficient funds, since the fee will logically be larger than 0,1)
 * The 3rd account should not be visible
 * If you select the 2nd Account, the message of insufficient funds will be displayed.
7. For some reason the selected fee payer was not pre-selected and the selection state was not kept. This PR also fixes this problem

## Screenshot
<img src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/20c19d27-646c-405b-ad4f-612c3d253e39" width="300">

## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
