### PR TITLE
[ABW-3199] Replace ModalBottomSheet to allow text field context actions to show

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
@@ -71,7 +71,7 @@ import com.babylon.wallet.android.presentation.account.settings.thirdpartydeposi
 import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.BottomDialogHeader
-import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
+import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
@@ -171,7 +171,7 @@ fun SpecificAssetsDepositsScreen(
                 sheetState.show()
             }
         },
-        modifier = Modifier
+        modifier = modifier
             .navigationBarsPadding()
             .fillMaxSize()
             .background(RadixTheme.colors.gray5),
@@ -181,33 +181,32 @@ fun SpecificAssetsDepositsScreen(
     )
 
     if (state.isAddAssetSheetVisible) {
-        DefaultModalSheetLayout(
-            modifier = modifier,
-            wrapContent = true,
-            sheetContent = {
-                AddAssetSheet(
-                    onResourceAddressChanged = sharedViewModel::assetExceptionAddressTyped,
-                    asset = state.assetExceptionToAdd,
-                    onAddAsset = {
-                        hideCallback()
-                        sharedViewModel.onAddAssetException()
-                    },
-                    modifier = Modifier
-                        .navigationBarsPadding()
-                        .fillMaxWidth()
-                        .clip(RadixTheme.shapes.roundedRectTopDefault),
-                    onAssetExceptionRuleChanged = sharedViewModel::onAssetExceptionRuleChanged,
-                    onDismiss = {
-                        hideCallback()
-                    }
-                )
-            },
+        BottomSheetDialogWrapper(
+            addScrim = true,
             showDragHandle = true,
-            sheetState = sheetState,
-            onDismissRequest = {
+            onDismiss = {
                 hideCallback()
-            }
-        )
+            },
+            showDefaultTopBar = false
+        ) {
+            AddAssetSheet(
+                onResourceAddressChanged = sharedViewModel::assetExceptionAddressTyped,
+                asset = state.assetExceptionToAdd,
+                onAddAsset = {
+                    hideCallback()
+                    sharedViewModel.onAddAssetException()
+                },
+                modifier = Modifier
+                    .navigationBarsPadding()
+                    .imePadding()
+                    .fillMaxWidth()
+                    .clip(RadixTheme.shapes.roundedRectTopDefault),
+                onAssetExceptionRuleChanged = sharedViewModel::onAssetExceptionRuleChanged,
+                onDismiss = {
+                    hideCallback()
+                }
+            )
+        }
     }
 }
 
@@ -424,6 +423,7 @@ private fun SpecificAssetsDepositsContent(
                                     .fillMaxSize()
                                     .padding(RadixTheme.dimensions.paddingDefault)
                             )
+
                             allowedAssets.isEmpty() -> {
                                 Text(
                                     modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
@@ -271,7 +271,7 @@ fun AddAssetSheet(
                 LabeledRadioButton(
                     modifier = Modifier.weight(1f),
                     label = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetAllow),
-                    selected = asset.assetException?.exceptionRule == DepositAddressExceptionRule.ALLOW,
+                    selected = asset.rule == DepositAddressExceptionRule.ALLOW,
                     onSelected = {
                         onAssetExceptionRuleChanged(DepositAddressExceptionRule.ALLOW)
                     }
@@ -279,7 +279,7 @@ fun AddAssetSheet(
                 LabeledRadioButton(
                     modifier = Modifier.weight(1f),
                     label = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetDeny),
-                    selected = asset.assetException?.exceptionRule == DepositAddressExceptionRule.DENY,
+                    selected = asset.rule == DepositAddressExceptionRule.DENY,
                     onSelected = {
                         onAssetExceptionRuleChanged(DepositAddressExceptionRule.DENY)
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
@@ -53,7 +53,7 @@ import com.babylon.wallet.android.presentation.account.settings.thirdpartydeposi
 import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.BottomDialogHeader
-import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
+import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
@@ -140,7 +140,7 @@ fun SpecificDepositorScreen(
                 sheetState.show()
             }
         },
-        modifier = Modifier
+        modifier = modifier
             .navigationBarsPadding()
             .fillMaxSize()
             .background(RadixTheme.colors.gray5),
@@ -149,32 +149,31 @@ fun SpecificDepositorScreen(
     )
 
     if (state.isAddDepositorSheetVisible) {
-        DefaultModalSheetLayout(
-            modifier = modifier.navigationBarsPadding(),
-            sheetContent = {
-                AddDepositorSheet(
-                    onResourceAddressChanged = sharedViewModel::depositorAddressTyped,
-                    onAddDepositor = {
-                        hideCallback()
-                        sharedViewModel.onAddDepositor()
-                    },
-                    modifier = Modifier
-                        .navigationBarsPadding()
-                        .fillMaxWidth()
-                        .clip(RadixTheme.shapes.roundedRectTopDefault),
-                    depositor = state.depositorToAdd,
-                    onDismiss = {
-                        hideCallback()
-                    }
-                )
-            },
+        BottomSheetDialogWrapper(
+            addScrim = true,
             showDragHandle = true,
-            wrapContent = true,
-            sheetState = sheetState,
-            onDismissRequest = {
+            onDismiss = {
                 hideCallback()
-            }
-        )
+            },
+            showDefaultTopBar = false
+        ) {
+            AddDepositorSheet(
+                onResourceAddressChanged = sharedViewModel::depositorAddressTyped,
+                onAddDepositor = {
+                    hideCallback()
+                    sharedViewModel.onAddDepositor()
+                },
+                modifier = Modifier
+                    .navigationBarsPadding()
+                    .imePadding()
+                    .fillMaxWidth()
+                    .clip(RadixTheme.shapes.roundedRectTopDefault),
+                depositor = state.depositorToAdd,
+                onDismiss = {
+                    hideCallback()
+                }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
@@ -48,7 +49,7 @@ import com.babylon.wallet.android.designsystem.composable.RadixTextField
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
-import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
+import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.radixdlt.sargon.Gateway
@@ -112,6 +113,7 @@ private fun GatewaysContent(
                 is SettingsEditGatewayEvent.CreateProfileOnNetwork -> {
                     onCreateProfile(it.newUrl, it.networkId)
                 }
+
                 else -> {
                     addGatewaySheetVisible(false)
                     scope.launch {
@@ -123,6 +125,7 @@ private fun GatewaysContent(
     }
 
     Scaffold(
+        modifier = modifier,
         topBar = {
             RadixCenteredTopAppBar(
                 title = stringResource(R.string.gateways_title),
@@ -132,7 +135,9 @@ private fun GatewaysContent(
         }
     ) { padding ->
         Column(
-            modifier = Modifier.padding(padding).fillMaxSize(),
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize(),
             horizontalAlignment = Alignment.Start
         ) {
             HorizontalDivider(color = RadixTheme.colors.gray5)
@@ -197,35 +202,33 @@ private fun GatewaysContent(
     }
 
     if (state.isAddGatewaySheetVisible) {
-        DefaultModalSheetLayout(
-            modifier = modifier,
-            sheetState = bottomSheetState,
-            wrapContent = true,
-            enableImePadding = true,
-            sheetContent = {
-                AddGatewaySheet(
-                    onAddGatewayClick = onAddGatewayClick,
-                    newUrl = state.newUrl,
-                    onNewUrlChanged = onNewUrlChanged,
-                    onClose = {
-                        addGatewaySheetVisible(false)
-                        scope.launch {
-                            bottomSheetState.hide()
-                        }
-                    },
-                    newUrlValid = state.newUrlValid,
-                    addingGateway = state.addingGateway,
-                    modifier = Modifier.navigationBarsPadding(),
-                    gatewayAddFailure = state.gatewayAddFailure
-                )
-            },
-            onDismissRequest = {
+        BottomSheetDialogWrapper(
+            addScrim = true,
+            showDragHandle = true,
+            onDismiss = {
                 addGatewaySheetVisible(false)
                 scope.launch {
                     bottomSheetState.hide()
                 }
-            }
-        )
+            },
+            showDefaultTopBar = false,
+        ) {
+            AddGatewaySheet(
+                onAddGatewayClick = onAddGatewayClick,
+                newUrl = state.newUrl,
+                onNewUrlChanged = onNewUrlChanged,
+                onClose = {
+                    addGatewaySheetVisible(false)
+                    scope.launch {
+                        bottomSheetState.hide()
+                    }
+                },
+                newUrlValid = state.newUrlValid,
+                addingGateway = state.addingGateway,
+                modifier = Modifier.navigationBarsPadding().imePadding(),
+                gatewayAddFailure = state.gatewayAddFailure
+            )
+        }
     }
 }
 
@@ -287,6 +290,7 @@ private fun AddGatewaySheet(
                 GatewayAddFailure.ErrorWhileAdding -> stringResource(
                     id = R.string.gateways_addNewGateway_establishingConnectionErrorMessage
                 )
+
                 else -> null
             }
         )


### PR DESCRIPTION
## Description
Modal bottom sheet from material3 library somehow prevent TextField contexttual actions to show, see [this](https://issuetracker.google.com/issues/327085717). Replaced it with our own bottom sheet dialog, as we done on transfer screen while ago. 

## How to test

1. Check that add gateway, add specific depositor, add asset rule dialogs work as before.
2. 
## PR submission checklist
- [x] I have verified that bottom dialogs work as before and copying into them is possible
