### PR TITLE
Show dash instead of zero when token prices are not available

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
@@ -129,10 +129,7 @@ class MainnetFiatPriceRepository @Inject constructor(
                         addresses = allAddresses,
                         minValidity = tokenPriceCacheValidity()
                     ).toFiatPrices()
-                }.getOrElse {
-                    Timber.e("failed to fetch tokens prices with exception: ${it.message}")
-                    emptyMap()
-                }
+                }.getOrThrow()
             } else {
                 tokensPrices.toFiatPrices()
             }

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
@@ -17,7 +17,6 @@ import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.ResourceAddress
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.string
-import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
@@ -26,7 +25,6 @@ import rdx.works.core.domain.assets.SupportedCurrency
 import rdx.works.core.domain.resources.XrdResource
 import rdx.works.peerdroid.di.IoDispatcher
 import timber.log.Timber
-import java.lang.IllegalStateException
 import javax.inject.Inject
 import javax.inject.Qualifier
 import kotlin.random.Random
@@ -62,6 +60,7 @@ interface FiatPriceRepository {
     // This will not be needed when using sargon's Address types
     sealed interface PriceRequestAddress {
         val address: ResourceAddress
+
         data class Regular(override val address: ResourceAddress) : PriceRequestAddress
         data class LSU(override val address: ResourceAddress) : PriceRequestAddress
     }
@@ -187,22 +186,23 @@ class TestnetFiatPriceRepository @Inject constructor(
             currency = currency,
             isRefreshing = isRefreshing
         ).map { result ->
-            val prices = result.toMutableMap()
-            val xrdPrice = prices.remove(mainnetXrdAddress)
+            if (result.isNotEmpty()) {
+                val prices = result.toMutableMap()
+                val xrdPrice = prices.remove(mainnetXrdAddress)
 
-            addresses.associate { priceRequestAddress ->
-                if (prices.isEmpty()) {
-                    // if the token price service (getFiatPrices) returns emptyMap we can't give random price
-                    priceRequestAddress.address to FiatPrice(0.toDecimal192(), currency)
-                } else if (priceRequestAddress.address in XrdResource.addressesPerNetwork().values) {
-                    priceRequestAddress.address to xrdPrice
-                } else {
-                    val randomPrice = prices.entries.elementAt(Random.nextInt(prices.entries.size)).value
-                    priceRequestAddress.address to randomPrice
-                }
-            }.mapNotNull { addressAndFiatPrice ->
-                addressAndFiatPrice.value?.let { fiatPrice -> addressAndFiatPrice.key to fiatPrice }
-            }.toMap()
+                addresses.associate { priceRequestAddress ->
+                    if (priceRequestAddress.address in XrdResource.addressesPerNetwork().values) {
+                        priceRequestAddress.address to xrdPrice
+                    } else {
+                        val randomPrice = prices.entries.elementAt(Random.nextInt(prices.entries.size)).value
+                        priceRequestAddress.address to randomPrice
+                    }
+                }.mapNotNull { addressAndFiatPrice ->
+                    addressAndFiatPrice.value?.let { fiatPrice -> addressAndFiatPrice.key to fiatPrice }
+                }.toMap()
+            } else {
+                emptyMap()
+            }
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
@@ -130,7 +130,7 @@ class AccountViewModel @Inject constructor(
                             _state.update { state ->
                                 state.copy(
                                     assetsWithAssetsPrices = assetsPrices.associateBy { it.asset },
-                                    hasFailedToFetchPricesForAccount = false
+                                    hasFailedToFetchPricesForAccount = assetsPrices.any { it.price == null }
                                 )
                             }
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
@@ -130,7 +130,7 @@ class AccountViewModel @Inject constructor(
                             _state.update { state ->
                                 state.copy(
                                     assetsWithAssetsPrices = assetsPrices.associateBy { it.asset },
-                                    hasFailedToFetchPricesForAccount = assetsPrices.any { it.price == null }
+                                    hasFailedToFetchPricesForAccount = false
                                 )
                             }
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -1,6 +1,5 @@
 package com.babylon.wallet.android.presentation.wallet
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,6 +16,7 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material3.Badge
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -216,13 +216,6 @@ private fun WalletContent(
                 onRadixBannerDismiss = onRadixBannerDismiss
             )
 
-            AnimatedVisibility(
-                modifier = Modifier.align(Alignment.Center),
-                visible = state.isLoading
-            ) {
-                CircularProgressIndicator(color = RadixTheme.colors.gray1)
-            }
-
             PullRefreshIndicator(
                 refreshing = state.isRefreshing,
                 state = pullRefreshState,
@@ -265,7 +258,7 @@ private fun WalletAccountList(
                 Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXSmall))
                 TotalFiatBalanceView(
                     fiatPrice = state.totalFiatValueOfWallet,
-                    isLoading = remember(state.totalFiatValueOfWallet) { state.totalFiatValueOfWallet == null },
+                    isLoading = state.isLoading,
                     currency = SupportedCurrency.USD,
                     formattedContentStyle = RadixTheme.typography.header,
                     onVisibilityToggle = onShowHideBalanceToggle,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
-import androidx.compose.material3.Badge
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -319,11 +319,11 @@ class WalletViewModel @Inject constructor(
     }
 
     /**
-     * if at least one account failed to fetch at least one price then return Zero
+     * if at least one account failed to fetch at least one price then return null
      */
     private fun buildTotalFiatValue(): FiatPrice? {
         val isAnyAccountTotalFailed = accountsAddressesWithAssetsPrices?.values?.any { assetsPrices ->
-            assetsPrices == null
+            assetsPrices == null || assetsPrices.any { it.price == null }
         } ?: false
         if (isAnyAccountTotalFailed) return null
 
@@ -355,10 +355,9 @@ class WalletViewModel @Inject constructor(
         }
 
         val assetsPrices = accountsAddressesWithAssetsPrices?.get(accountAddress) ?: return null
+        val hasAllPrices = assetsPrices.all { assetPrice -> assetPrice.price != null }
 
-        val hasAtLeastOnePrice = assetsPrices.any { assetPrice -> assetPrice.price != null }
-
-        return if (hasAtLeastOnePrice) {
+        return if (hasAllPrices) {
             var total = 0.toDecimal192()
             var currency = SupportedCurrency.USD
             assetsPrices.forEach { assetPrice ->
@@ -367,7 +366,7 @@ class WalletViewModel @Inject constructor(
             }
             FiatPrice(price = total, currency = currency)
         } else {
-            FiatPrice(price = 0.toDecimal192(), currency = SupportedCurrency.USD)
+            null
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -319,11 +319,11 @@ class WalletViewModel @Inject constructor(
     }
 
     /**
-     * if at least one account failed to fetch at least one price then return null
+     * if at least one account failed to fetch prices then return null
      */
     private fun buildTotalFiatValue(): FiatPrice? {
         val isAnyAccountTotalFailed = accountsAddressesWithAssetsPrices?.values?.any { assetsPrices ->
-            assetsPrices == null || assetsPrices.any { it.price == null }
+            assetsPrices == null
         } ?: false
         if (isAnyAccountTotalFailed) return null
 
@@ -355,9 +355,9 @@ class WalletViewModel @Inject constructor(
         }
 
         val assetsPrices = accountsAddressesWithAssetsPrices?.get(accountAddress) ?: return null
-        val hasAllPrices = assetsPrices.all { assetPrice -> assetPrice.price != null }
+        val hasAtLeastOnePrice = assetsPrices.any { assetPrice -> assetPrice.price != null }
 
-        return if (hasAllPrices) {
+        return if (hasAtLeastOnePrice) {
             var total = 0.toDecimal192()
             var currency = SupportedCurrency.USD
             assetsPrices.forEach { assetPrice ->


### PR DESCRIPTION
[Ticket](https://radixdlt.atlassian.net/browse/ABW-3338)

## Description
This PR updates the displayed value for assets' worth from "0" to "-" when the token prices API fails and there are no prices saved in db. 

## Video
[untitled.webm](https://github.com/radixdlt/babylon-wallet-android/assets/164897324/684fa0bb-9ff9-44d7-a20b-092059a382d1)

## PR submission checklist
- [x] I have tested the displayed value for assets' worth when price/tokens api returns 500
- [x] I have tested the displayed value for assets' worth when price/tokens api returns 200
