### PR TITLE
Fix p2p links observing

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
@@ -89,6 +90,7 @@ class MainViewModel @Inject constructor(
                 else -> p2PLinksRepository.observeP2PLinks().drop(1)
             }
         }
+        .distinctUntilChanged()
         .map { p2pLinks ->
             Timber.d("found ${p2pLinks.size} p2p links")
             p2pLinks.asList().forEach { p2PLink ->


### PR DESCRIPTION
## Description
This PR fixes unnecessary p2p link connection code being called whenever the profile is updated. This is not an issue as there is a guard check in the connector so the actual connection code is not executed again, but it's good to have this prevented at a higher lever anyway.
