### PR TITLE
Fix connecting to ledger device when creating first account

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/p2plink/P2PLinksRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/p2plink/P2PLinksRepository.kt
@@ -61,6 +61,7 @@ class P2PLinksRepositoryImpl @Inject constructor(
                     .orEmpty()
                     .asIdentifiable()
             }
+            .distinctUntilChanged()
             .flowOn(ioDispatcher)
     }
 

--- a/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetProfileUseCase.kt
@@ -4,7 +4,6 @@ import com.radixdlt.sargon.Profile
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.map
 import rdx.works.core.domain.ProfileState
 import rdx.works.profile.data.repository.ProfileRepository
 import rdx.works.profile.data.repository.profile
@@ -32,9 +31,6 @@ class GetProfileUseCase @Inject constructor(private val profileRepository: Profi
         .firstOrNull()?.let { state ->
             isInitialized(state)
         } == true
-
-    fun observeIsInitialized(): Flow<Boolean> = profileRepository.profileState
-        .map { state -> isInitialized(state) }
 
     private fun isInitialized(state: ProfileState): Boolean {
         return state is ProfileState.Restored && state.hasNetworks()


### PR DESCRIPTION
## Description
This PR fixes connecting to a ledger device when creating the first account during onboarding.

The issue was that the p2p links connection was conditioned by the profile being initialized, but we need p2p links connection during onboarding when adding a ledger device and there is no restored profile.

## How to test

Case 1:
1. Choose "I'm a new radix wallet user"
2. Skip until "Create First Account" screen
4. Check "Create with ledger hardware wallet"
5. Click "Add Ledger Device"
6. Link a connector
7. Click "Continue" and make sure the ledger connection request is displayed in the browser

Case 2:
1. Create/restore a profile
2. Add a linked connector from settings
3. Factory reset wallet
4. Create/restore a profile
5. Make sure the accounts are synced with the connector extension and/or the dApp requests are working


## PR submission checklist
- [x] I have tested the cases described above