### PR TITLE
Refine when the migration to new backup system screen is shown

### DIFF
--- a/profile/src/main/java/rdx/works/profile/cloudbackup/domain/CheckMigrationToNewBackupSystemUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/cloudbackup/domain/CheckMigrationToNewBackupSystemUseCase.kt
@@ -4,6 +4,7 @@ import android.app.backup.BackupManager
 import kotlinx.coroutines.flow.firstOrNull
 import rdx.works.core.preferences.PreferencesManager
 import rdx.works.core.sargon.canBackupToCloud
+import rdx.works.profile.cloudbackup.data.GoogleSignInManager
 import rdx.works.profile.data.repository.ProfileRepository
 import rdx.works.profile.data.repository.profile
 import javax.inject.Inject
@@ -11,13 +12,14 @@ import javax.inject.Inject
 class CheckMigrationToNewBackupSystemUseCase @Inject constructor(
     private val profileRepository: ProfileRepository,
     private val preferencesManager: PreferencesManager,
+    private val googleSignInManager: GoogleSignInManager,
     private val oldBackupManager: BackupManager,
 ) {
 
     suspend operator fun invoke(): Boolean {
         val profile = profileRepository.profile.firstOrNull() ?: return false
 
-        return profile.canBackupToCloud && preferencesManager.isUsingDeprecatedCloudBackup()
+        return profile.canBackupToCloud && preferencesManager.isUsingDeprecatedCloudBackup() && !googleSignInManager.isSignedIn()
     }
 
     suspend fun revokeAccessToDeprecatedCloudBackup() {

--- a/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
@@ -9,6 +9,7 @@ import rdx.works.core.sargon.babylon
 import rdx.works.core.sargon.changeGatewayToNetworkId
 import rdx.works.core.sargon.claim
 import rdx.works.core.then
+import rdx.works.core.toUnitResult
 import rdx.works.profile.cloudbackup.data.DriveClient
 import rdx.works.profile.cloudbackup.domain.CheckMigrationToNewBackupSystemUseCase
 import rdx.works.profile.data.repository.BackupProfileRepository
@@ -65,8 +66,12 @@ class RestoreProfileFromBackupUseCase @Inject constructor(
                     profileRepository.saveProfile(profileToSave)
                     backupProfileRepository.discardTemporaryRestoringSnapshot(backupType)
                     checkMigrationToNewBackupSystemUseCase.revokeAccessToDeprecatedCloudBackup()
-                }.map { }
+                }.toUnitResult()
             } else {
+                if (backupType is BackupType.DeprecatedCloud) {
+                    checkMigrationToNewBackupSystemUseCase.revokeAccessToDeprecatedCloudBackup()
+                }
+
                 Timber.tag("CloudBackup").d("Save profile")
                 profileRepository.saveProfile(profileToSave)
                 backupProfileRepository.discardTemporaryRestoringSnapshot(backupType)


### PR DESCRIPTION
## Description
There is this edge case were an old user had backed up with the previous backup system, deleted the app and installed the new one.

In the restoration process, logs in and selects the backup (restored from the old backup system `DeprecatedCloud`) and proceeds to restore the seed phrase. The migration screen was still shown.

So to fix that we also need to check that either a backup with the new system has not occurred by looking at the preference that shows that the previous system is in use and the user is not signed in yet.

Also in order to avoid showing the migration modal, we also remove the preference used by the old system, when the user restored from deprecated cloud.