### PR TITLE
Fix account refresh issue after network switching

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -44,7 +44,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.core.domain.assets.AssetPrice
@@ -161,7 +161,7 @@ class WalletViewModel @Inject constructor(
                     Timber.w(error)
                 }
             }
-            .onEach { accountsWithAssets ->
+            .mapLatest { accountsWithAssets ->
                 this.accountsWithAssets = accountsWithAssets
 
                 // keep the val here because the onAssetsReceived sets the refreshing to false


### PR DESCRIPTION
## Description
This PR fixes accounts refresh [issue](https://radixdlt.atlassian.net/browse/ABW-3227) after network switching.

Each time the user requests a refresh or the accounts change (for example when switching the network), we start fetching the fiat prices for every account asynchronously. Switching multiple times between the networks results in as many fetching operations launching which delays the accounts loading and displaying more and more. The fix is to stop waiting for the result of the previous fetching operation when a new one has started.


## How to test

1. Import a backup with many accounts (I've tested with 39 accounts on main and 27 on stokenet and the issue is very easy reproducible)
2. Refresh the account list
3. Switch network gateway from Settings -> Preferences
4. Go back to the account list and check the accounts are being properly loaded

## PR submission checklist
- [x] I have tested accounts refreshing after network switching
