### PR TITLE
[ABW-3408] - Fallback to 0 when fiat prices can't be converted to Decimal192

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/gateway/model/TokensAndLsusPricesResponse.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/gateway/model/TokensAndLsusPricesResponse.kt
@@ -3,7 +3,8 @@ package com.babylon.wallet.android.data.gateway.model
 import com.babylon.wallet.android.data.repository.cache.database.TokenPriceEntity
 import com.radixdlt.sargon.ResourceAddress
 import com.radixdlt.sargon.extensions.init
-import com.radixdlt.sargon.extensions.toDecimal192
+import com.radixdlt.sargon.extensions.orZero
+import com.radixdlt.sargon.extensions.toDecimal192OrNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import rdx.works.core.InstantGenerator
@@ -44,7 +45,7 @@ data class TokensAndLsusPricesResponse(
             val lsus = this.lsus.map { lsuPrice ->
                 TokenPriceEntity(
                     resourceAddress = ResourceAddress.init(lsuPrice.resourceAddress),
-                    price = lsuPrice.usdPrice.toDecimal192(),
+                    price = lsuPrice.usdPrice.toDecimal192OrNull().orZero(),
                     currency = SupportedCurrency.USD.code,
                     synced = instantGenerator
                 )
@@ -52,7 +53,7 @@ data class TokensAndLsusPricesResponse(
             val tokens = this.tokens.map { tokenPrice ->
                 TokenPriceEntity(
                     resourceAddress = ResourceAddress.init(tokenPrice.resourceAddress),
-                    price = tokenPrice.usdPrice.toDecimal192(),
+                    price = tokenPrice.usdPrice.toDecimal192OrNull().orZero(),
                     currency = SupportedCurrency.USD.code,
                     synced = instantGenerator
                 )


### PR DESCRIPTION
## Description
This PR fixes fiat values not being displayed if the prices can't be converted to Decimal192 by falling back to 0.
