### PR TITLE
[ABW-3321] Display one security prompt per account at a time

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
@@ -38,8 +38,7 @@ class GetEntitiesWithSecurityPromptUseCase @Inject constructor(
         val prompts = mutableSetOf<SecurityPromptType>().apply {
             if (!mnemonicRepository.mnemonicExist(factorSource.value.id.asGeneral())) {
                 add(SecurityPromptType.NEEDS_RESTORE)
-            }
-            if (!backedUpFactorSourceIds.contains(factorSourceId)) {
+            } else if (!backedUpFactorSourceIds.contains(factorSourceId)) {
                 add(SecurityPromptType.NEEDS_BACKUP)
             }
         }.toSet()


### PR DESCRIPTION
## Description
Before the fix, I was displaying "Recovery Required" and "Accounts and personas not recoverable" problems at the same time. My misunderstanding of intended behavior here.

## How to test

1. Restore profile that has some entites from backup but skip entering mnemonics.
2. After the fix you will only see "Recovery required" for a given seed phrase.

## PR submission checklist
- [ ] I have tested that there is only one problem at a time displayed for a seed phrsae

