### PR TITLE
[ABW-3409] Properly display ledger errors which are cause of signing error

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -309,13 +309,16 @@ fun RadixWalletException.LinkConnectionException.toUserFriendlyMessage(context: 
     RadixWalletException.LinkConnectionException.OldQRVersion -> {
         context.getString(R.string.linkedConnectors_oldQRErrorMessage)
     }
+
     RadixWalletException.LinkConnectionException.InvalidQR,
     RadixWalletException.LinkConnectionException.InvalidSignature -> {
         context.getString(R.string.linkedConnectors_incorrectQrMessage)
     }
+
     RadixWalletException.LinkConnectionException.PurposeChangeNotSupported -> {
         context.getString(R.string.linkedConnectors_changingPurposeNotSupportedErrorMessage)
     }
+
     RadixWalletException.LinkConnectionException.UnknownPurpose -> {
         context.getString(R.string.linkedConnectors_unknownPurposeErrorMessage)
     }
@@ -380,12 +383,19 @@ fun RadixWalletException.PrepareTransactionException.toUserFriendlyMessage(conte
 
             is RadixWalletException.PrepareTransactionException.CompileTransactionIntent -> R.string.error_transactionFailure_prepare
             is RadixWalletException.PrepareTransactionException.SignCompiledTransactionIntent ->
-                if (this.cause is ProfileException.NoMnemonic) {
-                    R.string.transactionReview_noMnemonicError_text
-                } else {
-                    R.string.error_transactionFailure_prepare
-                }
+                when (val cause = this.cause) {
+                    is ProfileException.NoMnemonic -> {
+                        R.string.transactionReview_noMnemonicError_text
+                    }
 
+                    is RadixWalletException.LedgerCommunicationException -> {
+                        return cause.toUserFriendlyMessage(context)
+                    }
+
+                    else -> {
+                        R.string.error_transactionFailure_prepare
+                    }
+                }
             RadixWalletException.PrepareTransactionException.ReceivingAccountDoesNotAllowDeposits ->
                 R.string.error_transactionFailure_doesNotAllowThirdPartyDeposits
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -434,7 +434,8 @@ data class TransactionErrorMessage(
         get() = isNoMnemonicErrorVisible ||
             error is RadixWalletException.PrepareTransactionException.ReceivingAccountDoesNotAllowDeposits ||
             error is RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities ||
-            error is RadixWalletException.LedgerCommunicationException.FailedToSignTransaction
+            error is RadixWalletException.LedgerCommunicationException.FailedToSignTransaction ||
+            error is RadixWalletException.PrepareTransactionException.SignCompiledTransactionIntent
 
     val uiMessage: UiMessage = UiMessage.ErrorMessage(error)
 


### PR DESCRIPTION
## Description
Depth of nested errors in this case is really getting out of hand. I did this change to not break anything else, but we should really simplify exceptions hierarchy at some point.
## How to test

1. Trigger transaction that requires blind signing, validate that error message is shown

## PR submission checklist
- [x] I have tested ledger signing with blind signing disabled
