### PR TITLE
Automatic refresh

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
@@ -15,16 +15,20 @@ import com.babylon.wallet.android.data.repository.tokenprice.FiatPriceRepository
 import com.babylon.wallet.android.domain.RadixWalletException
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.ResourceAddress
+import com.radixdlt.sargon.Timestamp
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.string
+import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
 import rdx.works.core.domain.assets.FiatPrice
 import rdx.works.core.domain.assets.SupportedCurrency
 import rdx.works.core.domain.resources.XrdResource
+import rdx.works.core.domain.toDouble
 import rdx.works.peerdroid.di.IoDispatcher
 import timber.log.Timber
+import java.time.OffsetDateTime
 import javax.inject.Inject
 import javax.inject.Qualifier
 import kotlin.random.Random
@@ -156,6 +160,8 @@ class TestnetFiatPriceRepository @Inject constructor(
         "resource_rdx1tkk83magp3gjyxrpskfsqwkg4g949rmcjee4tu2xmw93ltw2cz94sq"
     ).map { ResourceAddress.init(it) }
 
+    private val testnetPricesCache: MutableMap<ResourceAddress, TestnetPrice> = mutableMapOf()
+
     override suspend fun updateFiatPrices(currency: SupportedCurrency): Result<Unit> {
         if (!BuildConfig.EXPERIMENTAL_FEATURES_ENABLED) {
             return Result.failure(FiatPriceRepository.PricesNotSupportedInNetwork())
@@ -191,8 +197,7 @@ class TestnetFiatPriceRepository @Inject constructor(
                     if (priceRequestAddress.address in XrdResource.addressesPerNetwork().values) {
                         priceRequestAddress.address to xrdPrice
                     } else {
-                        val randomPrice = prices.entries.elementAt(Random.nextInt(prices.entries.size)).value
-                        priceRequestAddress.address to randomPrice
+                        priceRequestAddress.address to getTestnetPrice(address = priceRequestAddress.address, isRefreshing = isRefreshing)
                     }
                 }.mapNotNull { addressAndFiatPrice ->
                     addressAndFiatPrice.value?.let { fiatPrice -> addressAndFiatPrice.key to fiatPrice }
@@ -202,4 +207,44 @@ class TestnetFiatPriceRepository @Inject constructor(
             }
         }
     }
+
+    private fun getTestnetPrice(address: ResourceAddress, isRefreshing: Boolean): FiatPrice {
+        val cachedPrice = testnetPricesCache[address]
+
+        return if (cachedPrice == null) {
+            FiatPrice(
+                price = Random.nextDouble(from = 0.01, until = 1.0).toDecimal192(),
+                currency = SupportedCurrency.USD
+            ).also {
+                testnetPricesCache[address] = TestnetPrice(
+                    price = it,
+                    updatedAt = Timestamp.now()
+                )
+            }
+        } else {
+            val lastUpdatedAt = cachedPrice.updatedAt
+            if (isRefreshing || lastUpdatedAt.isBefore(OffsetDateTime.now().minusMinutes(5))) {
+                val price = cachedPrice.price.price.toDouble()
+                FiatPrice(
+                    price = Random.nextDouble(
+                        from = (price - 0.01).coerceAtLeast(0.01),
+                        until = price + 0.01
+                    ).toDecimal192(),
+                    currency = SupportedCurrency.USD
+                ).also {
+                    testnetPricesCache[address] = TestnetPrice(
+                        price = it,
+                        updatedAt = Timestamp.now()
+                    )
+                }
+            } else {
+                cachedPrice.price
+            }
+        }
+    }
+
+    private data class TestnetPrice(
+        val price: FiatPrice,
+        val updatedAt: Timestamp
+    )
 }

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/tokenprice/FiatPriceRepository.kt
@@ -223,12 +223,12 @@ class TestnetFiatPriceRepository @Inject constructor(
             }
         } else {
             val lastUpdatedAt = cachedPrice.updatedAt
-            if (isRefreshing || lastUpdatedAt.isBefore(OffsetDateTime.now().minusMinutes(5))) {
+            if (isRefreshing || lastUpdatedAt.isBefore(OffsetDateTime.now().minusMinutes(MEMORY_CACHE_VALIDITY_MINUTES))) {
                 val price = cachedPrice.price.price.toDouble()
                 FiatPrice(
                     price = Random.nextDouble(
-                        from = (price - 0.01).coerceAtLeast(0.01),
-                        until = price + 0.01
+                        from = (price - PRICE_FLUCTUATION).coerceAtLeast(PRICE_MINIMUM),
+                        until = price + PRICE_FLUCTUATION
                     ).toDecimal192(),
                     currency = SupportedCurrency.USD
                 ).also {
@@ -247,4 +247,10 @@ class TestnetFiatPriceRepository @Inject constructor(
         val price: FiatPrice,
         val updatedAt: Timestamp
     )
+
+    companion object {
+        private const val MEMORY_CACHE_VALIDITY_MINUTES = 5L
+        private const val PRICE_FLUCTUATION = 0.01
+        private const val PRICE_MINIMUM = 0.01
+    }
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.domain.usecases
 
+import com.radixdlt.sargon.AddressOfAccountOrPersona
 import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.FactorSourceId
 import com.radixdlt.sargon.extensions.ProfileEntity
@@ -77,6 +78,17 @@ data class EntityWithSecurityPrompt(
     val entity: ProfileEntity,
     val prompts: Set<SecurityPromptType>
 )
+
+fun List<EntityWithSecurityPrompt>.accountPrompts() = mapNotNull {
+    val accountAddress = it.entity.address as? AddressOfAccountOrPersona.Account ?: return@mapNotNull null
+    accountAddress.v1 to it.prompts
+}.associate { it }
+
+fun List<EntityWithSecurityPrompt>.personaPrompts() = mapNotNull {
+    val identityAddress = it.entity.address as? AddressOfAccountOrPersona.Identity ?: return@mapNotNull null
+    identityAddress.v1 to it.prompts
+}.associate { it }
+
 
 enum class SecurityPromptType {
     WRITE_DOWN_SEED_PHRASE,

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetEntitiesWithSecurityPromptUseCase.kt
@@ -89,7 +89,6 @@ fun List<EntityWithSecurityPrompt>.personaPrompts() = mapNotNull {
     identityAddress.v1 to it.prompts
 }.associate { it }
 
-
 enum class SecurityPromptType {
     WRITE_DOWN_SEED_PHRASE,
     RECOVERY_REQUIRED,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountTopBar.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountTopBar.kt
@@ -29,6 +29,7 @@ import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixSecondaryButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.domain.usecases.SecurityPromptType
+import com.babylon.wallet.android.presentation.account.AccountViewModel.State
 import com.babylon.wallet.android.presentation.ui.composables.ApplySecuritySettingsLabel
 import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.ActionableAddressView
 import com.babylon.wallet.android.presentation.ui.composables.toText
@@ -42,7 +43,7 @@ import com.radixdlt.sargon.Address
 @Composable
 fun AccountTopBar(
     modifier: Modifier = Modifier,
-    state: AccountUiState,
+    state: State,
     lazyListState: LazyListState,
     onBackClick: () -> Unit,
     onAccountPreferenceClick: (AccountAddress) -> Unit,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
@@ -5,10 +5,12 @@ package com.babylon.wallet.android.presentation.account
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.data.repository.tokenprice.FiatPriceRepository
+import com.babylon.wallet.android.di.coroutines.DefaultDispatcher
 import com.babylon.wallet.android.domain.model.assets.AccountWithAssets
 import com.babylon.wallet.android.domain.usecases.GetEntitiesWithSecurityPromptUseCase
 import com.babylon.wallet.android.domain.usecases.GetNetworkInfoUseCase
 import com.babylon.wallet.android.domain.usecases.SecurityPromptType
+import com.babylon.wallet.android.domain.usecases.accountPrompts
 import com.babylon.wallet.android.domain.usecases.assets.GetFiatValueUseCase
 import com.babylon.wallet.android.domain.usecases.assets.GetNextNFTsPageUseCase
 import com.babylon.wallet.android.domain.usecases.assets.GetWalletAssetsUseCase
@@ -22,24 +24,31 @@ import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.UiState
 import com.babylon.wallet.android.presentation.transfer.assets.AssetsTab
 import com.babylon.wallet.android.presentation.ui.composables.assets.AssetsViewState
+import com.babylon.wallet.android.presentation.wallet.WalletViewModel.RefreshType
 import com.babylon.wallet.android.utils.AppEvent
+import com.babylon.wallet.android.utils.AppEvent.RestoredMnemonic
 import com.babylon.wallet.android.utils.AppEventBus
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.ResourceAddress
-import com.radixdlt.sargon.extensions.ProfileEntity
 import com.radixdlt.sargon.extensions.orZero
 import com.radixdlt.sargon.extensions.plus
 import com.radixdlt.sargon.extensions.toDecimal192
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.core.domain.assets.Asset
@@ -58,6 +67,7 @@ import rdx.works.profile.domain.GetProfileUseCase
 import rdx.works.profile.domain.display.ChangeBalanceVisibilityUseCase
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.minutes
 
 @Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
@@ -72,89 +82,105 @@ class AccountViewModel @Inject constructor(
     private val changeBalanceVisibilityUseCase: ChangeBalanceVisibilityUseCase,
     private val appEventBus: AppEventBus,
     private val sendClaimRequestUseCase: SendClaimRequestUseCase,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
     savedStateHandle: SavedStateHandle
-) : StateViewModel<AccountUiState>(), OneOffEventHandler<AccountEvent> by OneOffEventHandlerImpl() {
+) : StateViewModel<AccountViewModel.State>(), OneOffEventHandler<AccountViewModel.Event> by OneOffEventHandlerImpl() {
 
     private val args = AccountArgs(savedStateHandle)
-    override fun initialState(): AccountUiState = AccountUiState(accountWithAssets = null)
+    override fun initialState(): State = State(accountWithAssets = null)
 
-    private val refreshFlow = MutableSharedFlow<Unit>()
-    private val accountFlow = combine(
-        getProfileUseCase.flow.mapNotNull { profile ->
+    private var automaticRefreshJob: Job? = null
+    private val refreshFlow = MutableSharedFlow<State.RefreshType>()
+    private val accountFlow = getProfileUseCase.flow
+        .mapNotNull { profile ->
             profile.activeAccountsOnCurrentNetwork.find { it.address == args.accountAddress }
-        },
-        refreshFlow
-    ) { account, _ -> account }
+        }
+        .distinctUntilChanged()
 
     init {
-        viewModelScope.launch {
-            accountFlow
-                .onEach { account ->
-                    // Update details of profile account each time it is updated
-                    _state.update { state ->
-                        val accountWithAssets = state.accountWithAssets?.copy(account = account) ?: AccountWithAssets(account = account)
-                        state.copy(accountWithAssets = accountWithAssets)
-                    }
-                }
-                .flatMapLatest { account ->
-                    getWalletAssetsUseCase(listOf(account), state.value.isRefreshing)
-                        .catch { error ->
-                            _state.update {
-                                it.copy(isRefreshing = false, uiMessage = UiMessage.ErrorMessage(error = error))
-                            }
-                        }
-                        .mapNotNull { it.firstOrNull() }
-                }
-                .collectLatest { accountWithAssets ->
-                    // keep the val here because the assets have been updated and we need to stop refreshing
-                    // in the next update of the state (below)
-                    val isRefreshing = state.value.isRefreshing
+        observeAccountAssets()
+        observeGlobalAppEvents()
+        observeSecurityPrompt()
+    }
 
-                    // Update assets of the account each time they are updated
-                    _state.update { state ->
-                        state.copy(
-                            accountWithAssets = state.accountWithAssets?.copy(assets = accountWithAssets.assets),
-                            isRefreshing = false
-                        )
-                    }
-
-                    getFiatValueUseCase.forAccount(
-                        accountWithAssets = accountWithAssets,
-                        isRefreshing = isRefreshing
+    private fun observeAccountAssets() {
+        combine(
+            accountFlow,
+            refreshFlow.onStart {
+                loadAccountDetails(refreshType = State.RefreshType.Manual(overrideCache = false, showRefreshIndicator = false))
+            }
+        ) { account, refreshEvent ->
+            _state.update { it.onAccount(account, refreshEvent) }
+            account
+        }.flatMapLatest { account ->
+            Timber.tag("WALLET").d("ACCOUNT Override: ${_state.value.refreshType.overrideCache}")
+            getWalletAssetsUseCase(
+                accounts = listOf(account),
+                isRefreshing = _state.value.refreshType.overrideCache
+            ).catch { error ->
+                _state.update {
+                    it.copy(
+                        refreshType = State.RefreshType.None,
+                        uiMessage = UiMessage.ErrorMessage(error = error)
                     )
-                        .onSuccess { assetsPrices ->
-                            _state.update { state ->
-                                state.copy(
-                                    assetsWithAssetsPrices = assetsPrices.associateBy { it.asset },
-                                    hasFailedToFetchPricesForAccount = false
-                                )
-                            }
-                        }
-                        .onFailure {
-                            if (it is FiatPriceRepository.PricesNotSupportedInNetwork) {
-                                disableFiatPrices()
-                            } else {
-                                _state.update { state ->
-                                    state.copy(hasFailedToFetchPricesForAccount = true)
-                                }
-                                Timber.e("Failed to fetch prices for account: ${it.message}")
-                                // now try to fetch prices per asset of the account
-                                getAssetsPricesForAccount(accountWithAssets = accountWithAssets, isRefreshing = isRefreshing)
-                            }
-                        }
                 }
-        }
+            }.mapNotNull { it.firstOrNull() }
+        }.onEach { accountWithAssets ->
+            val refreshState = state.value.refreshType
 
+            // Update assets of the account each time they are updated
+            _state.update { state ->
+                state.copy(
+                    accountWithAssets = state.accountWithAssets?.copy(assets = accountWithAssets.assets),
+                    refreshType = State.RefreshType.None
+                )
+            }
+
+            getFiatValueUseCase.forAccount(
+                accountWithAssets = accountWithAssets,
+                isRefreshing = refreshState.overrideCache
+            ).onSuccess { assetsPrices ->
+                _state.update { state ->
+                    state.copy(
+                        pricesState = State.PricesState.Enabled(assetsPrices.associateBy { it.asset })
+                    )
+                }
+            }.onFailure {
+                if (it is FiatPriceRepository.PricesNotSupportedInNetwork) {
+                    disableFiatPrices()
+                } else {
+                    Timber.e("Failed to fetch prices for account: ${it.message}")
+                    // now try to fetch prices per asset of the account
+                    getAssetsPricesForAccount(
+                        accountWithAssets = accountWithAssets,
+                        isRefreshing = refreshState.overrideCache
+                    )
+                }
+            }
+        }.flowOn(defaultDispatcher).launchIn(viewModelScope)
+    }
+
+    private fun observeGlobalAppEvents() {
         viewModelScope.launch {
             appEventBus.events.filter { event ->
                 event is AppEvent.RefreshAssetsNeeded || event is AppEvent.RestoredMnemonic
-            }.collect {
-                loadAccountDetails(withRefresh = it !is AppEvent.RestoredMnemonic)
+            }.collect { event ->
+                when (event) {
+                    AppEvent.RefreshAssetsNeeded -> loadAccountDetails(
+                        refreshType = State.RefreshType.Manual(
+                            overrideCache = true,
+                            showRefreshIndicator = true
+                        )
+                    )
+
+                    RestoredMnemonic -> loadAccountDetails(
+                        refreshType = State.RefreshType.Manual(overrideCache = false, showRefreshIndicator = false)
+                    )
+
+                    else -> {}
+                }
             }
         }
-
-        observeSecurityPrompt()
-        loadAccountDetails(withRefresh = false)
     }
 
     private suspend fun getAssetsPricesForAccount(
@@ -170,7 +196,7 @@ class AccountViewModel @Inject constructor(
                     isRefreshing = isRefreshing
                 )
                 _state.update { state ->
-                    state.copy(assetsWithAssetsPrices = assetsPrices.mapNotNull { it }.associateBy { it.asset })
+                    state.copy(pricesState = State.PricesState.Enabled(assetsPrices.mapNotNull { it }.associateBy { it.asset }))
                 }
             }
         }
@@ -179,9 +205,7 @@ class AccountViewModel @Inject constructor(
     private fun observeSecurityPrompt() {
         viewModelScope.launch {
             getEntitiesWithSecurityPromptUseCase().collect { entities ->
-                val securityPrompts = entities.find {
-                    (it.entity as? ProfileEntity.AccountEntity)?.account?.address == args.accountAddress
-                }?.prompts?.toList()
+                val securityPrompts = entities.accountPrompts()[args.accountAddress]?.toList()
 
                 _state.update { state ->
                     state.copy(securityPrompts = securityPrompts)
@@ -191,7 +215,7 @@ class AccountViewModel @Inject constructor(
     }
 
     fun refresh() {
-        loadAccountDetails(withRefresh = true)
+        loadAccountDetails(refreshType = State.RefreshType.Manual(overrideCache = true, showRefreshIndicator = true))
     }
 
     fun onShowHideBalanceToggle(isVisible: Boolean) {
@@ -204,7 +228,7 @@ class AccountViewModel @Inject constructor(
         val account = _state.value.accountWithAssets?.account ?: return
 
         viewModelScope.launch {
-            sendEvent(AccountEvent.OnFungibleClick(resource, account))
+            sendEvent(Event.OnFungibleClick(resource, account))
         }
     }
 
@@ -216,7 +240,7 @@ class AccountViewModel @Inject constructor(
 
         viewModelScope.launch {
             sendEvent(
-                AccountEvent.OnNonFungibleClick(
+                Event.OnNonFungibleClick(
                     resource = nonFungibleResource,
                     item = item,
                     account = account
@@ -229,7 +253,7 @@ class AccountViewModel @Inject constructor(
         val account = _state.value.accountWithAssets?.account ?: return
 
         viewModelScope.launch {
-            sendEvent(AccountEvent.OnFungibleClick(resource = liquidStakeUnit.fungibleResource, account = account))
+            sendEvent(Event.OnFungibleClick(resource = liquidStakeUnit.fungibleResource, account = account))
         }
     }
 
@@ -237,13 +261,13 @@ class AccountViewModel @Inject constructor(
         val account = _state.value.accountWithAssets?.account ?: return
 
         viewModelScope.launch {
-            sendEvent(AccountEvent.OnFungibleClick(resource = poolUnit.resource, account))
+            sendEvent(Event.OnFungibleClick(resource = poolUnit.resource, account))
         }
     }
 
     fun onApplySecuritySettingsClick() {
         viewModelScope.launch {
-            sendEvent(AccountEvent.NavigateToSecurityCenter)
+            sendEvent(Event.NavigateToSecurityCenter)
         }
     }
 
@@ -315,104 +339,156 @@ class AccountViewModel @Inject constructor(
         }
     }
 
-    private fun loadAccountDetails(withRefresh: Boolean) {
-        _state.update { it.copy(isRefreshing = withRefresh) }
-        viewModelScope.launch { refreshFlow.emit(Unit) }
+    private fun loadAccountDetails(refreshType: State.RefreshType) {
+        automaticRefreshJob?.cancel()
+        viewModelScope.launch { refreshFlow.emit(refreshType) }
         onLatestEpochRequest()
+        automaticRefreshJob = viewModelScope.launch {
+            delay(REFRESH_INTERVAL)
+            loadAccountDetails(refreshType = State.RefreshType.Automatic)
+        }
     }
 
     private fun disableFiatPrices() {
         _state.update { accountUiState ->
-            accountUiState.copy(isFiatBalancesEnabled = false)
+            accountUiState.copy(pricesState = State.PricesState.Disabled)
         }
     }
-}
 
-internal sealed interface AccountEvent : OneOffEvent {
-    data object NavigateToSecurityCenter : AccountEvent
-    data class OnFungibleClick(val resource: Resource.FungibleResource, val account: Account) : AccountEvent
-    data class OnNonFungibleClick(
-        val resource: Resource.NonFungibleResource,
-        val item: Resource.NonFungibleResource.Item,
-        val account: Account
-    ) : AccountEvent
-}
-
-data class AccountUiState(
-    val accountWithAssets: AccountWithAssets? = null,
-    val isFiatBalancesEnabled: Boolean = true,
-    val assetsWithAssetsPrices: Map<Asset, AssetPrice?>? = null,
-    private val hasFailedToFetchPricesForAccount: Boolean = false,
-    val nonFungiblesWithPendingNFTs: Set<ResourceAddress> = setOf(),
-    val pendingStakeUnits: Boolean = false,
-    val securityPrompts: List<SecurityPromptType>? = null,
-    val assetsViewState: AssetsViewState = AssetsViewState.init(),
-    val epoch: Long? = null,
-    val isRefreshing: Boolean = false,
-    val uiMessage: UiMessage? = null
-) : UiState {
-
-    val isAccountBalanceLoading: Boolean
-        get() = assetsWithAssetsPrices == null
-
-    val totalFiatValue: FiatPrice?
-        get() {
-            if (hasFailedToFetchPricesForAccount) return null
-
-            var total = 0.toDecimal192()
-            var currency = SupportedCurrency.USD
-            assetsWithAssetsPrices?.let { assetsWithAssetsPrices ->
-                assetsWithAssetsPrices.values
-                    .mapNotNull { it }
-                    .forEach { assetPrice ->
-                        total += assetPrice.price?.price.orZero()
-                        currency = assetPrice.price?.currency ?: SupportedCurrency.USD
-                    }
-            } ?: return null
-
-            return FiatPrice(price = total, currency = currency)
-        }
-
-    val isTransferEnabled: Boolean
-        get() = accountWithAssets?.assets != null
-
-    fun onNFTsLoading(forResource: Resource.NonFungibleResource): AccountUiState {
-        return copy(nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs + forResource.address)
+    internal sealed interface Event : OneOffEvent {
+        data object NavigateToSecurityCenter : Event
+        data class OnFungibleClick(val resource: Resource.FungibleResource, val account: Account) : Event
+        data class OnNonFungibleClick(
+            val resource: Resource.NonFungibleResource,
+            val item: Resource.NonFungibleResource.Item,
+            val account: Account
+        ) : Event
     }
 
-    fun onNFTsReceived(forResource: Resource.NonFungibleResource): AccountUiState {
-        if (accountWithAssets?.assets?.nonFungibles == null) return this
-        return copy(
-            accountWithAssets = accountWithAssets.copy(
-                assets = accountWithAssets.assets.copy(
-                    nonFungibles = accountWithAssets.assets.nonFungibles.mapWhen(
-                        predicate = {
-                            it.collection.address == forResource.address &&
-                                it.collection.items.size < forResource.items.size
-                        },
-                        mutation = { NonFungibleCollection(forResource) }
+    data class State(
+        val accountWithAssets: AccountWithAssets? = null,
+        private val pricesState: PricesState = PricesState.None,
+        val refreshType: RefreshType = RefreshType.None,
+        val nonFungiblesWithPendingNFTs: Set<ResourceAddress> = setOf(),
+        val pendingStakeUnits: Boolean = false,
+        val securityPrompts: List<SecurityPromptType>? = null,
+        val assetsViewState: AssetsViewState = AssetsViewState.init(),
+        val epoch: Long? = null,
+        val uiMessage: UiMessage? = null
+    ) : UiState {
+
+        val isRefreshing: Boolean = refreshType.showRefreshIndicator
+
+        sealed interface RefreshType {
+            val overrideCache: Boolean
+            val showRefreshIndicator: Boolean
+
+            data object None : RefreshType {
+                override val overrideCache: Boolean = false
+                override val showRefreshIndicator: Boolean = false
+            }
+
+            data class Manual(
+                override val overrideCache: Boolean,
+                override val showRefreshIndicator: Boolean
+            ) : RefreshType
+
+            data object Automatic : RefreshType {
+                override val overrideCache: Boolean = true
+                override val showRefreshIndicator: Boolean = false
+            }
+        }
+
+        sealed interface PricesState {
+            val totalPrice: FiatPrice?
+
+            data object None : PricesState {
+                override val totalPrice: FiatPrice? = null
+            }
+
+            data class Enabled(
+                val prices: Map<Asset, AssetPrice?>
+            ) : PricesState {
+                override val totalPrice: FiatPrice = run {
+                    var total = 0.toDecimal192()
+                    var currency = SupportedCurrency.USD
+                    prices.values.mapNotNull { it }
+                        .forEach { assetPrice ->
+                            total += assetPrice.price?.price.orZero()
+                            currency = assetPrice.price?.currency ?: SupportedCurrency.USD
+                        }
+
+                    FiatPrice(price = total, currency = currency)
+                }
+            }
+
+            data object Disabled : PricesState {
+                override val totalPrice: FiatPrice? = null
+            }
+        }
+
+        val isAccountBalanceLoading: Boolean
+            get() = pricesState is PricesState.None
+
+        val isPricesDisabled: Boolean
+            get() = pricesState is PricesState.Disabled
+
+        val assetsWithPrices: Map<Asset, AssetPrice?>?
+            get() = (pricesState as? PricesState.Enabled)?.prices
+
+        val totalFiatValue: FiatPrice?
+            get() = pricesState.totalPrice
+
+        val isTransferEnabled: Boolean
+            get() = accountWithAssets?.assets != null
+
+        fun onAccount(account: Account, refreshType: RefreshType): State = copy(
+            accountWithAssets = accountWithAssets?.copy(account = account) ?: AccountWithAssets(account = account),
+            refreshType = refreshType
+        )
+
+        fun onNFTsLoading(forResource: Resource.NonFungibleResource): State {
+            return copy(nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs + forResource.address)
+        }
+
+        fun onNFTsReceived(forResource: Resource.NonFungibleResource): State {
+            if (accountWithAssets?.assets?.nonFungibles == null) return this
+            return copy(
+                accountWithAssets = accountWithAssets.copy(
+                    assets = accountWithAssets.assets.copy(
+                        nonFungibles = accountWithAssets.assets.nonFungibles.mapWhen(
+                            predicate = {
+                                it.collection.address == forResource.address &&
+                                    it.collection.items.size < forResource.items.size
+                            },
+                            mutation = { NonFungibleCollection(forResource) }
+                        )
                     )
+                ),
+                nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs - forResource.address
+            )
+        }
+
+        fun onNFTsError(forResource: Resource.NonFungibleResource, error: Throwable): State {
+            if (accountWithAssets?.assets?.nonFungibles == null) return this
+            return copy(
+                nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs - forResource.address,
+                uiMessage = UiMessage.ErrorMessage(error = error)
+            )
+        }
+
+        fun onValidatorsReceived(validatorsWithStakes: List<ValidatorWithStakes>): State = copy(
+            accountWithAssets = accountWithAssets?.copy(
+                assets = accountWithAssets.assets?.copy(
+                    liquidStakeUnits = validatorsWithStakes.mapNotNull { it.liquidStakeUnit },
+                    stakeClaims = validatorsWithStakes.mapNotNull { it.stakeClaimNft }
                 )
             ),
-            nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs - forResource.address
+            pendingStakeUnits = false
         )
     }
 
-    fun onNFTsError(forResource: Resource.NonFungibleResource, error: Throwable): AccountUiState {
-        if (accountWithAssets?.assets?.nonFungibles == null) return this
-        return copy(
-            nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs - forResource.address,
-            uiMessage = UiMessage.ErrorMessage(error = error)
-        )
+    companion object {
+        private val REFRESH_INTERVAL = 1.minutes
     }
-
-    fun onValidatorsReceived(validatorsWithStakes: List<ValidatorWithStakes>): AccountUiState = copy(
-        accountWithAssets = accountWithAssets?.copy(
-            assets = accountWithAssets.assets?.copy(
-                liquidStakeUnits = validatorsWithStakes.mapNotNull { it.liquidStakeUnit },
-                stakeClaims = validatorsWithStakes.mapNotNull { it.stakeClaimNft }
-            )
-        ),
-        pendingStakeUnits = false
-    )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
@@ -443,7 +443,7 @@ class AccountViewModel @Inject constructor(
 
         fun onAssetsError(error: Throwable): State = copy(
             refreshType = RefreshType.None,
-            uiMessage = UiMessage.ErrorMessage(error = error)
+            uiMessage = if (refreshType is RefreshType.Automatic) null else UiMessage.ErrorMessage(error = error)
         )
 
         fun onAssetsReceived(assets: Assets?): State = copy(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountCardView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/AccountCardView.kt
@@ -33,6 +33,8 @@ import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.
 import com.babylon.wallet.android.presentation.ui.composables.assets.TotalFiatBalanceView
 import com.babylon.wallet.android.presentation.ui.composables.toText
 import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
+import com.babylon.wallet.android.presentation.wallet.WalletViewModel.State.AccountTag
+import com.babylon.wallet.android.presentation.wallet.WalletViewModel.State.AccountUiItem
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.DisplayName
 import com.radixdlt.sargon.annotation.UsesSampleValues
@@ -47,7 +49,7 @@ import rdx.works.core.domain.assets.SupportedCurrency
 @Composable
 fun AccountCardView(
     modifier: Modifier = Modifier,
-    accountWithAssets: WalletUiState.AccountUiItem,
+    accountWithAssets: AccountUiItem,
     onApplySecuritySettingsClick: () -> Unit
 ) {
     ConstraintLayout(
@@ -214,9 +216,9 @@ fun AccountCardView(
     }
 }
 
-private fun WalletUiState.AccountTag.toLabel(context: Context): String {
+private fun AccountTag.toLabel(context: Context): String {
     return when (this) {
-        WalletUiState.AccountTag.LEDGER_BABYLON -> {
+        AccountTag.LEDGER_BABYLON -> {
             StringBuilder()
                 .append(" ")
                 .append(context.resources.getString(R.string.dot_separator))
@@ -225,7 +227,7 @@ private fun WalletUiState.AccountTag.toLabel(context: Context): String {
                 .toString()
         }
 
-        WalletUiState.AccountTag.LEDGER_LEGACY -> {
+        AccountTag.LEDGER_LEGACY -> {
             StringBuilder()
                 .append(" ")
                 .append(context.resources.getString(R.string.dot_separator))
@@ -234,7 +236,7 @@ private fun WalletUiState.AccountTag.toLabel(context: Context): String {
                 .toString()
         }
 
-        WalletUiState.AccountTag.LEGACY_SOFTWARE -> {
+        AccountTag.LEGACY_SOFTWARE -> {
             StringBuilder()
                 .append(" ")
                 .append(context.resources.getString(R.string.dot_separator))
@@ -243,7 +245,7 @@ private fun WalletUiState.AccountTag.toLabel(context: Context): String {
                 .toString()
         }
 
-        WalletUiState.AccountTag.DAPP_DEFINITION -> {
+        AccountTag.DAPP_DEFINITION -> {
             StringBuilder()
                 .append(" ")
                 .append(context.resources.getString(R.string.dot_separator))
@@ -261,7 +263,7 @@ fun AccountCardPreview() {
     RadixWalletPreviewTheme {
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
             AccountCardView(
-                accountWithAssets = WalletUiState.AccountUiItem(
+                accountWithAssets = AccountUiItem(
                     account = Account.sampleMainnet(),
                     assets = Assets(
                         tokens = emptyList(),
@@ -271,7 +273,7 @@ fun AccountCardPreview() {
                         stakeClaims = emptyList()
                     ),
                     fiatTotalValue = FiatPrice(price = 3450900.899.toDecimal192(), currency = SupportedCurrency.USD),
-                    tag = WalletUiState.AccountTag.DAPP_DEFINITION,
+                    tag = AccountTag.DAPP_DEFINITION,
                     securityPrompts = null,
                     isFiatBalanceVisible = true,
                     isLoadingAssets = false,
@@ -290,7 +292,7 @@ fun AccountCardWithLongNameAndShortTotalValuePreview() {
     RadixWalletPreviewTheme {
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
             AccountCardView(
-                accountWithAssets = WalletUiState.AccountUiItem(
+                accountWithAssets = AccountUiItem(
                     account = Account.sampleMainnet().copy(
                         displayName = DisplayName("a very long name for my account")
                     ),
@@ -302,7 +304,7 @@ fun AccountCardWithLongNameAndShortTotalValuePreview() {
                         stakeClaims = emptyList()
                     ),
                     fiatTotalValue = FiatPrice(price = 3450.0.toDecimal192(), currency = SupportedCurrency.USD),
-                    tag = WalletUiState.AccountTag.DAPP_DEFINITION,
+                    tag = AccountTag.DAPP_DEFINITION,
                     securityPrompts = listOf(SecurityPromptType.RECOVERY_REQUIRED),
                     isFiatBalanceVisible = true,
                     isLoadingAssets = false,
@@ -321,7 +323,7 @@ fun AccountCardWithLongNameAndLongTotalValuePreview() {
     RadixWalletPreviewTheme {
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
             AccountCardView(
-                accountWithAssets = WalletUiState.AccountUiItem(
+                accountWithAssets = AccountUiItem(
                     account = Account.sampleMainnet().copy(
                         displayName = DisplayName("a very long name for my account again much more longer oh god ")
                     ),
@@ -333,7 +335,7 @@ fun AccountCardWithLongNameAndLongTotalValuePreview() {
                         stakeClaims = emptyList()
                     ),
                     fiatTotalValue = FiatPrice(price = 345008999008932.4.toDecimal192(), currency = SupportedCurrency.USD),
-                    tag = WalletUiState.AccountTag.DAPP_DEFINITION,
+                    tag = AccountTag.DAPP_DEFINITION,
                     securityPrompts = listOf(
                         SecurityPromptType.CONFIGURATION_BACKUP_PROBLEM,
                         SecurityPromptType.WRITE_DOWN_SEED_PHRASE,
@@ -357,7 +359,7 @@ fun AccountCardWithLongNameAndTotalValueHiddenPreview() {
         CompositionLocalProvider(value = LocalBalanceVisibility.provides(false)) {
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 AccountCardView(
-                    accountWithAssets = WalletUiState.AccountUiItem(
+                    accountWithAssets = AccountUiItem(
                         account = Account.sampleMainnet().copy(
                             displayName = DisplayName("a very long name for my account again much more longer oh god ")
                         ),
@@ -369,7 +371,7 @@ fun AccountCardWithLongNameAndTotalValueHiddenPreview() {
                             stakeClaims = emptyList()
                         ),
                         fiatTotalValue = FiatPrice(price = 34509008998732.4.toDecimal192(), currency = SupportedCurrency.USD),
-                        tag = WalletUiState.AccountTag.DAPP_DEFINITION,
+                        tag = AccountTag.DAPP_DEFINITION,
                         securityPrompts = listOf(SecurityPromptType.WALLET_NOT_RECOVERABLE),
                         isLoadingAssets = false,
                         isLoadingBalance = false,
@@ -389,7 +391,7 @@ fun AccountCardLoadingPreview() {
     RadixWalletPreviewTheme {
         Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
             AccountCardView(
-                accountWithAssets = WalletUiState.AccountUiItem(
+                accountWithAssets = AccountUiItem(
                     account = Account.sampleMainnet(),
                     assets = Assets(
                         tokens = emptyList(),
@@ -399,7 +401,7 @@ fun AccountCardLoadingPreview() {
                         stakeClaims = emptyList()
                     ),
                     fiatTotalValue = FiatPrice(price = 3450900899.0.toDecimal192(), currency = SupportedCurrency.USD),
-                    tag = WalletUiState.AccountTag.DAPP_DEFINITION,
+                    tag = AccountTag.DAPP_DEFINITION,
                     securityPrompts = null,
                     isFiatBalanceVisible = true,
                     isLoadingAssets = true,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -59,6 +59,7 @@ import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.composables.assets.TotalFiatBalanceView
 import com.babylon.wallet.android.presentation.ui.composables.assets.TotalFiatBalanceViewToggle
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import com.babylon.wallet.android.presentation.wallet.WalletViewModel.Event
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.openUrl
 import com.radixdlt.sargon.Account
@@ -128,7 +129,7 @@ fun WalletScreen(
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.collect {
             when (it) {
-                is WalletEvent.NavigateToSecurityCenter -> onNavigateToSecurityCenter()
+                is Event.NavigateToSecurityCenter -> onNavigateToSecurityCenter()
             }
         }
     }
@@ -162,7 +163,7 @@ fun SyncPopUpScreensState(popUpScreen: WalletViewModel.PopUpScreen?, onDismiss: 
 @Composable
 private fun WalletContent(
     modifier: Modifier = Modifier,
-    state: WalletUiState,
+    state: WalletViewModel.State,
     onMenuClick: () -> Unit,
     onShowHideBalanceToggle: (isVisible: Boolean) -> Unit,
     onAccountClick: (Account) -> Unit,
@@ -244,7 +245,7 @@ private fun WalletContent(
 @Composable
 private fun WalletAccountList(
     modifier: Modifier = Modifier,
-    state: WalletUiState,
+    state: WalletViewModel.State,
     onShowHideBalanceToggle: (isVisible: Boolean) -> Unit,
     onAccountClick: (Account) -> Unit,
     onAccountCreationClick: () -> Unit,
@@ -392,7 +393,7 @@ private fun RadixBanner(
 @Preview("large font", fontScale = 2f, showBackground = true)
 @Composable
 private fun WalletContentPreview(
-    @PreviewParameter(WalletUiStateProvider::class) uiState: WalletUiState
+    @PreviewParameter(WalletUiStateProvider::class) uiState: WalletViewModel.State
 ) {
     RadixWalletPreviewTheme {
         WalletContent(
@@ -410,13 +411,13 @@ private fun WalletContentPreview(
 }
 
 @UsesSampleValues
-class WalletUiStateProvider : PreviewParameterProvider<WalletUiState> {
+class WalletUiStateProvider : PreviewParameterProvider<WalletViewModel.State> {
 
-    override val values: Sequence<WalletUiState>
+    override val values: Sequence<WalletViewModel.State>
         get() = sequenceOf(
-            WalletUiState(
+            WalletViewModel.State(
                 accountUiItems = listOf(
-                    WalletUiState.AccountUiItem(
+                    WalletViewModel.State.AccountUiItem(
                         account = Account.sampleMainnet(),
                         assets = null,
                         fiatTotalValue = FiatPrice(
@@ -429,7 +430,7 @@ class WalletUiStateProvider : PreviewParameterProvider<WalletUiState> {
                         isLoadingAssets = false,
                         isLoadingBalance = false
                     ),
-                    WalletUiState.AccountUiItem(
+                    WalletViewModel.State.AccountUiItem(
                         account = Account.sampleMainnet.other().copy(
                             displayName = DisplayName("my account with a way too much long name")
                         ),
@@ -451,7 +452,7 @@ class WalletUiStateProvider : PreviewParameterProvider<WalletUiState> {
                         isLoadingAssets = false,
                         isLoadingBalance = false
                     ),
-                    WalletUiState.AccountUiItem(
+                    WalletViewModel.State.AccountUiItem(
                         account = Account.sampleMainnet(),
                         assets = null,
                         fiatTotalValue = null,
@@ -468,10 +469,10 @@ class WalletUiStateProvider : PreviewParameterProvider<WalletUiState> {
                     currency = SupportedCurrency.USD
                 )
             ),
-            WalletUiState(
+            WalletViewModel.State(
                 isRadixBannerVisible = true
             ),
-            WalletUiState(
+            WalletViewModel.State(
                 isLoading = true
             )
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -13,7 +13,6 @@ import com.babylon.wallet.android.domain.usecases.SecurityPromptType
 import com.babylon.wallet.android.domain.usecases.accountPrompts
 import com.babylon.wallet.android.domain.usecases.assets.GetFiatValueUseCase
 import com.babylon.wallet.android.domain.usecases.assets.GetWalletAssetsUseCase
-import com.babylon.wallet.android.presentation.account.AccountViewModel.State.RefreshType
 import com.babylon.wallet.android.presentation.common.OneOffEvent
 import com.babylon.wallet.android.presentation.common.OneOffEventHandler
 import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
@@ -105,7 +104,7 @@ class WalletViewModel @Inject constructor(
             }
         }
         observePrompts()
-        observeWallet()
+        observeWalletAssets()
         observeGlobalAppEvents()
         observeNpsSurveyState()
         observeShowRelinkConnectors()
@@ -182,7 +181,7 @@ class WalletViewModel @Inject constructor(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun observeWallet() {
+    private fun observeWalletAssets() {
         combine(
             accountsFlow,
             refreshFlow.onStart {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -205,7 +205,7 @@ class WalletViewModel @Inject constructor(
             // Only when all assets have concluded (either success or error) then we
             // can request for prices.
             if (accountsWithAssets.none { it.assets == null }) {
-                Timber.tag("WALLET").d("Getting prices")
+                Timber.tag("WALLET").d("Getting prices, $overrideCache")
 
                 val pricesPerAccount = mutableMapOf<AccountAddress, List<AssetPrice>?>()
                 for (accountWithAssets in accountsWithAssets) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -13,6 +13,7 @@ import com.babylon.wallet.android.domain.usecases.SecurityPromptType
 import com.babylon.wallet.android.domain.usecases.accountPrompts
 import com.babylon.wallet.android.domain.usecases.assets.GetFiatValueUseCase
 import com.babylon.wallet.android.domain.usecases.assets.GetWalletAssetsUseCase
+import com.babylon.wallet.android.presentation.account.AccountViewModel.State.RefreshType
 import com.babylon.wallet.android.presentation.common.OneOffEvent
 import com.babylon.wallet.android.presentation.common.OneOffEventHandler
 import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
@@ -42,7 +43,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -390,7 +390,7 @@ class WalletViewModel @Inject constructor(
             error: Throwable
         ): State = copy(
             refreshType = RefreshType.None,
-            uiMessage = UiMessage.ErrorMessage(error),
+            uiMessage = if (refreshType is RefreshType.Automatic) null else UiMessage.ErrorMessage(error),
             accountsWithAssets = accountsWithAssets?.map { accountWithAssets ->
                 if (accountWithAssets.assets == null) {
                     // If assets don't exist leave them empty

--- a/app/src/test/java/com/babylon/wallet/android/presentation/WalletViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/WalletViewModelTest.kt
@@ -9,7 +9,6 @@ import com.babylon.wallet.android.domain.model.assets.AccountWithAssets
 import com.babylon.wallet.android.domain.usecases.GetEntitiesWithSecurityPromptUseCase
 import com.babylon.wallet.android.domain.usecases.assets.GetFiatValueUseCase
 import com.babylon.wallet.android.domain.usecases.assets.GetWalletAssetsUseCase
-import com.babylon.wallet.android.presentation.wallet.WalletUiState
 import com.babylon.wallet.android.presentation.wallet.WalletViewModel
 import com.babylon.wallet.android.utils.AppEventBus
 import com.radixdlt.sargon.NetworkId
@@ -138,7 +137,7 @@ class WalletViewModelTest : StateViewModelTest<WalletViewModel>() {
 
         viewModel.state.test {
             assertEquals(
-                WalletUiState(),
+                WalletViewModel.State(),
                 expectMostRecentItem()
             )
         }


### PR DESCRIPTION
## Description
* The wallet screen refreshes the assets every 5 minutes and the account screen every 1 minute
* The "refresh timer" starts counting from the last time a previous refresh occurred. Meaning that if the user does a manual refresh meanwhile then the timer restarts.
* Errors are not shown when an automatic refresh occurs.
* Substantial changes to the `WalletViewModel` regarding the structure of state and how it is represented. More detailed types for refresh and price state exist and give more flexibility to preserve state and convey it to the user.


## How to test
1. Open wallet from scratch
2. Reopen wallet
3. Play around with refresh
4. Do the same with account screen
