### PR TITLE
[ABW-3434] Check cloud backup file availability when backup is disabled

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupViewModel.kt
@@ -17,6 +17,7 @@ import rdx.works.profile.cloudbackup.data.GoogleSignInManager
 import rdx.works.profile.cloudbackup.domain.CheckCloudBackupFileAvailabilityUseCase
 import rdx.works.profile.cloudbackup.model.GoogleAccount
 import rdx.works.profile.domain.EnsureBabylonFactorSourceExistUseCase
+import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.backup.BackupProfileToFileUseCase
 import rdx.works.profile.domain.backup.BackupType
 import rdx.works.profile.domain.backup.ChangeBackupSettingUseCase
@@ -24,7 +25,7 @@ import rdx.works.profile.domain.backup.GetBackupStateUseCase
 import timber.log.Timber
 import javax.inject.Inject
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 @HiltViewModel
 class BackupViewModel @Inject constructor(
     private val changeBackupSettingUseCase: ChangeBackupSettingUseCase,
@@ -32,6 +33,7 @@ class BackupViewModel @Inject constructor(
     private val ensureBabylonFactorSourceExistUseCase: EnsureBabylonFactorSourceExistUseCase,
     private val googleSignInManager: GoogleSignInManager,
     private val checkCloudBackupFileAvailabilityUseCase: CheckCloudBackupFileAvailabilityUseCase,
+    private val getProfileUseCase: GetProfileUseCase,
     getBackupStateUseCase: GetBackupStateUseCase
 ) : StateViewModel<BackupViewModel.State>(),
     CanSignInToGoogle,
@@ -81,12 +83,11 @@ class BackupViewModel @Inject constructor(
             sendEvent(Event.SignInToGoogle)
         } else {
             _state.update { it.copy(isCloudAuthorizationInProgress = true) }
-            ensureBabylonFactorSourceExistUseCase()
-                .onSuccess { profile ->
-                    // in case the backup file has been deleted
-                    // the wallet should not show the "last cloud backup" label
-                    checkCloudBackupFileAvailabilityUseCase(profile)
-                }
+            val profile = getProfileUseCase()
+            // in case the backup file has been deleted
+            // the wallet should not show the "last cloud backup" label
+            checkCloudBackupFileAvailabilityUseCase(profile)
+
             changeBackupSettingUseCase(isChecked = false)
             _state.update { it.copy(isCloudAuthorizationInProgress = false) }
         }

--- a/profile/src/main/java/rdx/works/profile/cloudbackup/domain/CheckBackupStatusUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/cloudbackup/domain/CheckBackupStatusUseCase.kt
@@ -43,9 +43,7 @@ class CheckBackupStatusUseCase @AssistedInject constructor(
             Result.success()
         } else {
             Timber.tag("CloudBackup").d("\uD83D\uDEDC Check Backup Status")
-            return lastCloudBackupEvent?.let {
-                checkCloudBackupFileAvailabilityUseCase(profile)
-            } ?: Result.success()
+            return checkCloudBackupFileAvailabilityUseCase(profile)
         }
     }
 }

--- a/profile/src/main/java/rdx/works/profile/cloudbackup/domain/CheckBackupStatusUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/cloudbackup/domain/CheckBackupStatusUseCase.kt
@@ -13,21 +13,17 @@ import rdx.works.core.domain.ProfileState
 import rdx.works.core.preferences.PreferencesManager
 import rdx.works.core.sargon.canBackupToCloud
 import rdx.works.profile.cloudbackup.CloudBackupSyncExecutor
-import rdx.works.profile.cloudbackup.data.DriveClient
-import rdx.works.profile.cloudbackup.model.BackupServiceException
 import rdx.works.profile.data.repository.ProfileRepository
 import timber.log.Timber
 
-@Suppress("LongParameterList")
 @HiltWorker
 class CheckBackupStatusUseCase @AssistedInject constructor(
     @Assisted context: Context,
     @Assisted private val params: WorkerParameters,
     private val preferencesManager: PreferencesManager,
     private val profileRepository: ProfileRepository,
-    private val driveClient: DriveClient,
     private val cloudBackupSyncExecutor: CloudBackupSyncExecutor,
-    private val cloudBackupErrorStream: CloudBackupErrorStream
+    private val checkCloudBackupFileAvailabilityUseCase: CheckCloudBackupFileAvailabilityUseCase
 ) : CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
@@ -36,31 +32,20 @@ class CheckBackupStatusUseCase @AssistedInject constructor(
             it is ProfileState.NotInitialised
         }.first()
         val profile = (profileState as? ProfileState.Restored)?.profile ?: return Result.success()
-        if (!profile.canBackupToCloud) return Result.success()
 
-        val lastBackupEvent = preferencesManager.lastCloudBackupEvent.firstOrNull()
+        val lastCloudBackupEvent = preferencesManager.lastCloudBackupEvent.firstOrNull()
 
-        return if (lastBackupEvent == null || profile.header.lastModified > lastBackupEvent.profileModifiedTime) {
+        return if (
+            profile.canBackupToCloud &&
+            (lastCloudBackupEvent == null || profile.header.lastModified > lastCloudBackupEvent.profileModifiedTime)
+        ) {
             cloudBackupSyncExecutor.requestCloudBackup()
             Result.success()
         } else {
             Timber.tag("CloudBackup").d("\uD83D\uDEDC Check Backup Status")
-            driveClient.getCloudBackupEntity(fileId = lastBackupEvent.fileId, profile = profile).fold(
-                onSuccess = {
-                    Timber.tag("CloudBackup").d("\uD83D\uDEDC Check Backup Status: All good ✅")
-                    // File still exists, no further action required
-                    cloudBackupErrorStream.resetErrors()
-                    Result.success()
-                },
-                onFailure = { exception ->
-                    Timber.tag("CloudBackup").d(exception, "\uD83D\uDEDC Check Backup Status: Error ❌")
-                    if (exception is BackupServiceException) {
-                        cloudBackupErrorStream.onError(exception)
-                    }
-
-                    Result.success()
-                }
-            )
+            return lastCloudBackupEvent?.let {
+                checkCloudBackupFileAvailabilityUseCase(profile)
+            } ?: Result.success()
         }
     }
 }

--- a/profile/src/main/java/rdx/works/profile/cloudbackup/domain/CheckCloudBackupFileAvailabilityUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/cloudbackup/domain/CheckCloudBackupFileAvailabilityUseCase.kt
@@ -1,0 +1,40 @@
+package rdx.works.profile.cloudbackup.domain
+
+import androidx.work.ListenableWorker.Result
+import com.radixdlt.sargon.Profile
+import kotlinx.coroutines.flow.firstOrNull
+import rdx.works.core.preferences.PreferencesManager
+import rdx.works.profile.cloudbackup.data.DriveClient
+import rdx.works.profile.cloudbackup.model.BackupServiceException
+import timber.log.Timber
+import javax.inject.Inject
+
+class CheckCloudBackupFileAvailabilityUseCase @Inject constructor(
+    private val driveClient: DriveClient,
+    private val preferencesManager: PreferencesManager,
+    private val cloudBackupErrorStream: CloudBackupErrorStream
+) {
+    suspend operator fun invoke(profile: Profile): Result {
+        val lastCloudBackupEvent = preferencesManager.lastCloudBackupEvent.firstOrNull()
+        return lastCloudBackupEvent?.let {
+            driveClient.getCloudBackupEntity(
+                fileId = lastCloudBackupEvent.fileId,
+                profile = profile
+            ).fold(
+                onSuccess = {
+                    Timber.tag("CloudBackup").d("\uD83D\uDEDC Check Backup Status: All good ✅")
+                    // File still exists, no further action required
+                    cloudBackupErrorStream.resetErrors()
+                    Result.success()
+                },
+                onFailure = { exception ->
+                    Timber.tag("CloudBackup").d(exception, "\uD83D\uDEDC Check Backup Status: Error ❌")
+                    if (exception is BackupServiceException) {
+                        cloudBackupErrorStream.onError(exception)
+                    }
+                    Result.success()
+                }
+            )
+        } ?: Result.success()
+    }
+}

--- a/profile/src/main/java/rdx/works/profile/domain/backup/GetBackupStateUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/GetBackupStateUseCase.kt
@@ -30,9 +30,9 @@ class GetBackupStateUseCase @Inject constructor(
         if (profile.canBackupToCloud && email != null && backupError == null) {
             BackupState.CloudBackupEnabled(email = email)
         } else {
-            if (email != null &&
-                (backupError is BackupServiceException.ServiceException || backupError is BackupServiceException.Unknown)
-            ) {
+            val isServiceError = (backupError is BackupServiceException.ServiceException || backupError is BackupServiceException.Unknown)
+
+            if (isServiceError && profile.canBackupToCloud && email != null) {
                 BackupState.CloudBackupEnabled(
                     email = email,
                     hasAnyErrors = true,

--- a/profile/src/test/java/rdx/works/profile/domain/GetBackupStateUseCaseTest.kt
+++ b/profile/src/test/java/rdx/works/profile/domain/GetBackupStateUseCaseTest.kt
@@ -1,0 +1,244 @@
+package rdx.works.profile.domain
+
+import com.radixdlt.sargon.Profile
+import com.radixdlt.sargon.Timestamp
+import com.radixdlt.sargon.samples.sample
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import rdx.works.core.domain.cloudbackup.BackupState
+import rdx.works.core.domain.cloudbackup.GoogleDriveFileId
+import rdx.works.core.domain.cloudbackup.LastCloudBackupEvent
+import rdx.works.core.preferences.PreferencesManager
+import rdx.works.core.sargon.updateCloudSyncEnabled
+import rdx.works.profile.FakeProfileRepository
+import rdx.works.profile.cloudbackup.data.GoogleSignInManager
+import rdx.works.profile.cloudbackup.domain.CloudBackupErrorStream
+import rdx.works.profile.cloudbackup.model.BackupServiceException
+import rdx.works.profile.domain.backup.GetBackupStateUseCase
+import java.time.Instant
+
+@ExperimentalCoroutinesApi
+class GetBackupStateUseCaseTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    private val preferencesManagerMock = mockk<PreferencesManager>()
+    private val googleSignInManagerMock = mockk<GoogleSignInManager>()
+
+    @Test
+    fun `given cloud backup enabled, when no cloud backup errors, then no warnings on screen`() = testScope.runTest {
+        coEvery { googleSignInManagerMock.getSignedInGoogleAccount()?.email } returns "mail@email.com"
+        coEvery { preferencesManagerMock.lastManualBackupInstant } returns flowOf(Instant.now())
+        coEvery { preferencesManagerMock.lastCloudBackupEvent } returns flowOf(
+            LastCloudBackupEvent(
+                fileId = GoogleDriveFileId(id = "googleDriveFileId"),
+                profileModifiedTime = Timestamp.now(),
+                cloudBackupTime = Timestamp.now()
+            )
+        )
+
+        val getBackupStateUseCase = GetBackupStateUseCase(
+            profileRepository = FakeProfileRepository(Profile.sample()),
+            preferencesManager = preferencesManagerMock,
+            googleSignInManager = googleSignInManagerMock,
+            cloudBackupErrorStream = CloudBackupErrorStreamFake(),
+        )
+
+        val event = mutableListOf<BackupState>()
+        getBackupStateUseCase().onEach {
+            event.add(it)
+        }.launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+        advanceUntilIdle()
+
+        Assert.assertTrue(event.isNotEmpty())
+        Assert.assertTrue(event.first().isCloudBackupEnabled)
+        Assert.assertNull(event.first().backupWarning)
+    }
+
+    @Test
+    fun `given cloud backup enabled, when cloud backup service error and neither updated cloud backup nor manual backup, then warnings on screen`() =
+        testScope.runTest {
+            val profile = Profile.sample()
+            val lastProfileModified = profile.header.lastModified
+
+            coEvery { googleSignInManagerMock.getSignedInGoogleAccount()?.email } returns "mail@email.com"
+            coEvery { preferencesManagerMock.lastManualBackupInstant } returns flowOf(
+                lastProfileModified.minusDays(2).toInstant()
+            )
+            coEvery { preferencesManagerMock.lastCloudBackupEvent } returns flowOf(
+                LastCloudBackupEvent(
+                    fileId = GoogleDriveFileId(id = "googleDriveFileId"),
+                    profileModifiedTime = lastProfileModified,
+                    cloudBackupTime = lastProfileModified.minusHours(4)
+                )
+            )
+            val cloudBackupErrorStreamFake = CloudBackupErrorStreamFake(
+                error = BackupServiceException.ServiceException(statusCode = 1, message = "service error")
+            )
+
+            val getBackupStateUseCase = GetBackupStateUseCase(
+                profileRepository = FakeProfileRepository(profile),
+                preferencesManager = preferencesManagerMock,
+                googleSignInManager = googleSignInManagerMock,
+                cloudBackupErrorStream = cloudBackupErrorStreamFake,
+            )
+
+            val event = mutableListOf<BackupState>()
+            getBackupStateUseCase().onEach {
+                event.add(it)
+            }.launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+            advanceUntilIdle()
+
+            Assert.assertTrue(event.isNotEmpty())
+            Assert.assertTrue(event.first().isCloudBackupEnabled)
+            Assert.assertTrue(event.first().isNotUpdated)
+            Assert.assertNotNull(event.first().backupWarning)
+        }
+
+    @Test
+    fun `given cloud backup disabled, when cloud backup not updated and updated manual backup, then no warnings on screen`() =
+        testScope.runTest {
+            val profile = Profile.sample().updateCloudSyncEnabled(false)
+            val lastProfileModifiedTime = profile.header.lastModified
+            val lastCloudBackupTime = lastProfileModifiedTime.minusHours(1)
+
+            coEvery { googleSignInManagerMock.getSignedInGoogleAccount()?.email } returns "mail@email.com"
+            coEvery { preferencesManagerMock.lastManualBackupInstant } returns flowOf(lastProfileModifiedTime.toInstant())
+            coEvery { preferencesManagerMock.lastCloudBackupEvent } returns flowOf(
+                LastCloudBackupEvent(
+                    fileId = GoogleDriveFileId(id = "googleDriveFileId"),
+                    profileModifiedTime = lastProfileModifiedTime,
+                    cloudBackupTime = lastCloudBackupTime
+                )
+            )
+            val cloudBackupErrorStreamFake = CloudBackupErrorStreamFake(
+                error = BackupServiceException.ServiceException(statusCode = 1, message = "service error")
+            )
+
+            val getBackupStateUseCase = GetBackupStateUseCase(
+                profileRepository = FakeProfileRepository(profile),
+                preferencesManager = preferencesManagerMock,
+                googleSignInManager = googleSignInManagerMock,
+                cloudBackupErrorStream = cloudBackupErrorStreamFake,
+            )
+
+            val event = mutableListOf<BackupState>()
+            getBackupStateUseCase().onEach {
+                event.add(it)
+            }.launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+            advanceUntilIdle()
+
+            Assert.assertTrue(event.isNotEmpty())
+            Assert.assertFalse(event.first().isCloudBackupEnabled)
+            Assert.assertFalse(event.first().isNotUpdated)
+            Assert.assertNull(event.first().backupWarning)
+        }
+
+    @Test
+    fun `given cloud backup enabled, when cloud backup gets unauthorized and neither updated cloud backup nor manual backup, then warnings on screen and cloud backup disabled`() =
+        testScope.runTest {
+            val profile = Profile.sample()
+            val lastProfileModifiedTime = profile.header.lastModified
+            val lastManualBackupTime = lastProfileModifiedTime.minusDays(3)
+            val lastCloudBackupTime = lastProfileModifiedTime.minusHours(1)
+
+            coEvery { googleSignInManagerMock.getSignedInGoogleAccount()?.email } returns "mail@email.com"
+            coEvery { preferencesManagerMock.lastManualBackupInstant } returns flowOf(lastManualBackupTime.toInstant())
+            coEvery { preferencesManagerMock.lastCloudBackupEvent } returns flowOf(
+                LastCloudBackupEvent(
+                    fileId = GoogleDriveFileId(id = "googleDriveFileId"),
+                    profileModifiedTime = lastProfileModifiedTime,
+                    cloudBackupTime = lastCloudBackupTime
+                )
+            )
+            val cloudBackupErrorStreamFake = CloudBackupErrorStreamFake(
+                error = BackupServiceException.UnauthorizedException
+            )
+
+            val getBackupStateUseCase = GetBackupStateUseCase(
+                profileRepository = FakeProfileRepository(profile),
+                preferencesManager = preferencesManagerMock,
+                googleSignInManager = googleSignInManagerMock,
+                cloudBackupErrorStream = cloudBackupErrorStreamFake,
+            )
+
+            val event = mutableListOf<BackupState>()
+            getBackupStateUseCase().onEach {
+                event.add(it)
+            }.launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+            advanceUntilIdle()
+
+            Assert.assertTrue(event.isNotEmpty())
+            Assert.assertFalse(event.first().isCloudBackupEnabled)
+            Assert.assertTrue(event.first().isNotUpdated)
+            Assert.assertNotNull(event.first().backupWarning)
+        }
+
+    @Test
+    fun `given cloud backup disabled, when cloud backup gets deleted, then last cloud backup label is none`() =
+        testScope.runTest {
+            val profile = Profile.sample().updateCloudSyncEnabled(false)
+            val lastProfileModifiedTime = profile.header.lastModified
+            val lastManualBackupTime = lastProfileModifiedTime.minusDays(3)
+
+            coEvery { googleSignInManagerMock.getSignedInGoogleAccount()?.email } returns "mail@email.com"
+            coEvery { preferencesManagerMock.lastManualBackupInstant } returns flowOf(lastManualBackupTime.toInstant())
+            coEvery { preferencesManagerMock.lastCloudBackupEvent } returns flowOf(null)
+            val cloudBackupErrorStreamFake = CloudBackupErrorStreamFake(
+                error = BackupServiceException.UnauthorizedException
+            )
+
+            val getBackupStateUseCase = GetBackupStateUseCase(
+                profileRepository = FakeProfileRepository(profile),
+                preferencesManager = preferencesManagerMock,
+                googleSignInManager = googleSignInManagerMock,
+                cloudBackupErrorStream = cloudBackupErrorStreamFake,
+            )
+
+            val event = mutableListOf<BackupState>()
+            getBackupStateUseCase().onEach {
+                event.add(it)
+            }.launchIn(CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+            advanceUntilIdle()
+
+            Assert.assertTrue(event.isNotEmpty())
+            Assert.assertFalse(event.first().isCloudBackupEnabled)
+            Assert.assertTrue(event.first().isNotUpdated)
+            Assert.assertNull(event.first().lastCloudBackupTime)
+        }
+}
+
+class CloudBackupErrorStreamFake(private val error: BackupServiceException? = null) : CloudBackupErrorStream {
+
+    override val errors: MutableStateFlow<BackupServiceException?>
+        get() = MutableStateFlow(error)
+
+    override fun onError(error: BackupServiceException) {
+        errors.update { error }
+    }
+
+    override fun resetErrors() {
+        errors.update { null }
+    }
+
+}


### PR DESCRIPTION
## Description
In short, a "Last backup:" label is presented on the Backup screen when backup is disabled. This label indicates when was the last backup performed. 
Now, if the user keeps the backup disabled and revokes and/or delete the app data from Drive settings the wallet will still show the label on the screen which is misleading since no backup file on the cloud. 
Therefore, wallet must check the cloud backup file availability even when backup is disabled.


## How to test

**Scenario 1**
1. Enable cloud backup in the wallet and perform a successful backup
2. Turn off the cloud backup and ensure that you see the "Last backup: ..." label
3. Navigate to the Google Drive settings and revoke or/and delete Radix Wallet app data
4. Relaunch the wallet and navigate to Backup screen. There you must see "**None**" in the last cloud backup label

**Scenario 2**
1. Enable cloud backup in the wallet and perform a successful backup
2. Keep the wallet in the foreground and navigate to the Backup screen
3. Navigate to the Google Drive settings and revoke or/and delete Radix Wallet app data
4. Now in the wallet turn off the cloud backup
5. There you must see "**None**" in the "Last backup:" label

## Screenshot

<img src="https://github.com/radixdlt/babylon-wallet-android/assets/118305718/d4010556-dcfa-4c48-ab2e-4d0e811ec5c9" width=40%> <img src="https://github.com/radixdlt/babylon-wallet-android/assets/118305718/64c775da-5bd8-48fc-bc85-9a7b77483522" width=40%>


## PR submission checklist
- [X] I have tested cloud backups
- [X] I have written unit tests
