### PR TITLE
Update auth sign request to work with dapp

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/model/transaction/TransactionStatusParameterType.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/transaction/TransactionStatusParameterType.kt
@@ -38,5 +38,6 @@ data class TransactionStatusFields(
     val isInternal: Boolean,
     val error: String?,
     val walletErrorType: String?,
-    val blockUntilComplete: Boolean
+    val blockUntilComplete: Boolean,
+    val isMobileConnect: Boolean
 ) : Parcelable

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
@@ -183,7 +183,7 @@ class BuildAuthorizedDappResponseUseCase @Inject constructor(
                 )
                 val signRequest = SignRequest.SignAuthChallengeRequest(
                     challengeHex = authRequest.challenge.hex,
-                    origin = request.metadata.origin,
+                    origin = request.metadata.origin.substring(0, request.metadata.origin.length - 1),
                     dAppDefinitionAddress = request.metadata.dAppDefinitionAddress
                 )
                 rolaClient.signAuthChallenge(

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
@@ -183,7 +183,7 @@ class BuildAuthorizedDappResponseUseCase @Inject constructor(
                 )
                 val signRequest = SignRequest.SignAuthChallengeRequest(
                     challengeHex = authRequest.challenge.hex,
-                    origin = request.metadata.origin.substring(0, request.metadata.origin.length - 1),
+                    origin = request.metadata.origin,
                     dAppDefinitionAddress = request.metadata.dAppDefinitionAddress
                 )
                 rolaClient.signAuthChallenge(

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.domain.usecases.transaction
 
 import com.babylon.wallet.android.data.transaction.InteractionState
 import com.babylon.wallet.android.domain.RadixWalletException
+import com.babylon.wallet.android.utils.removeTrailingSlash
 import com.radixdlt.sargon.BagOfBytes
 import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.Hash
@@ -125,6 +126,7 @@ sealed interface SignRequest {
         val dAppDefinitionAddress: String
     ) : SignRequest {
 
+        // TODO removeTrailingSlash is a hack to fix the issue with dapp login, it should be removed after logic is moved to sargon
         override val dataToSign: BagOfBytes
             get() {
                 require(dAppDefinitionAddress.length <= UByte.MAX_VALUE.toInt())
@@ -133,7 +135,7 @@ sealed interface SignRequest {
                         challengeHex.hexToBagOfBytes().toByteArray() +
                         dAppDefinitionAddress.length.toUByte().toByte() +
                         dAppDefinitionAddress.toByteArray() +
-                        origin.toByteArray()
+                        origin.removeTrailingSlash().toByteArray()
                 )
             }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialog.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.R
@@ -99,7 +101,8 @@ fun TransactionStatusDialog(
                     FailureDialogContent(
                         title = title,
                         subtitle = state.failureError,
-                        transactionAddress = state.transactionId
+                        transactionAddress = state.transactionId,
+                        isMobileConnect = state.status.isMobileConnect
                     )
                 }
 
@@ -109,7 +112,10 @@ fun TransactionStatusDialog(
                     exit = fadeOut()
                 ) {
                     // Need to send the correct transaction id
-                    SuccessContent(transactionAddress = state.transactionId)
+                    SuccessContent(
+                        transactionAddress = state.transactionId,
+                        isMobileConnect = state.status.isMobileConnect
+                    )
                 }
 
                 if (state.isIgnoreTransactionModalShowing) {
@@ -136,7 +142,8 @@ fun TransactionStatusDialog(
 @Composable
 private fun SuccessContent(
     modifier: Modifier = Modifier,
-    transactionAddress: String
+    transactionAddress: String,
+    isMobileConnect: Boolean
 ) {
     Column(
         modifier
@@ -184,6 +191,14 @@ private fun SuccessContent(
                 )
             }
         }
+        if (isMobileConnect) {
+            Text(
+                text = "You can return back to the dApp!",
+                style = RadixTheme.typography.body1HighImportance,
+                color = RadixTheme.colors.gray1,
+                textAlign = TextAlign.Center
+            )
+        }
     }
 }
 
@@ -215,11 +230,20 @@ private fun CompletingContent(
     }
 }
 
+internal class MobileConnectParameterProvider : PreviewParameterProvider<Boolean> {
+    override val values: Sequence<Boolean> = sequenceOf(true, false)
+}
+
 @Preview(showBackground = true)
 @Composable
-fun SuccessBottomDialogPreview() {
+fun SuccessBottomDialogPreview(
+    @PreviewParameter(MobileConnectParameterProvider::class) isMobileConnect: Boolean
+) {
     RadixWalletTheme {
-        SuccessContent(transactionAddress = "txid_tdx_21_1nsdfruuw5gd6tsh07ur5mgq4tjpns9vxj0nnaahaxpxmxapjzrfqmfzr4s")
+        SuccessContent(
+            transactionAddress = "txid_tdx_21_1nsdfruuw5gd6tsh07ur5mgq4tjpns9vxj0nnaahaxpxmxapjzrfqmfzr4s",
+            isMobileConnect = isMobileConnect
+        )
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogNav.kt
@@ -104,7 +104,8 @@ fun AppEvent.Status.Transaction.toTransactionStatusFields(): TransactionStatusFi
         isInternal = isInternal,
         error = errorSerialized,
         walletErrorType = walletErrorType,
-        blockUntilComplete = blockUntilComplete
+        blockUntilComplete = blockUntilComplete,
+        isMobileConnect = isMobileConnect
     )
 }
 
@@ -118,20 +119,23 @@ private fun SavedStateHandle.toStatus(): AppEvent.Status.Transaction {
             errorMessage = transactionStatusFields.error?.let { Json.decodeFromString(it) },
             blockUntilComplete = checkNotNull(transactionStatusFields.blockUntilComplete),
             walletErrorType = transactionStatusFields.walletErrorType?.let { Json.decodeFromString(it) },
+            isMobileConnect = checkNotNull(transactionStatusFields.isMobileConnect)
         )
 
         VALUE_STATUS_SUCCESS -> AppEvent.Status.Transaction.Success(
             requestId = checkNotNull(transactionStatusFields.requestId),
             transactionId = checkNotNull(transactionStatusFields.transactionId),
             isInternal = checkNotNull(transactionStatusFields.isInternal),
-            blockUntilComplete = checkNotNull(transactionStatusFields.blockUntilComplete)
+            blockUntilComplete = checkNotNull(transactionStatusFields.blockUntilComplete),
+            isMobileConnect = checkNotNull(transactionStatusFields.isMobileConnect)
         )
 
         VALUE_STATUS_IN_PROGRESS -> AppEvent.Status.Transaction.InProgress(
             requestId = checkNotNull(transactionStatusFields.requestId),
             transactionId = checkNotNull(transactionStatusFields.transactionId),
             isInternal = checkNotNull(transactionStatusFields.isInternal),
-            blockUntilComplete = checkNotNull(transactionStatusFields.blockUntilComplete)
+            blockUntilComplete = checkNotNull(transactionStatusFields.blockUntilComplete),
+            isMobileConnect = checkNotNull(transactionStatusFields.isMobileConnect)
         )
 
         else -> error("Status not received")

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
@@ -87,7 +87,8 @@ class TransactionStatusDialogViewModel @Inject constructor(
                             requestId = status.requestId,
                             transactionId = status.transactionId,
                             isInternal = status.isInternal,
-                            blockUntilComplete = status.blockUntilComplete
+                            blockUntilComplete = status.blockUntilComplete,
+                            isMobileConnect = status.isMobileConnect
                         )
                     )
                 }.onFailure { error ->
@@ -111,7 +112,8 @@ class TransactionStatusDialogViewModel @Inject constructor(
                             isInternal = status.isInternal,
                             errorMessage = exceptionMessageProvider.throwableMessage(error),
                             blockUntilComplete = status.blockUntilComplete,
-                            walletErrorType = error.asRadixWalletException()?.toConnectorExtensionError()
+                            walletErrorType = error.asRadixWalletException()?.toConnectorExtensionError(),
+                            isMobileConnect = status.isMobileConnect
                         )
                     )
                 }
@@ -177,19 +179,22 @@ sealed interface TransactionStatus {
     val transactionId: String
     val isInternal: Boolean
     val blockUntilComplete: Boolean
+    val isMobileConnect: Boolean
 
     data class Completing(
         override val requestId: String,
         override val transactionId: String,
         override val isInternal: Boolean,
-        override val blockUntilComplete: Boolean
+        override val blockUntilComplete: Boolean,
+        override val isMobileConnect: Boolean
     ) : TransactionStatus
 
     data class Success(
         override val requestId: String,
         override val transactionId: String,
         override val isInternal: Boolean,
-        override val blockUntilComplete: Boolean
+        override val blockUntilComplete: Boolean,
+        override val isMobileConnect: Boolean
     ) : TransactionStatus
 
     data class Failed(
@@ -198,7 +203,8 @@ sealed interface TransactionStatus {
         override val isInternal: Boolean,
         override val blockUntilComplete: Boolean,
         val errorMessage: String?,
-        val walletErrorType: DappWalletInteractionErrorType?
+        val walletErrorType: DappWalletInteractionErrorType?,
+        override val isMobileConnect: Boolean
     ) : TransactionStatus
 
     companion object {
@@ -209,21 +215,24 @@ sealed interface TransactionStatus {
                 isInternal = event.isInternal,
                 errorMessage = event.errorMessage,
                 blockUntilComplete = event.blockUntilComplete,
-                walletErrorType = event.walletErrorType
+                walletErrorType = event.walletErrorType,
+                isMobileConnect = event.isMobileConnect
             )
 
             is AppEvent.Status.Transaction.InProgress -> Completing(
                 requestId = event.requestId,
                 transactionId = event.transactionId,
                 isInternal = event.isInternal,
-                blockUntilComplete = event.blockUntilComplete
+                blockUntilComplete = event.blockUntilComplete,
+                isMobileConnect = event.isMobileConnect
             )
 
             is AppEvent.Status.Transaction.Success -> Success(
                 requestId = event.requestId,
                 transactionId = event.transactionId,
                 isInternal = event.isInternal,
-                blockUntilComplete = event.blockUntilComplete
+                blockUntilComplete = event.blockUntilComplete,
+                isMobileConnect = event.isMobileConnect
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
@@ -155,7 +155,8 @@ class TransactionSubmitDelegate @Inject constructor(
                     requestId = transactionRequest.interactionId.toString(),
                     transactionId = notarization.intentHash.bech32EncodedTxId,
                     isInternal = transactionRequest.isInternal,
-                    blockUntilComplete = transactionRequest.blockUntilComplete
+                    blockUntilComplete = transactionRequest.blockUntilComplete,
+                    isMobileConnect = transactionRequest.isMobileConnectRequest
                 )
             )
             transactionStatusClient.pollTransactionStatus(
@@ -200,7 +201,8 @@ class TransactionSubmitDelegate @Inject constructor(
                                 isInternal = transactionRequest.isInternal,
                                 errorMessage = exceptionMessageProvider.throwableMessage(radixWalletException),
                                 blockUntilComplete = transactionRequest.blockUntilComplete,
-                                walletErrorType = radixWalletException.toConnectorExtensionError()
+                                walletErrorType = radixWalletException.toConnectorExtensionError(),
+                                isMobileConnect = transactionRequest.isMobileConnectRequest
                             )
                         )
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -52,6 +52,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
@@ -422,7 +424,8 @@ fun FailureDialogContent(
     modifier: Modifier = Modifier,
     title: String,
     subtitle: String?,
-    transactionAddress: String
+    transactionAddress: String,
+    isMobileConnect: Boolean
 ) {
     Column(
         modifier
@@ -479,14 +482,27 @@ fun FailureDialogContent(
                 )
             }
         }
+        if (isMobileConnect) {
+            Text(
+                text = "You can return back to the dApp!",
+                style = RadixTheme.typography.body1HighImportance,
+                color = RadixTheme.colors.gray1,
+                textAlign = TextAlign.Center
+            )
+        }
     }
+}
+
+internal class MobileConnectParameterProvider : PreviewParameterProvider<Boolean> {
+    override val values: Sequence<Boolean> = sequenceOf(true, false)
 }
 
 @Composable
 @Preview
-fun SomethingWentWrongDialogPreview() {
+fun SomethingWentWrongDialogPreview(@PreviewParameter(MobileConnectParameterProvider::class) isMobileConnect: Boolean) {
     RadixWalletTheme {
         FailureDialogContent(
+            isMobileConnect = isMobileConnect,
             title = "Title",
             subtitle = "Subtitle",
             transactionAddress = "rdx1239j329fj292r32e23"

--- a/app/src/main/java/com/babylon/wallet/android/utils/AppEventBusImpl.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/AppEventBusImpl.kt
@@ -55,19 +55,22 @@ sealed interface AppEvent {
             abstract val transactionId: String
             abstract val isInternal: Boolean
             abstract val blockUntilComplete: Boolean
+            abstract val isMobileConnect: Boolean
 
             data class InProgress(
                 override val requestId: String,
                 override val transactionId: String,
                 override val isInternal: Boolean,
-                override val blockUntilComplete: Boolean
+                override val blockUntilComplete: Boolean,
+                override val isMobileConnect: Boolean
             ) : Transaction()
 
             data class Success(
                 override val requestId: String,
                 override val transactionId: String,
                 override val isInternal: Boolean,
-                override val blockUntilComplete: Boolean
+                override val blockUntilComplete: Boolean,
+                override val isMobileConnect: Boolean
             ) : Transaction()
 
             data class Fail(
@@ -76,7 +79,8 @@ sealed interface AppEvent {
                 override val isInternal: Boolean,
                 override val blockUntilComplete: Boolean,
                 val errorMessage: String?,
-                val walletErrorType: DappWalletInteractionErrorType?
+                val walletErrorType: DappWalletInteractionErrorType?,
+                override val isMobileConnect: Boolean
             ) : Transaction()
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/StringExtensions.kt
@@ -38,6 +38,14 @@ fun String.toMnemonicWords(expectedWordCount: Int): List<String> {
     }
 }
 
+fun String.removeTrailingSlash(): String {
+    return if (endsWith("/")) {
+        substring(0, length - 1)
+    } else {
+        this
+    }
+}
+
 fun String.formattedSpans(
     boldStyle: SpanStyle
 ): AnnotatedString {


### PR DESCRIPTION
## Description
- strip `origin` trailing slash so that proper signature is computed when handling login with challenge request
- pass flag to indicate that request is mobile connect in the transaction status dialogs