### PR TITLE
Fix re-link connector screen appearing after fresh install

### DIFF
--- a/profile/src/main/java/rdx/works/profile/domain/backup/SaveTemporaryRestoringSnapshotUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/SaveTemporaryRestoringSnapshotUseCase.kt
@@ -31,7 +31,6 @@ class SaveTemporaryRestoringSnapshotUseCase @Inject constructor(
         data.read(byteArray)
         byteArray.toString(Charsets.UTF_8)
     }.then { snapshot ->
-        ensureP2PLinkMigrationAcknowledged(snapshot, BackupType.DeprecatedCloud)
         backupProfileRepository.saveTemporaryRestoringSnapshot(snapshot, BackupType.DeprecatedCloud)
     }
 
@@ -53,6 +52,8 @@ class SaveTemporaryRestoringSnapshotUseCase @Inject constructor(
                 jsonString = content
             )
         }
-        preferencesManager.setShowRelinkConnectorsAfterProfileRestore(containsLegacyP2PLinks)
+        if (containsLegacyP2PLinks) {
+            preferencesManager.setShowRelinkConnectorsAfterProfileRestore(true)
+        }
     }
 }


### PR DESCRIPTION
## Description
This PR fixes re-link connector screen appearing after fresh install if there was an old system backup present with a profile containing p2p links.


## How to test

1. Install app from 1.5.4 tag
2. Create or restore the profile and make sure there are p2p links
3. Perform a cloud backup (old system)
4. Uninstall the app
5. Install 1.6.0 version
6. Create profile
7. Verify that re-link connector screen is not appearing
