### PR TITLE
Format decimal with respect to locale when max amount is tapped

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -17,6 +17,7 @@ import com.radixdlt.sargon.FactorSourceId
 import com.radixdlt.sargon.ResourceAddress
 import com.radixdlt.sargon.extensions.clamped
 import com.radixdlt.sargon.extensions.compareTo
+import com.radixdlt.sargon.extensions.formattedTextField
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.isZero
 import com.radixdlt.sargon.extensions.minus
@@ -121,7 +122,7 @@ class TransferViewModel @Inject constructor(
             .filterNot { it.address == account.address }
             .sumOf { it.amountSpent(fungibleAsset) }
         val remainingAmount = (maxAmount - spentAmount).clamped
-        val remainingAmountString = remainingAmount.string
+        val remainingAmountString = remainingAmount.formattedTextField()
 
         if (fungibleAsset.resource.isXrd && remainingAmount > 0.toDecimal192()) {
             _state.update {
@@ -156,7 +157,7 @@ class TransferViewModel @Inject constructor(
                 state.updateAssetAmount(
                     account = maxXrdError.account,
                     asset = fungibleAsset,
-                    amountString = remainingAmountString.string
+                    amountString = remainingAmountString.formattedTextField()
                 )
                     .copy(
                         maxXrdError = null


### PR DESCRIPTION
## Description
- use formatting that respect locale when applying max amount and filling it into text field

## How to test

1. Before the fix, ensure you have asset with amount that is decimal number. Tap max amount in your default locale, then test it with locale that has different decimal separator then your default. For example in Polish locale decimal separator is coma, dot in UK locale.

## PR submission checklist
- [x] I have tested above scenarios and verified it works
