### PR TITLE
Add loading spinner in Backup screen when cloud auth is in progress

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
@@ -400,8 +400,8 @@ private fun BackupStatusCard(
                     contentDescription = null
                 )
             },
-            enabled = isCloudAuthorizationInProgress.not(),
             onCheckedChange = onBackupCheckChanged,
+            isLoading = isCloudAuthorizationInProgress
         )
         if (cloudBackupState is CloudBackupState.Disabled) {
             Text(
@@ -809,6 +809,18 @@ fun BackupStatusCardPreview() {
         BackupStatusCard(
             cloudBackupState = CloudBackupState.Enabled(email = "my cool email"),
             isCloudAuthorizationInProgress = false,
+            onBackupCheckChanged = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun BackupStatusCarAuthInProgressPreview() {
+    RadixWalletPreviewTheme {
+        BackupStatusCard(
+            cloudBackupState = CloudBackupState.Enabled(email = "my cool email"),
+            isCloudAuthorizationInProgress = true,
             onBackupCheckChanged = {}
         )
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupViewModel.kt
@@ -72,6 +72,7 @@ class BackupViewModel @Inject constructor(
     }
 
     fun onBackupSettingChanged(isChecked: Boolean) = viewModelScope.launch {
+        Timber.tag("CloudBackup").d("Cloud backup toggle is: $isChecked")
         if (isChecked) {
             Timber.tag("CloudBackup").d("Cloud backup authorization is in progress...")
             _state.update { it.copy(isCloudAuthorizationInProgress = true) }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SwitchSettingsItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SwitchSettingsItem.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,9 +18,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixSwitch
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
 
 @Composable
 fun SwitchSettingsItem(
@@ -29,6 +34,7 @@ fun SwitchSettingsItem(
     onCheckedChange: (Boolean) -> Unit,
     icon: @Composable (() -> Unit)? = null,
     @StringRes subtitleRes: Int? = null,
+    isLoading: Boolean = false
 ) {
     Row(
         modifier = modifier,
@@ -56,11 +62,22 @@ fun SwitchSettingsItem(
             }
         }
 
-        RadixSwitch(
-            checked = checked,
-            enabled = enabled,
-            onCheckedChange = onCheckedChange
-        )
+        if (isLoading) {
+            Box(
+                modifier = Modifier.height(28.dp)
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center),
+                    color = RadixTheme.colors.gray1
+                )
+            }
+        } else {
+            RadixSwitch(
+                checked = checked,
+                enabled = enabled,
+                onCheckedChange = onCheckedChange
+            )
+        }
     }
 }
 
@@ -89,4 +106,43 @@ fun SwitchSettingsItem(
         },
         subtitleRes = subtitleRes
     )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SwitchSettingsItemPreview() {
+    RadixWalletPreviewTheme {
+        SwitchSettingsItem(
+            titleRes = R.string.configurationBackup_automated_toggleAndroid,
+            checked = true,
+            icon = {
+                Icon(
+                    painter = painterResource(id = DSR.ic_backup),
+                    tint = RadixTheme.colors.gray1,
+                    contentDescription = null
+                )
+            },
+            onCheckedChange = { },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SwitchSettingsItemLoadingPreview() {
+    RadixWalletPreviewTheme {
+        SwitchSettingsItem(
+            titleRes = R.string.configurationBackup_automated_toggleAndroid,
+            checked = true,
+            icon = {
+                Icon(
+                    painter = painterResource(id = DSR.ic_backup),
+                    tint = RadixTheme.colors.gray1,
+                    contentDescription = null
+                )
+            },
+            onCheckedChange = { },
+            isLoading = true
+        )
+    }
 }

--- a/profile/src/main/java/rdx/works/profile/cloudbackup/data/DriveClient.kt
+++ b/profile/src/main/java/rdx/works/profile/cloudbackup/data/DriveClient.kt
@@ -178,6 +178,7 @@ class DriveClientImpl @Inject constructor(
         updatedHeader: Header
     ): Result<CloudBackupFileEntity> = withContext(ioDispatcher) {
         runCatching {
+            Timber.tag("CloudBackup").d("Start claiming process with file id: ${file.id}")
             googleSignInManager.getDrive().files()
                 .update(
                     file.id.id,
@@ -202,6 +203,7 @@ class DriveClientImpl @Inject constructor(
         profile: Profile
     ): Result<CloudBackupFileEntity> = withContext(ioDispatcher) {
         runCatching {
+            Timber.tag("CloudBackup").d("Create backup file")
             val driveFile = CloudBackupFileEntity.newDriveFile(profile.header)
             val backupContent = ByteArrayContent("application/json", profile.toJson().toByteArray())
 

--- a/profile/src/main/java/rdx/works/profile/cloudbackup/data/GoogleSignInManager.kt
+++ b/profile/src/main/java/rdx/works/profile/cloudbackup/data/GoogleSignInManager.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withContext
 import rdx.works.core.mapError
 import rdx.works.core.then
 import rdx.works.profile.BuildConfig
+import rdx.works.profile.cloudbackup.domain.CloudBackupErrorStream
 import rdx.works.profile.cloudbackup.model.BackupServiceException
 import rdx.works.profile.cloudbackup.model.GoogleAccount
 import rdx.works.profile.di.coroutines.IoDispatcher
@@ -35,6 +36,7 @@ import kotlin.coroutines.resume
 class GoogleSignInManager @Inject constructor(
     @ApplicationContext private val applicationContext: Context,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val cloudBackupErrorStream: CloudBackupErrorStream
 ) {
 
     fun createSignInIntent(): Intent = getGoogleSignInClient(applicationContext).signInIntent
@@ -75,6 +77,7 @@ class GoogleSignInManager @Inject constructor(
                     }
             }
         }.then { googleAccount ->
+            cloudBackupErrorStream.resetErrors()
             ensureAccessToDrive(googleAccount)
         }.onFailure {
             if (it is BackupServiceException.UnauthorizedException) {

--- a/profile/src/main/java/rdx/works/profile/data/repository/DeviceInfoRepository.kt
+++ b/profile/src/main/java/rdx/works/profile/data/repository/DeviceInfoRepository.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import rdx.works.core.domain.DeviceInfo
+import timber.log.Timber
 import javax.inject.Inject
 
 interface DeviceInfoRepository {
@@ -21,7 +22,9 @@ class DeviceInfoRepositoryImpl @Inject constructor(
         val storedDeviceInfo = getStoredDeviceInfo(context)
 
         if (storedDeviceInfo != null) {
-            return storedDeviceInfo
+            return storedDeviceInfo.also {
+                Timber.d("Device id exists: ${it.id}")
+            }
         }
 
         val generated = DeviceInfo.factory(context)
@@ -29,7 +32,9 @@ class DeviceInfoRepositoryImpl @Inject constructor(
             putString(DEVICE_INFO, Json.encodeToString(generated))
         }
 
-        return generated
+        return generated.also {
+            Timber.d("Generated device id: ${generated.id}")
+        }
     }
 
     private fun getStoredDeviceInfo(context: Context): DeviceInfo? {

--- a/profile/src/main/java/rdx/works/profile/domain/backup/CloudBackupFileEntity.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/CloudBackupFileEntity.kt
@@ -65,18 +65,18 @@ data class CloudBackupFileEntity(
     }
 
     companion object {
-        const val HEADER_SNAPSHOT_VERSION = "header.snapshot_version"
-        const val HEADER_PROFILE_ID = "header.profile_id"
-        const val HEADER_LAST_MODIFIED = "header.last_modified"
-        const val HEADER_CREATING_DEVICE_ID = "header.creating_device.id"
-        const val HEADER_CREATING_DEVICE_DATE = "header.creating_device.date"
-        const val HEADER_CREATING_DEVICE_DESCRIPTION = "header.creating_device.description"
-        const val HEADER_LAST_USED_ON_DEVICE_ID = "header.last_used_on_device.id"
-        const val HEADER_LAST_USED_ON_DEVICE_DATE = "header.last_used_on_device.date"
-        const val HEADER_LAST_USED_ON_DEVICE_DESCRIPTION = "header.last_used_on_device.description"
-        const val HEADER_CONTENT_HINT_TOTAL_ACCOUNTS = "header.content_hint.total_accounts"
-        const val HEADER_CONTENT_HINT_TOTAL_PERSONAS = "header.content_hint.total_personas"
-        const val HEADER_CONTENT_HINT_TOTAL_NETWORKS = "header.content_hint.total_networks"
+        const val HEADER_SNAPSHOT_VERSION = "snapshotVersion"
+        const val HEADER_PROFILE_ID = "profileID"
+        const val HEADER_LAST_MODIFIED = "lastModified"
+        const val HEADER_CREATING_DEVICE_ID = "creatingDeviceID"
+        const val HEADER_CREATING_DEVICE_DATE = "creatingDeviceDate"
+        const val HEADER_CREATING_DEVICE_DESCRIPTION = "creatingDeviceDescription"
+        const val HEADER_LAST_USED_ON_DEVICE_ID = "lastUsedOnDeviceID"
+        const val HEADER_LAST_USED_ON_DEVICE_DATE = "lastUsedOnDeviceDate"
+        const val HEADER_LAST_USED_ON_DEVICE_DESCRIPTION = "lastUsedOnDeviceDescription"
+        const val HEADER_CONTENT_HINT_TOTAL_ACCOUNTS = "numberOfAccounts"
+        const val HEADER_CONTENT_HINT_TOTAL_PERSONAS = "numberOfPersonas"
+        const val HEADER_CONTENT_HINT_TOTAL_NETWORKS = "numberOfNetworks"
 
         const val LAST_USED_DATE_FORMAT_SHORT_MONTH = "d MMM yyyy"
 


### PR DESCRIPTION
## Description
This PR 
- adds a loading spinner in Backup screen when cloud auth is in progress
- resets the backup errors when user signs in - that caused some UI bugs previously
- updates the cloud metadata keys after a sync with iOS team


## How to test

1. Delete wallet from Drive settings
2. Perform a clean install ❗ 


## PR submission checklist
- [X] I have tested cloud backups 
