### PR TITLE
Do not show warning when cloud backup is disabled and manual backup is updated

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
@@ -7,8 +7,7 @@ import com.radixdlt.sargon.extensions.asGeneral
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
-import rdx.works.core.domain.cloudbackup.CloudBackupDisabled
-import rdx.works.core.domain.cloudbackup.CloudBackupServiceError
+import rdx.works.core.domain.cloudbackup.BackupWarning
 import rdx.works.core.domain.cloudbackup.CloudBackupState
 import rdx.works.core.preferences.PreferencesManager
 import rdx.works.core.sargon.allEntitiesOnCurrentNetwork
@@ -48,14 +47,11 @@ class GetEntitiesWithSecurityPromptUseCase @Inject constructor(
         val prompts = mutableSetOf<SecurityPromptType>().apply {
             cloudBackupState.backupWarning?.let { backupWarning ->
                 when (backupWarning) {
-                    is CloudBackupDisabled -> {
-                        if (backupWarning.hasUpdatedManualBackup) {
-                            add(SecurityPromptType.CONFIGURATION_BACKUP_NOT_UPDATED)
-                        } else {
-                            add(SecurityPromptType.WALLET_NOT_RECOVERABLE)
-                        }
-                    }
-                    CloudBackupServiceError -> add(SecurityPromptType.CONFIGURATION_BACKUP_PROBLEM)
+                    BackupWarning.CLOUD_BACKUP_SERVICE_ERROR -> add(SecurityPromptType.CONFIGURATION_BACKUP_PROBLEM)
+                    BackupWarning.CLOUD_BACKUP_DISABLED_WITH_NO_MANUAL_BACKUP -> add(SecurityPromptType.WALLET_NOT_RECOVERABLE)
+                    BackupWarning.CLOUD_BACKUP_DISABLED_WITH_OUTDATED_MANUAL_BACKUP -> add(
+                        SecurityPromptType.CONFIGURATION_BACKUP_NOT_UPDATED
+                    )
                 }
             }
 

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetSecurityProblemsUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetSecurityProblemsUseCase.kt
@@ -43,7 +43,7 @@ class GetSecurityProblemsUseCase @Inject constructor(
 
         mutableSetOf<SecurityProblem>().apply {
             // entities that need cloud backup
-            if (cloudBackupState is CloudBackupState.Disabled) {
+            if (cloudBackupState is CloudBackupState.Disabled && cloudBackupState.isNotUpdated) {
                 add(
                     SecurityProblem.CloudBackupNotWorking.Disabled(
                         isAnyActivePersonaAffected = activePersonasNeedCloudBackup > 0,

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCaseTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCaseTest.kt
@@ -1,0 +1,109 @@
+package com.babylon.wallet.android.domain.usecases
+
+import com.babylon.wallet.android.fakes.FakePreferenceManager
+import com.babylon.wallet.android.fakes.FakeProfileRepository
+import com.babylon.wallet.android.presentation.TestDispatcherRule
+import com.radixdlt.sargon.Gateway
+import com.radixdlt.sargon.NetworkId
+import com.radixdlt.sargon.Profile
+import com.radixdlt.sargon.extensions.forNetwork
+import com.radixdlt.sargon.samples.sample
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import rdx.works.core.TimestampGenerator
+import rdx.works.core.domain.cloudbackup.CloudBackupState
+import rdx.works.core.sargon.changeGateway
+import rdx.works.profile.data.repository.MnemonicRepository
+import rdx.works.profile.domain.GetProfileUseCase
+import rdx.works.profile.domain.backup.GetCloudBackupStateUseCase
+
+@ExperimentalCoroutinesApi
+class GetEntitiesWithSecurityPromptUseCaseTest {
+
+    @get:Rule
+    val coroutineRule = TestDispatcherRule()
+
+    private val profile = Profile.sample().changeGateway(Gateway.forNetwork(NetworkId.MAINNET))
+    private val mnemonicRepositoryMock = mockk<MnemonicRepository>()
+    private val getCloudBackupStateUseCaseMock = mockk<GetCloudBackupStateUseCase>()
+
+    private val getEntitiesWithSecurityPromptUseCase = GetEntitiesWithSecurityPromptUseCase(
+        getProfileUseCase = GetProfileUseCase(profileRepository = FakeProfileRepository(profile)),
+        preferencesManager = FakePreferenceManager(),
+        mnemonicRepository = mnemonicRepositoryMock,
+        getCloudBackupStateUseCase = getCloudBackupStateUseCaseMock
+    )
+
+    @Test
+    fun `when cloud backup is disabled but manual backup file is updated then no security prompt`() = runTest {
+        // no recovery required
+        coEvery { mnemonicRepositoryMock.mnemonicExist(key = any()) } returns true
+
+        val now = TimestampGenerator()
+        val oneDayBefore = now.minusDays(1)
+        // when cloud backup disabled but user has exported an updated manual backup file
+        coEvery { getCloudBackupStateUseCaseMock() } returns flowOf(
+            CloudBackupState.Disabled(
+                email = "email",
+                lastCloudBackupTime = oneDayBefore,
+                lastManualBackupTime = now.toInstant(),
+                lastModifiedProfileTime = oneDayBefore
+            )
+        )
+
+        val event = mutableListOf<List<EntityWithSecurityPrompt>>()
+        getEntitiesWithSecurityPromptUseCase().onEach {
+            event.add(it)
+        }.launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+        advanceUntilIdle()
+
+        val entityWithSecurityPromptList = event.first()
+        val prompts = entityWithSecurityPromptList.flatMap { it.prompts }
+
+        Assert.assertTrue(prompts.isEmpty())
+    }
+
+    @Test
+    fun `when cloud backup is enabled but not working then security prompt is problem with configuration backup`() = runTest {
+        // no recovery required
+        coEvery { mnemonicRepositoryMock.mnemonicExist(key = any()) } returns true
+
+        val now = TimestampGenerator()
+        val oneDayBefore = now.minusDays(1)
+        // when cloud backup is enabled but not working, for example unavailable service
+        coEvery { getCloudBackupStateUseCaseMock() } returns flowOf(
+            CloudBackupState.Enabled(
+                email = "email",
+                hasAnyErrors = true,
+                lastCloudBackupTime = oneDayBefore,
+                lastManualBackupTime = now.toInstant(),
+                lastModifiedProfileTime = oneDayBefore
+            )
+        )
+
+        val event = mutableListOf<List<EntityWithSecurityPrompt>>()
+        getEntitiesWithSecurityPromptUseCase().onEach {
+            event.add(it)
+        }.launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+        advanceUntilIdle()
+
+        val entityWithSecurityPromptList = event.first()
+        val prompts = entityWithSecurityPromptList.flatMap { it.prompts }
+
+        Assert.assertTrue(prompts.isNotEmpty())
+        Assert.assertTrue(prompts.contains(SecurityPromptType.CONFIGURATION_BACKUP_PROBLEM))
+    }
+}

--- a/app/src/test/java/com/babylon/wallet/android/fakes/FakePreferenceManager.kt
+++ b/app/src/test/java/com/babylon/wallet/android/fakes/FakePreferenceManager.kt
@@ -4,10 +4,20 @@ import androidx.datastore.preferences.core.Preferences
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.Epoch
 import com.radixdlt.sargon.FactorSourceId
+import com.radixdlt.sargon.Gateway
+import com.radixdlt.sargon.NetworkId
+import com.radixdlt.sargon.Profile
+import com.radixdlt.sargon.extensions.forNetwork
+import com.radixdlt.sargon.extensions.id
+import com.radixdlt.sargon.samples.sample
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import rdx.works.core.domain.cloudbackup.LastCloudBackupEvent
 import rdx.works.core.preferences.PreferencesManager
+import rdx.works.core.sargon.allEntitiesOnCurrentNetwork
+import rdx.works.core.sargon.changeGateway
+import rdx.works.core.sargon.factorSourceId
 import java.time.Instant
 
 class FakePreferenceManager : PreferencesManager {
@@ -71,7 +81,16 @@ class FakePreferenceManager : PreferencesManager {
     }
 
     override fun getBackedUpFactorSourceIds(): Flow<Set<FactorSourceId.Hash>> {
-        TODO("Not yet implemented")
+        val profile = Profile.sample().changeGateway(Gateway.forNetwork(NetworkId.MAINNET))
+        return flowOf(
+            profile.factorSources
+                .filter {
+                    it.id is FactorSourceId.Hash
+                }.map {
+                    it.id as FactorSourceId.Hash
+                }
+                .toSet()
+        )
     }
 
     override suspend fun markFactorSourceBackedUp(id: FactorSourceId.Hash) {


### PR DESCRIPTION
## Description
This PR adds logic to not show backup warnings when a user has an updated manual backup file. See the `CloudBackupState` and the thread in slack.


## How to test

1. Create a wallet and perform a cloud backup
2. Disabled cloud backup and do some updates in your profile
3. You will see backup warnings in the screens
4. Now export a manual backup file
5. You will not see any backup warnings **until you make a new change in your profile!**


## PR submission checklist
- [X] I have tested the above flow
- [X] I have written unit tests
