### PR TITLE
Fix fiat prices parsing

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/gateway/model/TokensAndLsusPricesResponse.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/gateway/model/TokensAndLsusPricesResponse.kt
@@ -23,7 +23,7 @@ data class TokensAndLsusPricesResponse(
         @SerialName(value = "resource_address")
         val resourceAddress: String,
         @SerialName(value = "usd_price")
-        val usdPrice: String,
+        val usdPrice: Double,
         @SerialName(value = "last_updated_at")
         val lastUpdatedAt: String
     )
@@ -35,7 +35,7 @@ data class TokensAndLsusPricesResponse(
         @SerialName(value = "xrd_redemption_value")
         val xrdRedemptionValue: Double,
         @SerialName(value = "usd_price")
-        val usdPrice: String
+        val usdPrice: Double
     )
 
     companion object {


### PR DESCRIPTION
## Description
This PR fixes fiat price parsing by deserializing the price as Double. Now that Sargon truncates the decimals when overflowing, deserializing the price as Double won't be an issue. The issue now is when a price contains many decimals and deserializing it as String automatically applies the engineering notation, thus making Sargon fail when converting String (with engineering notation) to Decimal192. 

`"2.63376612877e-07".toDecimal192()` - this currently doesn't work, while using the Double extension works.