### PR TITLE
[ABW-3429] Decoupled warnings in cloud backup section of Backup screen

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetSecurityProblemsUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetSecurityProblemsUseCase.kt
@@ -4,21 +4,21 @@ import com.babylon.wallet.android.domain.model.SecurityProblem
 import com.radixdlt.sargon.extensions.ProfileEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import rdx.works.core.domain.cloudbackup.CloudBackupState
+import rdx.works.core.domain.cloudbackup.BackupState
 import rdx.works.core.sargon.factorSourceId
 import rdx.works.core.sargon.isHidden
 import rdx.works.core.sargon.isNotHidden
-import rdx.works.profile.domain.backup.GetCloudBackupStateUseCase
+import rdx.works.profile.domain.backup.GetBackupStateUseCase
 import javax.inject.Inject
 
 class GetSecurityProblemsUseCase @Inject constructor(
     private val getEntitiesWithSecurityPromptUseCase: GetEntitiesWithSecurityPromptUseCase,
-    private val getCloudBackupStateUseCase: GetCloudBackupStateUseCase
+    private val getBackupStateUseCase: GetBackupStateUseCase
 ) {
 
     operator fun invoke(): Flow<Set<SecurityProblem>> = combine(
         getEntitiesWithSecurityPromptUseCase(),
-        getCloudBackupStateUseCase()
+        getBackupStateUseCase()
     ) { entitiesWithSecurityPrompts, cloudBackupState ->
         // personas that need cloud backup
         val personasNeedCloudBackup = entitiesWithSecurityPrompts
@@ -43,14 +43,14 @@ class GetSecurityProblemsUseCase @Inject constructor(
 
         mutableSetOf<SecurityProblem>().apply {
             // entities that need cloud backup
-            if (cloudBackupState is CloudBackupState.Disabled && cloudBackupState.isNotUpdated) {
+            if (cloudBackupState is BackupState.CloudBackupDisabled && cloudBackupState.isNotUpdated) {
                 add(
                     SecurityProblem.CloudBackupNotWorking.Disabled(
                         isAnyActivePersonaAffected = activePersonasNeedCloudBackup > 0,
                         hasManualBackup = cloudBackupState.lastManualBackupTime != null
                     )
                 )
-            } else if (cloudBackupState is CloudBackupState.Enabled && cloudBackupState.hasAnyErrors) {
+            } else if (cloudBackupState is BackupState.CloudBackupEnabled && cloudBackupState.hasAnyErrors) {
                 add(SecurityProblem.CloudBackupNotWorking.ServiceError(isAnyActivePersonaAffected = activePersonasNeedCloudBackup > 0))
             }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupViewModel.kt
@@ -12,14 +12,14 @@ import com.babylon.wallet.android.utils.CanSignInToGoogle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import rdx.works.core.domain.cloudbackup.CloudBackupState
+import rdx.works.core.domain.cloudbackup.BackupState
 import rdx.works.profile.cloudbackup.data.GoogleSignInManager
 import rdx.works.profile.cloudbackup.model.GoogleAccount
 import rdx.works.profile.domain.EnsureBabylonFactorSourceExistUseCase
 import rdx.works.profile.domain.backup.BackupProfileToFileUseCase
 import rdx.works.profile.domain.backup.BackupType
 import rdx.works.profile.domain.backup.ChangeBackupSettingUseCase
-import rdx.works.profile.domain.backup.GetCloudBackupStateUseCase
+import rdx.works.profile.domain.backup.GetBackupStateUseCase
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -30,7 +30,7 @@ class BackupViewModel @Inject constructor(
     private val backupProfileToFileUseCase: BackupProfileToFileUseCase,
     private val ensureBabylonFactorSourceExistUseCase: EnsureBabylonFactorSourceExistUseCase,
     private val googleSignInManager: GoogleSignInManager,
-    getCloudBackupStateUseCase: GetCloudBackupStateUseCase
+    getBackupStateUseCase: GetBackupStateUseCase
 ) : StateViewModel<BackupViewModel.State>(),
     CanSignInToGoogle,
     OneOffEventHandler<BackupViewModel.Event> by OneOffEventHandlerImpl() {
@@ -39,8 +39,8 @@ class BackupViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            getCloudBackupStateUseCase().collect { backupState ->
-                _state.update { it.copy(cloudBackupState = backupState) }
+            getBackupStateUseCase().collect { backupState ->
+                _state.update { it.copy(backupState = backupState) }
             }
         }
     }
@@ -173,7 +173,7 @@ class BackupViewModel @Inject constructor(
     }
 
     data class State(
-        val cloudBackupState: CloudBackupState = CloudBackupState.Enabled(email = ""),
+        val backupState: BackupState = BackupState.CloudBackupEnabled(email = ""),
         val isCloudAuthorizationInProgress: Boolean = false,
         val isExportFileDialogVisible: Boolean = false,
         val encryptSheet: EncryptSheet = EncryptSheet.Closed,

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCaseTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCaseTest.kt
@@ -22,11 +22,11 @@ import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import rdx.works.core.TimestampGenerator
-import rdx.works.core.domain.cloudbackup.CloudBackupState
+import rdx.works.core.domain.cloudbackup.BackupState
 import rdx.works.core.sargon.changeGateway
 import rdx.works.profile.data.repository.MnemonicRepository
 import rdx.works.profile.domain.GetProfileUseCase
-import rdx.works.profile.domain.backup.GetCloudBackupStateUseCase
+import rdx.works.profile.domain.backup.GetBackupStateUseCase
 
 @ExperimentalCoroutinesApi
 class GetEntitiesWithSecurityPromptUseCaseTest {
@@ -36,13 +36,13 @@ class GetEntitiesWithSecurityPromptUseCaseTest {
 
     private val profile = Profile.sample().changeGateway(Gateway.forNetwork(NetworkId.MAINNET))
     private val mnemonicRepositoryMock = mockk<MnemonicRepository>()
-    private val getCloudBackupStateUseCaseMock = mockk<GetCloudBackupStateUseCase>()
+    private val getBackupStateUseCaseMock = mockk<GetBackupStateUseCase>()
 
     private val getEntitiesWithSecurityPromptUseCase = GetEntitiesWithSecurityPromptUseCase(
         getProfileUseCase = GetProfileUseCase(profileRepository = FakeProfileRepository(profile)),
         preferencesManager = FakePreferenceManager(),
         mnemonicRepository = mnemonicRepositoryMock,
-        getCloudBackupStateUseCase = getCloudBackupStateUseCaseMock
+        getBackupStateUseCase = getBackupStateUseCaseMock
     )
 
     @Test
@@ -53,8 +53,8 @@ class GetEntitiesWithSecurityPromptUseCaseTest {
         val now = TimestampGenerator()
         val oneDayBefore = now.minusDays(1)
         // when cloud backup disabled but user has exported an updated manual backup file
-        coEvery { getCloudBackupStateUseCaseMock() } returns flowOf(
-            CloudBackupState.Disabled(
+        coEvery { getBackupStateUseCaseMock() } returns flowOf(
+            BackupState.CloudBackupDisabled(
                 email = "email",
                 lastCloudBackupTime = oneDayBefore,
                 lastManualBackupTime = now.toInstant(),
@@ -83,8 +83,8 @@ class GetEntitiesWithSecurityPromptUseCaseTest {
         val now = TimestampGenerator()
         val oneDayBefore = now.minusDays(1)
         // when cloud backup is enabled but not working, for example unavailable service
-        coEvery { getCloudBackupStateUseCaseMock() } returns flowOf(
-            CloudBackupState.Enabled(
+        coEvery { getBackupStateUseCaseMock() } returns flowOf(
+            BackupState.CloudBackupEnabled(
                 email = "email",
                 hasAnyErrors = true,
                 lastCloudBackupTime = oneDayBefore,

--- a/app/src/test/java/com/babylon/wallet/android/presentation/WalletViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/WalletViewModelTest.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import rdx.works.core.InstantGenerator
 import rdx.works.core.TimestampGenerator
-import rdx.works.core.domain.cloudbackup.CloudBackupState
+import rdx.works.core.domain.cloudbackup.BackupState
 import rdx.works.core.domain.assets.Assets
 import rdx.works.core.domain.assets.Token
 import rdx.works.core.domain.resources.ExplicitMetadataKey
@@ -42,13 +42,13 @@ import rdx.works.core.preferences.PreferencesManager
 import rdx.works.profile.cloudbackup.domain.CheckMigrationToNewBackupSystemUseCase
 import rdx.works.profile.domain.EnsureBabylonFactorSourceExistUseCase
 import rdx.works.profile.domain.GetProfileUseCase
-import rdx.works.profile.domain.backup.GetCloudBackupStateUseCase
+import rdx.works.profile.domain.backup.GetBackupStateUseCase
 import rdx.works.profile.domain.display.ChangeBalanceVisibilityUseCase
 
 @ExperimentalCoroutinesApi
 class WalletViewModelTest : StateViewModelTest<WalletViewModel>() {
 
-    private val getCloudBackupStateUseCase = mockk<GetCloudBackupStateUseCase>()
+    private val getBackupStateUseCase = mockk<GetBackupStateUseCase>()
     private val getWalletAssetsUseCase = mockk<GetWalletAssetsUseCase>()
     private val getFiatValueUseCase = mockk<GetFiatValueUseCase>()
     private val getProfileUseCase = mockk<GetProfileUseCase>()
@@ -90,8 +90,8 @@ class WalletViewModelTest : StateViewModelTest<WalletViewModel>() {
         super.setUp()
         coEvery { ensureBabylonFactorSourceExistUseCase.babylonFactorSourceExist() } returns true
         every { getAccountsForSecurityPromptUseCase() } returns flow { emit(emptyList()) }
-        every { getCloudBackupStateUseCase() } returns flowOf(
-            CloudBackupState.Disabled(
+        every { getBackupStateUseCase() } returns flowOf(
+            BackupState.CloudBackupDisabled(
                 email = "email",
                 lastCloudBackupTime = TimestampGenerator(),
                 lastManualBackupTime = InstantGenerator(),

--- a/core/src/main/java/rdx/works/core/domain/cloudbackup/BackupState.kt
+++ b/core/src/main/java/rdx/works/core/domain/cloudbackup/BackupState.kt
@@ -6,14 +6,17 @@ import java.time.Instant
 import java.time.ZoneId
 
 /**
- * CloudBackupState reflects the state of the toggle button in BackupScreen.
- * Enabled = on / Disabled = off
+ * BackupState reflects the state of Backup screen and
+ * takes into consideration the cloud backup state and the manual backup state.
+ *
+ * Enabled and Disabled express the toggle button state. Enabled = on / Disabled = off
  *
  * Important note: Enabled doesn't necessarily means that cloud backup is working properly.
  * Thus, the hasAnyErrors in the Enabled. If this is true the backup screen shows warnings
  * and toggle remains on.
+ *
  */
-sealed class CloudBackupState {
+sealed class BackupState {
 
     // email for cloud backup authorization
     abstract val email: String?
@@ -21,20 +24,25 @@ sealed class CloudBackupState {
     abstract val lastManualBackupTime: Instant?
     abstract val lastModifiedProfileTime: Timestamp?
 
-    data class Enabled(
+    data class CloudBackupEnabled(
         override val email: String,
         val hasAnyErrors: Boolean = false,
         override val lastCloudBackupTime: Timestamp? = null,
         override val lastManualBackupTime: Instant? = null,
         override val lastModifiedProfileTime: Timestamp? = null,
-    ) : CloudBackupState()
+    ) : BackupState()
 
-    data class Disabled(
+    data class CloudBackupDisabled(
         override val email: String?,
         override val lastCloudBackupTime: Timestamp?,
         override val lastManualBackupTime: Instant?,
         override val lastModifiedProfileTime: Timestamp?
-    ) : CloudBackupState()
+    ) : BackupState()
+
+    // It is used for the login status of the Configuration Backup screen.
+    // Cloud backup might be authorized even if state is disabled.
+    val isAuthorized: Boolean
+        get() = email.isNullOrEmpty().not()
 
     // it is needed to inform the user when the last cloud backup happened
     val lastCloudBackupLabel: String?
@@ -48,20 +56,29 @@ sealed class CloudBackupState {
             DateUtils.getRelativeTimeSpanString(epochMilli)
         }?.toString()
 
-    val isEnabled: Boolean
-        get() = this is Enabled
+    val isCloudBackupEnabled: Boolean
+        get() = this is CloudBackupEnabled
 
+    val isCloudBackupNotUpdated: Boolean
+        get() {
+            return when (this) {
+                is CloudBackupDisabled -> {
+                    true
+                }
+                is CloudBackupEnabled -> {
+                    hasAnyErrors
+                }
+            }
+        }
+
+    // neither an updated cloud backup nor an updated manual backup
     val isNotUpdated: Boolean
         get() = backupWarning != null
 
-    // It is used for the login status of the Configuration Backup screen.
-    // Cloud backup might be authorized even if state is disabled.
-    val isAuthorized: Boolean
-        get() = email.isNullOrEmpty().not()
-
+    // warnings in Backup screen take into consideration the cloud backup state AND the manual backup state
     val backupWarning: BackupWarning?
         get() = when (this) {
-            is Disabled -> {
+            is CloudBackupDisabled -> {
                 val lastManualBackupTimestamp = lastManualBackupTime?.let {
                     Timestamp.ofInstant(it, ZoneId.systemDefault())
                 }
@@ -75,7 +92,7 @@ sealed class CloudBackupState {
                 }
             }
 
-            is Enabled -> {
+            is CloudBackupEnabled -> {
                 if (hasAnyErrors) {
                     BackupWarning.CLOUD_BACKUP_SERVICE_ERROR
                 } else {

--- a/core/src/main/java/rdx/works/core/domain/cloudbackup/BackupState.kt
+++ b/core/src/main/java/rdx/works/core/domain/cloudbackup/BackupState.kt
@@ -9,11 +9,11 @@ import java.time.ZoneId
  * BackupState reflects the state of Backup screen and
  * takes into consideration the cloud backup state and the manual backup state.
  *
- * Enabled and Disabled express the toggle button state. Enabled = on / Disabled = off
+ * CloudBackupEnabled and CloudBackupDisabled express the toggle button state. CloudBackupEnabled = on / CloudBackupDisabled = off
  *
- * Important note: Enabled doesn't necessarily means that cloud backup is working properly.
- * Thus, the hasAnyErrors in the Enabled. If this is true the backup screen shows warnings
- * and toggle remains on.
+ * Important note: CloudBackupEnabled doesn't necessarily means that cloud backup is working properly.
+ * Thus, the hasAnyErrors in the CloudBackupEnabled.
+ * If this is true the backup screen shows warnings and toggle remains on.
  *
  */
 sealed class BackupState {

--- a/profile/src/main/java/rdx/works/profile/domain/backup/GetBackupStateUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/GetBackupStateUseCase.kt
@@ -2,7 +2,7 @@ package rdx.works.profile.domain.backup
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import rdx.works.core.domain.cloudbackup.CloudBackupState
+import rdx.works.core.domain.cloudbackup.BackupState
 import rdx.works.core.preferences.PreferencesManager
 import rdx.works.core.sargon.canBackupToCloud
 import rdx.works.profile.cloudbackup.data.GoogleSignInManager
@@ -12,14 +12,14 @@ import rdx.works.profile.data.repository.ProfileRepository
 import rdx.works.profile.data.repository.profile
 import javax.inject.Inject
 
-class GetCloudBackupStateUseCase @Inject constructor(
+class GetBackupStateUseCase @Inject constructor(
     private val profileRepository: ProfileRepository,
     private val preferencesManager: PreferencesManager,
     private val googleSignInManager: GoogleSignInManager,
     private val cloudBackupErrorStream: CloudBackupErrorStream
 ) {
 
-    operator fun invoke(): Flow<CloudBackupState> = combine(
+    operator fun invoke(): Flow<BackupState> = combine(
         profileRepository.profile,
         preferencesManager.lastCloudBackupEvent,
         cloudBackupErrorStream.errors,
@@ -28,19 +28,19 @@ class GetCloudBackupStateUseCase @Inject constructor(
         val email = googleSignInManager.getSignedInGoogleAccount()?.email
 
         if (profile.canBackupToCloud && email != null && backupError == null) {
-            CloudBackupState.Enabled(email = email)
+            BackupState.CloudBackupEnabled(email = email)
         } else {
             if (email != null &&
                 (backupError is BackupServiceException.ServiceException || backupError is BackupServiceException.Unknown)
             ) {
-                CloudBackupState.Enabled(
+                BackupState.CloudBackupEnabled(
                     email = email,
                     hasAnyErrors = true,
                     lastCloudBackupTime = lastCloudBackupEvent?.cloudBackupTime,
                     lastManualBackupTime = lastManualBackupInstant
                 )
             } else {
-                CloudBackupState.Disabled(
+                BackupState.CloudBackupDisabled(
                     email = email,
                     lastCloudBackupTime = lastCloudBackupEvent?.cloudBackupTime,
                     lastManualBackupTime = lastManualBackupInstant,


### PR DESCRIPTION
## Description
This PR decouples the cloud backup section from the manual backup state. In short, when a cloud backup is disabled or has any errors the warnings are yellow and they do not depend on the status of the manual backup, e.g. an updated manual backup file


## How to test

1. Create wallet and turn on cloud backup. Do some changes in the profile.
2. Turn off cloud backup and do some changes in the profile.
3. Navigate to Backup screen and verify that the cloud backup section (status list) is yellow, and a warning would be presented at the top.
4. Perform a manual backup.
5. Verify that the warning at the top is gone and the status list is still yellow.


