### PR TITLE
Fix derive public key dialog when user dismiss

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/derivepublickey/DerivePublicKeyDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/derivepublickey/DerivePublicKeyDialog.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.presentation.accessfactorsources.derivepublickey
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -45,6 +46,10 @@ fun DerivePublicKeyDialog(
     val state by viewModel.state.collectAsState()
     val context = LocalContext.current
 
+    BackHandler {
+        viewModel.onUserDismiss()
+    }
+
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.collect { event ->
             when (event) {
@@ -58,6 +63,7 @@ fun DerivePublicKeyDialog(
                     }
                 }
                 DerivePublicKeyViewModel.Event.AccessingFactorSourceCompleted -> onDismiss()
+                DerivePublicKeyViewModel.Event.UserDismissed -> onDismiss()
             }
         }
     }
@@ -66,7 +72,7 @@ fun DerivePublicKeyDialog(
         modifier = modifier,
         showContentForFactorSource = state.showContentForFactorSource,
         shouldShowRetryButton = state.shouldShowRetryButton,
-        onDismiss = onDismiss,
+        onDismiss = viewModel::onUserDismiss,
         onRetryClick = viewModel::onRetryClick
     )
 }
@@ -81,9 +87,7 @@ private fun DerivePublicKeyBottomSheetContent(
 ) {
     BottomSheetDialogWrapper(
         modifier = modifier,
-        onDismiss = {
-            onDismiss()
-        }
+        onDismiss = onDismiss
     ) {
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/derivepublickey/DerivePublicKeyViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/derivepublickey/DerivePublicKeyViewModel.kt
@@ -21,6 +21,7 @@ import com.radixdlt.sargon.PublicKey
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.string
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -114,6 +115,16 @@ class DerivePublicKeyViewModel @Inject constructor(
         }
     }
 
+    fun onUserDismiss() {
+        viewModelScope.launch {
+            derivePublicKeyJob?.cancel()
+            accessFactorSourcesUiProxy.setOutput(
+                output = AccessFactorSourcesOutput.Failure(CancellationException("User cancelled"))
+            )
+            sendEvent(Event.UserDismissed)
+        }
+    }
+
     private suspend fun derivePublicKey(): Result<Unit> {
         return when (val factorSource = input.factorSource) {
             is FactorSource.Device -> {
@@ -192,5 +203,6 @@ class DerivePublicKeyViewModel @Inject constructor(
     sealed interface Event : OneOffEvent {
         data object RequestBiometricPrompt : Event
         data object AccessingFactorSourceCompleted : Event
+        data object UserDismissed : Event
     }
 }


### PR DESCRIPTION
## Description
This PR fixes a bug where the user dismiss the bottom sheet dialog when creating a new account.


## How to test

**This is very hard to reproduce.**

Test 1
1. With an existing wallet click on "Create a New Account" at wallet screen
2. At the "Create New Account" screen type an account name and click "Continue"
3. Dismiss the biometric prompt
4. Click on the "X" button of the "Creating Account" bottomsheet dialog
5. Remain at the "Create New Account" screen and select "Create with Ledger..."
6. Add a NEW ledger device
7. Once adding ledger flow is done select the new ledger and proceed

At this point the wallet returns again back to "Create New Account" screen. 

Test 2
1. Fresh install wallet
2. At "Create First Account" screen give a name and select with ledger
3. Click continue and authenticate
4. At "Choose Ledger Device" navigate back
5. And then click again "continue" at the  "Create First Account" screen 
6. Proceed with the flow to add a ledger
7. Once ledger is added and selected 

At this point you will see (very instant) the bottomshet "Creating Account" dialog twice.

❗   In addition this [crash](https://console.firebase.google.com/project/radix-wallet-fe520/crashlytics/app/android:com.radixpublishing.radixwallet.android/issues/3ee22ac4bb4a7b4ad833b875f21e7e17?time=last-ninety-days&types=crash&sessionEventKey=666581BD0130000145E92B3B477D6B80_1956893551180887228) might be related to this fix. 



## PR submission checklist
- [X] I have tested account creation with several scenarios when user dismiss
