### PR TITLE
[ABW-3412] Update to seed phrase empty condition

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/seedphrase/SeedPhraseInputDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/seedphrase/SeedPhraseInputDelegate.kt
@@ -141,7 +141,7 @@ class SeedPhraseInputDelegate(
     ) : UiState {
 
         private val isInputEmpty: Boolean
-            get() = seedPhraseWords.all { it.state == SeedPhraseWord.State.Empty }
+            get() = seedPhraseWords.any { it.state == SeedPhraseWord.State.Empty }
 
         private val isSeedPhraseInputValid: Boolean
             get() = seedPhraseWords.all { it.valid }


### PR DESCRIPTION
## How to test

1. Verify that seed phrase incorrect warning shows only when all input fields are non-empty