### PR TITLE
Save contents while claiming

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/walletclaimed/ClaimedByAnotherDeviceViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/walletclaimed/ClaimedByAnotherDeviceViewModel.kt
@@ -43,11 +43,11 @@ class ClaimedByAnotherDeviceViewModel @Inject constructor(
         val currentProfile = profileRepository.profile.firstOrNull() ?: return@launch
 
         _state.update { it.copy(isReclaiming = true) }
-        val updatedHeader = currentProfile.claim(deviceInfo = deviceInfoRepository.getDeviceInfo()).header
+        val claimingProfile = currentProfile.claim(deviceInfo = deviceInfoRepository.getDeviceInfo())
 
         driveClient.claimCloudBackup(
             file = args.claimedEntity,
-            updatedHeader = updatedHeader
+            claimingProfile = claimingProfile
         ).onSuccess {
             cloudBackupErrorStream.resetErrors()
             sendEvent(Event.Reclaimed)

--- a/profile/src/main/java/rdx/works/profile/cloudbackup/data/DriveClient.kt
+++ b/profile/src/main/java/rdx/works/profile/cloudbackup/data/DriveClient.kt
@@ -4,7 +4,6 @@ import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAuthIO
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.ByteArrayContent
 import com.google.api.services.drive.model.File
-import com.radixdlt.sargon.Header
 import com.radixdlt.sargon.Profile
 import com.radixdlt.sargon.extensions.toJson
 import kotlinx.coroutines.CoroutineDispatcher

--- a/profile/src/main/java/rdx/works/profile/cloudbackup/data/DriveClient.kt
+++ b/profile/src/main/java/rdx/works/profile/cloudbackup/data/DriveClient.kt
@@ -54,7 +54,7 @@ interface DriveClient {
 
     suspend fun claimCloudBackup(
         file: CloudBackupFileEntity,
-        updatedHeader: Header
+        claimingProfile: Profile
     ): Result<CloudBackupFileEntity>
 }
 
@@ -111,7 +111,7 @@ class DriveClientImpl @Inject constructor(
                         // 2. The user exports the same profile to file.
                         // 3. Either restores this device or in a new device, imports the exported file
                         // 4. This file has the same profile id, but also exists on cloud. We need to claim it.
-                        claimCloudBackup(file = existingBackup, updatedHeader = profile.header)
+                        claimCloudBackup(file = existingBackup, claimingProfile = profile)
                     }
                 }
         } else {
@@ -175,14 +175,15 @@ class DriveClientImpl @Inject constructor(
 
     override suspend fun claimCloudBackup(
         file: CloudBackupFileEntity,
-        updatedHeader: Header
+        claimingProfile: Profile
     ): Result<CloudBackupFileEntity> = withContext(ioDispatcher) {
         runCatching {
             Timber.tag("CloudBackup").d("Start claiming process with file id: ${file.id}")
             googleSignInManager.getDrive().files()
                 .update(
                     file.id.id,
-                    file.claim(header = updatedHeader) // Updates the lastUsedOnDevice.id
+                    file.claim(header = claimingProfile.header), // Updates the lastUsedOnDevice.id
+                    ByteArrayContent("application/json", claimingProfile.toJson().toByteArray())
                 )
                 .setFields(claimFields)
                 .execute()
@@ -192,7 +193,7 @@ class DriveClientImpl @Inject constructor(
             preferencesManager.updateLastCloudBackupEvent(
                 LastCloudBackupEvent(
                     fileId = entity.id,
-                    profileModifiedTime = updatedHeader.lastModified,
+                    profileModifiedTime = claimingProfile.header.lastModified,
                     cloudBackupTime = entity.lastBackup
                 )
             )

--- a/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
@@ -60,7 +60,7 @@ class RestoreProfileFromBackupUseCase @Inject constructor(
                 Timber.tag("CloudBackup").d("☁\uFE0F Claiming Profile...")
                 driveClient.claimCloudBackup(
                     file = backupType.entity,
-                    updatedHeader = profileToSave.header
+                    claimingProfile = profileToSave
                 ).onSuccess {
                     Timber.tag("CloudBackup").d("☁\uFE0F Profile claimed, and now save it")
                     profileRepository.saveProfile(profileToSave)


### PR DESCRIPTION
## Description
When claiming the profile it is not only necessary to update the metadata of the file but it is safe to also update the contents of the file to depict the current profile in the device.

One very nice example is:
1. User connects to **Account A** and backs up. (A **file_id_A** is created)
2. User disconnects from that account and connects to **Account B**.
3. The backup process will start again trying to backup to **file_id_A** wich will result in `404` and us deleting this id locally. The backup executor will retry without showing the error.
4. Upon retry since no file id exists, will end up in the `createBackupFile` which will create the profile in **B** with **file_id_B**
5. But the user decides to disconnect from **B**, same as (3) we will end up deleting `file_id_B` due to `404`.
6. User makes a change to the profile (e.g. "Creates a persona")
7. The user connects back to **A**.
8. We don't have any local file id to refer to so we need to query the current state of the drive files. Here an old version of the same profile exists with the same profile id, so the `claimCloudBackup` is called.
9. This method **needs to also update the contents of the file** along with the metadata.