### PR TITLE
Fix request handled on rejection at Login screen

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -584,11 +584,11 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
 
     fun onAbortDappLogin(walletWalletErrorType: DappWalletInteractionErrorType = DappWalletInteractionErrorType.REJECTED_BY_USER) {
         viewModelScope.launch {
+            sendEvent(Event.CloseLoginFlow)
             incomingRequestRepository.requestHandled(request.interactionId)
             if (!request.isInternal) {
                 respondToIncomingRequestUseCase.respondWithFailure(request, walletWalletErrorType)
             }
-            sendEvent(Event.CloseLoginFlow)
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/mobileconnect/MobileConnectLinkViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/mobileconnect/MobileConnectLinkViewModel.kt
@@ -15,7 +15,6 @@ import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
 import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.UiState
-import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
 import com.babylon.wallet.android.utils.AppEvent
 import com.babylon.wallet.android.utils.AppEventBus
 import com.radixdlt.sargon.DappWalletInteractionErrorType


### PR DESCRIPTION
## Description
This PR solves the following bug:

1. launch wallet
2. connect to a desktop dapp, e.g. https://dev-sandbox.rdx-works-main.extratools.works/
3. send a transaction request through webrtc fromt the above dapp - leave request on the screen
4. send a "Update Account Sharing" through webrtc fromt the above dapp
5. send a mobile connect request from RQ
6. send a mobile connect request from gumball
7. now you have a total of 4 requests in the queue
8. back to the wallet start rejecting requests one by one

At this point you won't get on the screen the last 2 (mobile) requests and you will dismiss only the first two.
