### PR TITLE
[ABW-3430] Display hidden accounts only state in seed phrases list item

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/SeedPhrasesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/SeedPhrasesScreen.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.presentation.settings.securitycenter.seedphrases
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,6 +25,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -193,21 +195,21 @@ fun SeedPhraseCard(
                 Text(
                     text = stringResource(
                         id = if (data.personas.isNotEmpty()) {
-                            if (data.accounts.size == 1) {
+                            if (data.allAccounts.size == 1) {
                                 R.string.displayMnemonics_connectedAccountsPersonasLabel_one
                             } else {
                                 R.string.displayMnemonics_connectedAccountsPersonasLabel_many
                             }
                         } else {
-                            if (data.accounts.size == 1) {
+                            if (data.allAccounts.size == 1) {
                                 R.string.displayMnemonics_connectedAccountsLabel_one
-                            } else if (data.accounts.isEmpty()) {
+                            } else if (data.allAccounts.isEmpty()) {
                                 R.string.seedPhrases_seedPhrase_noConnectedAccountsReveal
                             } else {
                                 R.string.displayMnemonics_connectedAccountsLabel_many
                             }
                         },
-                        data.accounts.size
+                        data.allAccounts.size
                     ),
                     style = RadixTheme.typography.body2Regular,
                     color = RadixTheme.colors.gray2,
@@ -231,11 +233,25 @@ fun SeedPhraseCard(
             )
         }
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXSmall))
-        data.accounts.forEach { account ->
-            SimpleAccountCard(
-                modifier = Modifier.fillMaxWidth(),
-                account = account
+        if (data.hasOnlyHiddenAccounts) {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = RadixTheme.dimensions.paddingXXXXLarge)
+                    .background(RadixTheme.colors.gray5, shape = RadixTheme.shapes.roundedRectMedium)
+                    .padding(RadixTheme.dimensions.paddingXXLarge),
+                text = stringResource(id = R.string.seedPhrases_hiddenAccountsOnly),
+                textAlign = TextAlign.Center,
+                style = RadixTheme.typography.body1HighImportance,
+                color = RadixTheme.colors.gray2
             )
+        } else {
+            data.allAccounts.forEach { account ->
+                SimpleAccountCard(
+                    modifier = Modifier.fillMaxWidth(),
+                    account = account
+                )
+            }
         }
     }
 }
@@ -250,12 +266,14 @@ fun SeedPhrasesWithAccountsAndPersonasPreview() {
             deviceFactorSourceData = persistentListOf(
                 DeviceFactorSourceData(
                     deviceFactorSource = FactorSource.Device.sample(),
-                    accounts = Account.sampleMainnet.all,
-                    personas = Persona.sampleMainnet.all
+                    allAccounts = Account.sampleMainnet.all,
+                    personas = Persona.sampleMainnet.all,
+                    hasOnlyHiddenAccounts = false
                 ),
                 DeviceFactorSourceData(
                     deviceFactorSource = FactorSource.Device.sample.other(),
-                    accounts = persistentListOf(Account.sampleMainnet())
+                    allAccounts = persistentListOf(Account.sampleMainnet()),
+                    hasOnlyHiddenAccounts = true
                 )
             ),
             onSeedPhraseClick = {}
@@ -276,7 +294,7 @@ fun SeedPhrasesWithoutAccountsAndPersonasPreview() {
                 ),
                 DeviceFactorSourceData(
                     deviceFactorSource = FactorSource.Device.sample.other(),
-                    accounts = persistentListOf(Account.sampleMainnet())
+                    allAccounts = persistentListOf(Account.sampleMainnet())
                 )
             ),
             onSeedPhraseClick = {}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/SeedPhrasesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/SeedPhrasesScreen.kt
@@ -267,13 +267,11 @@ fun SeedPhrasesWithAccountsAndPersonasPreview() {
                 DeviceFactorSourceData(
                     deviceFactorSource = FactorSource.Device.sample(),
                     allAccounts = Account.sampleMainnet.all,
-                    personas = Persona.sampleMainnet.all,
-                    hasOnlyHiddenAccounts = false
+                    personas = Persona.sampleMainnet.all
                 ),
                 DeviceFactorSourceData(
                     deviceFactorSource = FactorSource.Device.sample.other(),
-                    allAccounts = persistentListOf(Account.sampleMainnet()),
-                    hasOnlyHiddenAccounts = true
+                    allAccounts = persistentListOf(Account.sampleMainnet())
                 )
             ),
             onSeedPhraseClick = {}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/SeedPhrasesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/SeedPhrasesScreen.kt
@@ -246,7 +246,7 @@ fun SeedPhraseCard(
                 color = RadixTheme.colors.gray2
             )
         } else {
-            data.allAccounts.forEach { account ->
+            data.notHiddenAccounts.forEach { account ->
                 SimpleAccountCard(
                     modifier = Modifier.fillMaxWidth(),
                     account = account

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/accountrecoveryscan/chooseseed/ChooseSeedPhraseScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/accountrecoveryscan/chooseseed/ChooseSeedPhraseScreen.kt
@@ -222,12 +222,12 @@ fun SeedPhraseCard(
                 )
                 Text(
                     text = stringResource(
-                        id = if (data.accounts.size == 1) {
+                        id = if (data.allAccounts.size == 1) {
                             R.string.displayMnemonics_connectedAccountsLabel_one
                         } else {
                             R.string.displayMnemonics_connectedAccountsLabel_many
                         },
-                        data.accounts.size
+                        data.allAccounts.size
                     ),
                     style = RadixTheme.typography.body2Regular,
                     color = RadixTheme.colors.gray2,
@@ -245,9 +245,9 @@ fun SeedPhraseCard(
                 onClick = onSelectionChanged,
             )
         }
-        if (data.accounts.isNotEmpty()) {
+        if (data.allAccounts.isNotEmpty()) {
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXSmall))
-            data.accounts.forEach { account ->
+            data.allAccounts.forEach { account ->
                 SimpleAccountCard(
                     modifier = Modifier.fillMaxWidth(),
                     account = account

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/accountrecoveryscan/chooseseed/ChooseSeedPhraseViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/accountrecoveryscan/chooseseed/ChooseSeedPhraseViewModel.kt
@@ -49,7 +49,7 @@ class ChooseSeedPhraseViewModel @Inject constructor(
                 var updated = factorSources.map { entry ->
                     val data = DeviceFactorSourceData(
                         deviceFactorSource = entry.key,
-                        accounts = entry.value.toPersistentList()
+                        allAccounts = entry.value.toPersistentList()
                     )
                     Selectable(data, selected = existing.any { it.data.deviceFactorSource.id == entry.key.id && it.selected })
                 }

--- a/profile/src/main/java/rdx/works/profile/domain/DeviceFactorSourceData.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/DeviceFactorSourceData.kt
@@ -3,6 +3,7 @@ package rdx.works.profile.domain
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.Persona
+import rdx.works.core.sargon.notHiddenAccounts
 
 data class DeviceFactorSourceData(
     val deviceFactorSource: FactorSource.Device,
@@ -15,4 +16,6 @@ data class DeviceFactorSourceData(
     enum class MnemonicState {
         BackedUp, NotBackedUp, NeedRecover
     }
+
+    val notHiddenAccounts = allAccounts.notHiddenAccounts()
 }

--- a/profile/src/main/java/rdx/works/profile/domain/DeviceFactorSourceData.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/DeviceFactorSourceData.kt
@@ -6,10 +6,11 @@ import com.radixdlt.sargon.Persona
 
 data class DeviceFactorSourceData(
     val deviceFactorSource: FactorSource.Device,
-    val accounts: List<Account> = emptyList(),
+    val allAccounts: List<Account> = emptyList(),
     val personas: List<Persona> = emptyList(),
     val mnemonicState: MnemonicState = MnemonicState.NotBackedUp,
-    val isBabylon: Boolean = false
+    val isBabylon: Boolean = false,
+    val hasOnlyHiddenAccounts: Boolean = false
 ) {
     enum class MnemonicState {
         BackedUp, NotBackedUp, NeedRecover

--- a/profile/src/main/java/rdx/works/profile/domain/DeviceFactorSourceData.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/DeviceFactorSourceData.kt
@@ -3,6 +3,7 @@ package rdx.works.profile.domain
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.Persona
+import rdx.works.core.sargon.isHidden
 import rdx.works.core.sargon.notHiddenAccounts
 
 data class DeviceFactorSourceData(
@@ -10,12 +11,13 @@ data class DeviceFactorSourceData(
     val allAccounts: List<Account> = emptyList(),
     val personas: List<Persona> = emptyList(),
     val mnemonicState: MnemonicState = MnemonicState.NotBackedUp,
-    val isBabylon: Boolean = false,
-    val hasOnlyHiddenAccounts: Boolean = false
+    val isBabylon: Boolean = false
 ) {
     enum class MnemonicState {
         BackedUp, NotBackedUp, NeedRecover
     }
 
     val notHiddenAccounts = allAccounts.notHiddenAccounts()
+
+    val hasOnlyHiddenAccounts = allAccounts.isNotEmpty() && allAccounts.all { it.isHidden }
 }

--- a/profile/src/main/java/rdx/works/profile/domain/GetFactorSourcesWithAccountsUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/GetFactorSourcesWithAccountsUseCase.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.map
 import rdx.works.core.sargon.currentNetwork
 import rdx.works.core.sargon.factorSourceId
 import rdx.works.core.sargon.hasBabylonSeedPhraseLength
-import rdx.works.core.sargon.isHidden
 import rdx.works.core.sargon.usesEd25519
 import rdx.works.core.sargon.usesSECP256k1
 import javax.inject.Inject
@@ -41,8 +40,7 @@ class GetFactorSourcesWithAccountsUseCase @Inject constructor(
                                 deviceFactorSource = deviceFactorSource,
                                 allAccounts = babylonAccounts,
                                 isBabylon = true,
-                                personas = babylonPersonas,
-                                hasOnlyHiddenAccounts = babylonAccounts.all { it.isHidden }
+                                personas = babylonPersonas
                             )
                         )
                     }
@@ -50,8 +48,7 @@ class GetFactorSourcesWithAccountsUseCase @Inject constructor(
                         DeviceFactorSourceData(
                             deviceFactorSource = deviceFactorSource,
                             allAccounts = olympiaAccounts,
-                            isBabylon = false,
-                            hasOnlyHiddenAccounts = olympiaAccounts.all { it.isHidden }
+                            isBabylon = false
                         )
                     )
                 } else {
@@ -66,8 +63,7 @@ class GetFactorSourcesWithAccountsUseCase @Inject constructor(
                             deviceFactorSource = deviceFactorSource,
                             allAccounts = accounts,
                             isBabylon = deviceFactorSource.supportsBabylon,
-                            personas = personas,
-                            hasOnlyHiddenAccounts = accounts.all { it.isHidden }
+                            personas = personas
                         )
                     )
                 }


### PR DESCRIPTION
## Description
- use all accounts for showing total count of accounts
- display Hidden accounts only box if seed phrase has only hidden ones

## How to test

1. Verify counter displays all the accounts when hiding some
2. Verify that if all are hidden, it is marked under specific seed phrase

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/118203440/2e0a79b0-c747-48b6-902e-2edb26bec93a" width=30%>

## PR submission checklist
- [x] I have tested scenarios described in How to test section

