### PR TITLE
Pre-select single persona when none selected

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaViewModel.kt
@@ -102,11 +102,18 @@ class SelectPersonaViewModel @Inject constructor(
                 personaUiModel
             }
         }.sortedByDescending { it.lastUsedOnTimestamp }
-        val currentlySelectedPersona = state.value.personaListToDisplay.firstOrNull { it.selected }
+        var currentlySelectedPersona = state.value.personaListToDisplay.firstOrNull { it.selected }
             ?: updatedPersonas.firstOrNull { it.lastUsedOn != null }
+
+        // When we have a single persona and there are no pre-selected ones, pre-select it.
+        if (currentlySelectedPersona == null && updatedPersonas.size == 1) {
+            currentlySelectedPersona = updatedPersonas[0]
+        }
+
         currentlySelectedPersona?.persona?.let {
             sendEvent(DAppSelectPersonaEvent.PersonaSelected(it))
         }
+
         return updatedPersonas.map { p ->
             p.copy(selected = p.persona.address == currentlySelectedPersona?.persona?.address)
         }


### PR DESCRIPTION
## Description
* When there is only one persona available, preselect it.
* When there are more than one personas or one persona was already authorised for a dApp continue the same logic as before

## How to test

1. Create one persona. Subsequent logins with dApps have this persona pre-selected.
2. Create multiple personas. Subsequent logins have nothing preselected, except if one persona was authorised in the past. If so that persona in ordered first, preselected and displays the last used timestamp