### PR TITLE
[ABW-3312] Fix compose IME crash when adding a ledger

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLedgerDeviceScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -93,6 +94,7 @@ fun AddLedgerDeviceScreen(
                     .fillMaxSize()
                     .background(RadixTheme.colors.defaultBackground)
             ) {
+                val imeController = LocalSoftwareKeyboardController.current
                 var ledgerNameValue by remember {
                     mutableStateOf("")
                 }
@@ -198,8 +200,8 @@ fun AddLedgerDeviceScreen(
                                 text = stringResource(com.babylon.wallet.android.R.string.addLedgerDevice_nameLedger_continueButtonTitle),
                                 enabled = ledgerNameValue.trim().isNotEmpty(),
                                 onClick = {
+                                    imeController?.hide()
                                     onConfirmLedgerNameClick(ledgerNameValue)
-                                    ledgerNameValue = ""
                                 },
                                 modifier = Modifier
                                     .fillMaxWidth()


### PR DESCRIPTION
## Description
So far this crash manifest itself only on samsung devices.
- don't update state of text field after we started process of storing ledger device and closing the screen
- close keyboard when user confirms saving ledger device.

I could easily reproduce issue on galaxy s21 ultra, and after the fix problem was gone.


## How to test

1. Try to add ledger device in account creation (first time) or from Security Factors/Ledger Devices. Make sure keyboard is visible on screen when tapping "Continue"

## PR submission checklist
- [x] I have tested adding ledger account on Samsung device
