### PR TITLE
[ABW-2747] Refactor signature request in transactions

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
+++ b/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
@@ -25,6 +25,7 @@ import com.babylon.wallet.android.domain.model.IncomingMessage
 import com.babylon.wallet.android.domain.userFriendlyMessage
 import com.babylon.wallet.android.presentation.accessfactorsources.deriveaccounts.deriveAccounts
 import com.babylon.wallet.android.presentation.accessfactorsources.derivepublickey.derivePublicKeyDialog
+import com.babylon.wallet.android.presentation.accessfactorsources.signatures.getSignatures
 import com.babylon.wallet.android.presentation.dapp.authorized.login.dAppLoginAuthorized
 import com.babylon.wallet.android.presentation.dapp.unauthorized.login.dAppLoginUnauthorized
 import com.babylon.wallet.android.presentation.main.MAIN_ROUTE
@@ -218,7 +219,8 @@ private fun HandleAccessFactorSourcesEvents(
         accessFactorSourcesEvents.collect { event ->
             when (event) {
                 AppEvent.AccessFactorSources.DerivePublicKey -> navController.derivePublicKeyDialog()
-                AppEvent.AccessFactorSources.DeriveAccounts -> navController.deriveAccounts()
+                is AppEvent.AccessFactorSources.DeriveAccounts -> navController.deriveAccounts()
+                AppEvent.AccessFactorSources.GetSignatures -> navController.getSignatures()
                 is AppEvent.AccessFactorSources.SelectedLedgerDevice -> {}
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/LedgerMessenger.kt
@@ -172,7 +172,7 @@ class LedgerMessengerImpl @Inject constructor(
                 }
             }
             .onFailure { throwable ->
-                emit(Result.failure(Exception("Failed to connect Ledger device ", throwable)))
+                emit(Result.failure(RadixWalletException.LedgerCommunicationException.FailedToConnect))
             }
     }.first()
 }

--- a/app/src/main/java/com/babylon/wallet/android/di/UiModule.kt
+++ b/app/src/main/java/com/babylon/wallet/android/di/UiModule.kt
@@ -1,8 +1,8 @@
 package com.babylon.wallet.android.di
 
+import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesIOHandler
 import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesProxy
 import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesProxyImpl
-import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesUiProxy
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,9 +13,9 @@ import dagger.hilt.android.components.ActivityRetainedComponent
 interface UiModule {
 
     @Binds
-    fun bindAccessFactorSourcesUiProxy(
+    fun bindAccessFactorSourcesIOHandler(
         accessFactorSourcesProxyImpl: AccessFactorSourcesProxyImpl
-    ): AccessFactorSourcesUiProxy
+    ): AccessFactorSourcesIOHandler
 
     @Binds
     fun bindAccessFactorSourcesProxy(

--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -173,6 +173,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
     }
 
     sealed class LedgerCommunicationException : RadixWalletException(), ConnectorExtensionThrowable {
+        data object FailedToConnect : LedgerCommunicationException()
         data object FailedToGetDeviceId : LedgerCommunicationException()
         data object FailedToDerivePublicKeys : LedgerCommunicationException()
         data object FailedToDeriveAndDisplayAddress : LedgerCommunicationException()
@@ -186,6 +187,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
                 is FailedToSignTransaction -> DappWalletInteractionErrorType.INVALID_REQUEST
                 is FailedToDeriveAndDisplayAddress -> DappWalletInteractionErrorType.INVALID_REQUEST
                 FailedToSignAuthChallenge -> DappWalletInteractionErrorType.INVALID_REQUEST
+                FailedToConnect -> DappWalletInteractionErrorType.INVALID_REQUEST
             }
     }
 
@@ -233,6 +235,8 @@ fun RadixWalletException.LedgerCommunicationException.toUserFriendlyMessage(cont
             RadixWalletException.LedgerCommunicationException.FailedToSignAuthChallenge -> {
                 R.string.ledgerHardwareDevices_verification_requestFailed
             }
+
+            RadixWalletException.LedgerCommunicationException.FailedToConnect -> R.string.common_somethingWentWrong
         }
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetFreeXrdUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetFreeXrdUseCase.kt
@@ -49,13 +49,12 @@ class GetFreeXrdUseCase @Inject constructor(
 
             val epochResult = transactionRepository.getLedgerEpoch()
             epochResult.getOrNull()?.let { epoch ->
-                signTransactionUseCase.sign(
+                signTransactionUseCase(
                     request = SignTransactionUseCase.Request(
                         manifest = manifest,
                         lockFee = TransactionConfig.DEFAULT_LOCK_FEE.toDecimal192(),
                         tipPercentage = TIP_PERCENTAGE
-                    ),
-                    deviceBiometricAuthenticationProvider = { true }
+                    )
                 ).then { notarization ->
                     submitTransactionUseCase(notarizationResult = notarization)
                 }.onSuccess { notarization ->

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/NotariseTransactionUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/NotariseTransactionUseCase.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.domain.usecases
 
+import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.RadixWalletException.PrepareTransactionException
 import com.radixdlt.sargon.Epoch
 import com.radixdlt.sargon.IntentSignature
@@ -47,7 +48,11 @@ class NotariseTransactionUseCase @Inject constructor() {
         }
 
         val signatures = signatureGatherer.gatherSignatures(intent = intent).getOrElse { error ->
-            return Result.failure(PrepareTransactionException.SignCompiledTransactionIntent(error))
+            if (error is RadixWalletException.DappRequestException.RejectedByUser) {
+                return Result.failure(error)
+            } else {
+                return Result.failure(PrepareTransactionException.SignCompiledTransactionIntent(error))
+            }
         }
 
         val signedIntent = runCatching {

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/SignTransactionUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/SignTransactionUseCase.kt
@@ -97,13 +97,17 @@ class SignTransactionUseCase @Inject constructor(
         override suspend fun gatherSignatures(intent: TransactionIntent): Result<List<SignatureWithPublicKey>> = runCatching {
             SignRequest.SignTransactionRequest(intent = intent)
         }.then { signRequest ->
-            accessFactorSourcesProxy.getSignatures(
-                accessFactorSourcesInput = AccessFactorSourcesInput.ToGetSignatures(
-                    signers = notaryAndSigners.signers,
-                    signRequest = signRequest
-                )
-            ).mapCatching { result ->
-                result.signaturesWithPublicKey
+            if (notaryAndSigners.notaryIsSignatory) {
+                Result.success(emptyList())
+            } else {
+                accessFactorSourcesProxy.getSignatures(
+                    accessFactorSourcesInput = AccessFactorSourcesInput.ToGetSignatures(
+                        signers = notaryAndSigners.signers,
+                        signRequest = signRequest
+                    )
+                ).mapCatching { result ->
+                    result.signaturesWithPublicKey
+                }
             }
         }
 

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/CollectSignersSignaturesUseCase.kt
@@ -21,6 +21,7 @@ import rdx.works.core.toByteArray
 import rdx.works.profile.domain.signing.GetSigningEntitiesByFactorSourceUseCase
 import javax.inject.Inject
 
+@Deprecated("will be removed after refactoring. Now it is used only in ROLAClient")
 class CollectSignersSignaturesUseCase @Inject constructor(
     private val signWithDeviceFactorSourceUseCase: SignWithDeviceFactorSourceUseCase,
     private val signWithLedgerFactorSourceUseCase: SignWithLedgerFactorSourceUseCase,
@@ -60,7 +61,7 @@ class CollectSignersSignaturesUseCase @Inject constructor(
                     signWithDeviceFactorSourceUseCase(
                         deviceFactorSource = factorSource,
                         signers = signers,
-                        request = signRequest
+                        signRequest = signRequest
                     ).onSuccess { signatures ->
                         signaturesWithPublicKeys.addAll(signatures)
                     }.onFailure {

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/SignWithDeviceFactorSourceUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/transaction/SignWithDeviceFactorSourceUseCase.kt
@@ -23,14 +23,14 @@ class SignWithDeviceFactorSourceUseCase @Inject constructor(
     suspend operator fun invoke(
         deviceFactorSource: FactorSource.Device,
         signers: List<ProfileEntity>,
-        request: SignRequest
+        signRequest: SignRequest
     ): Result<List<SignatureWithPublicKey>> {
         val result = mutableListOf<SignatureWithPublicKey>()
 
         signers.forEach { signer ->
             when (val securityState = signer.securityState) {
                 is EntitySecurityState.Unsecured -> {
-                    val factorInstance = when (request) {
+                    val factorInstance = when (signRequest) {
                         is SignRequest.SignAuthChallengeRequest ->
                             securityState.value.authenticationSigning
                                 ?: securityState.value.transactionSigning
@@ -41,7 +41,7 @@ class SignWithDeviceFactorSourceUseCase @Inject constructor(
                     if (mnemonicExist.not()) return Result.failure(ProfileException.NoMnemonic)
                     mnemonicRepository.readMnemonic(deviceFactorSource.value.id.asGeneral()).mapCatching { mnemonic ->
                         val signatureWithPublicKey = mnemonic.sign(
-                            hash = request.hashedDataToSign,
+                            hash = signRequest.hashedDataToSign,
                             path = factorInstance.publicKey.derivationPath
                         )
                         result.add(signatureWithPublicKey)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
@@ -10,7 +10,7 @@ import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.SignatureWithPublicKey
 import com.radixdlt.sargon.extensions.ProfileEntity
 
-// interface for clients (viewmodels or usecases) that need access to factor sources
+// interface for the callers (viewmodels or usecases) that need access to factor sources
 //
 // for example CreateAccountViewModel needs a public key to create an account therefore it must call:
 //
@@ -46,7 +46,7 @@ interface AccessFactorSourcesProxy {
 }
 
 // interface that is passed as parameter in the viewmodels of the bottom sheet dialogs
-// when a access-factor-source-bottom-sheet dialog pops up its viewmodel
+// when a access-factor-source-bottom-sheet dialog pops up, then its viewmodel
 // 1. takes the input from the accessFactorSourcesIOHandler.getInput()
 // 2. returns the output to the caller (e.g. CreateAccountViewModel) by calling accessFactorSourcesIOHandler.setOutput(...)
 //
@@ -68,12 +68,12 @@ interface AccessFactorSourcesIOHandler {
 sealed interface AccessFactorSourcesInput {
 
     data class ToDerivePublicKey(
+        val entityKind: EntityKind,
         val forNetworkId: NetworkId,
         val factorSource: FactorSource,
         // Need this information only when a new profile is created, meaning that biometrics have been provided
         // No need to ask the user for authentication again.
-        val isBiometricsProvided: Boolean,
-        val entityKind: EntityKind
+        val isBiometricsProvided: Boolean
     ) : AccessFactorSourcesInput
 
     sealed interface ToReDeriveAccounts : AccessFactorSourcesInput {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
@@ -10,12 +10,14 @@ import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.SignatureWithPublicKey
 import com.radixdlt.sargon.extensions.ProfileEntity
 
-// interface for the callers (viewmodels or usecases) that need access to factor sources
-//
-// for example CreateAccountViewModel needs a public key to create an account therefore it must call:
-//
-// val publicKey = accessFactorSourcesProxy.getPublicKeyAndDerivationPathForFactorSource(...)
-// createAccountUseCase(displayName = ""a name", publicKey = publicKey)
+/**
+ * Interface for the callers (ViewModels or UseCases) that need access to factor sources.
+ *
+ * for example CreateAccountViewModel needs a public key to create an account therefore it must call:
+ * val publicKey = accessFactorSourcesProxy.getPublicKeyAndDerivationPathForFactorSource(...)
+ * createAccountUseCase(displayName = ""a name", publicKey = publicKey)
+ *
+ */
 interface AccessFactorSourcesProxy {
 
     suspend fun getPublicKeyAndDerivationPathForFactorSource(
@@ -45,12 +47,16 @@ interface AccessFactorSourcesProxy {
     fun getTempMnemonicWithPassphrase(): MnemonicWithPassphrase?
 }
 
-// interface that is passed as parameter in the viewmodels of the bottom sheet dialogs
-// when a access-factor-source-bottom-sheet dialog pops up, then its viewmodel
-// 1. takes the input from the accessFactorSourcesIOHandler.getInput()
-// 2. returns the output to the caller (e.g. CreateAccountViewModel) by calling accessFactorSourcesIOHandler.setOutput(...)
-//
-// This interface is also implemented in the AccessFactorSourcesProxyImpl
+/**
+ * Interface that is passed as parameter in the ViewModels of the bottom sheet dialogs.
+ *
+ * when a access-factor-source-bottom-sheet dialog pops up, then its viewmodel:
+ * 1. takes the input from the accessFactorSourcesIOHandler.getInput()
+ * 2. returns the output to the caller (e.g. CreateAccountViewModel) by calling accessFactorSourcesIOHandler.setOutput(...)
+ *
+ * This interface is also implemented in the AccessFactorSourcesProxyImpl.
+ *
+ */
 interface AccessFactorSourcesIOHandler {
 
     fun getInput(): AccessFactorSourcesInput
@@ -60,11 +66,14 @@ interface AccessFactorSourcesIOHandler {
 
 // ----- Models for input/output ----- //
 
-// We must clearly define what is the minimum input and the minimum output.
-//
-// For example, when wallet needs to create an account,
-// we need to access factor sources in order to derive a public key,
-// therefore the public key is the output and not the whole account!
+/**
+ * Define in a clear manner with proper naming the minimum input and output.
+ *
+ * For example, when wallet needs to create an account,
+ * we need to access factor sources in order to derive a public key,
+ * therefore the public key is the (minimum) output and not the whole account!
+ *
+ */
 sealed interface AccessFactorSourcesInput {
 
     data class ToDerivePublicKey(
@@ -104,6 +113,14 @@ sealed interface AccessFactorSourcesInput {
     data object Init : AccessFactorSourcesInput
 }
 
+/**
+ * Define in a clear manner with proper naming the minimum input and output.
+ *
+ * For example, when wallet needs to create an account,
+ * we need to access factor sources in order to derive a public key,
+ * therefore the public key is the (minimum) output and not the whole account!
+ *
+ */
 sealed interface AccessFactorSourcesOutput {
 
     data class HDPublicKey(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
@@ -1,11 +1,14 @@
 package com.babylon.wallet.android.presentation.accessfactorsources
 
+import com.babylon.wallet.android.domain.usecases.transaction.SignRequest
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.EntityKind
 import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.HierarchicalDeterministicPublicKey
 import com.radixdlt.sargon.MnemonicWithPassphrase
 import com.radixdlt.sargon.NetworkId
+import com.radixdlt.sargon.SignatureWithPublicKey
+import com.radixdlt.sargon.extensions.ProfileEntity
 
 // interface for clients that need access to factor sources
 interface AccessFactorSourcesProxy {
@@ -17,6 +20,10 @@ interface AccessFactorSourcesProxy {
     suspend fun reDeriveAccounts(
         accessFactorSourcesInput: AccessFactorSourcesInput.ToReDeriveAccounts
     ): Result<AccessFactorSourcesOutput.DerivedAccountsWithNextDerivationPath>
+
+    suspend fun getSignatures(
+        accessFactorSourcesInput: AccessFactorSourcesInput.ToGetSignatures
+    ): Result<AccessFactorSourcesOutput.Signatures>
 
     /**
      * This method temporarily keeps in memory the mnemonic that has been added through
@@ -75,6 +82,11 @@ sealed interface AccessFactorSourcesInput {
         ) : ToReDeriveAccounts
     }
 
+    data class ToGetSignatures(
+        val signers: List<ProfileEntity>,
+        val signRequest: SignRequest
+    ) : AccessFactorSourcesInput
+
     data object Init : AccessFactorSourcesInput
 }
 
@@ -87,6 +99,10 @@ sealed interface AccessFactorSourcesOutput {
     data class DerivedAccountsWithNextDerivationPath(
         val derivedAccounts: List<Account>,
         val nextDerivationPathOffset: UInt // is used as pointer when user clicks "scan the next 50"
+    ) : AccessFactorSourcesOutput
+
+    data class Signatures(
+        val signaturesWithPublicKey: List<SignatureWithPublicKey>
     ) : AccessFactorSourcesOutput
 
     data class Failure(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
@@ -45,12 +45,12 @@ interface AccessFactorSourcesProxy {
     fun getTempMnemonicWithPassphrase(): MnemonicWithPassphrase?
 }
 
-// interface which acts as a mediator between the clients who need access to factor sources
+// interface which acts as a proxy between the clients who need access to factor sources
 // and the viewmodels of the bottom sheet dialogs
 //
 // for example when we call this:
 // val publicKey = accessFactorSourcesProxy.getPublicKeyAndDerivationPathForFactorSource(...)
-// the AccessFactorSourcesProxyImpl is the mediator between the CreateAccountViewModel and the DerivePublicKeyViewModel
+// the AccessFactorSourcesProxyImpl is the proxy between the CreateAccountViewModel and the DerivePublicKeyViewModel
 interface AccessFactorSourcesUiProxy {
 
     fun getInput(): AccessFactorSourcesInput

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
@@ -10,7 +10,12 @@ import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.SignatureWithPublicKey
 import com.radixdlt.sargon.extensions.ProfileEntity
 
-// interface for clients that need access to factor sources
+// interface for clients (viewmodels or usecases) that need access to factor sources
+//
+// for example CreateAccountViewModel needs a public key to create an account therefore it must call:
+//
+// val publicKey = accessFactorSourcesProxy.getPublicKeyAndDerivationPathForFactorSource(...)
+// createAccountUseCase(displayName = ""a name", publicKey = publicKey)
 interface AccessFactorSourcesProxy {
 
     suspend fun getPublicKeyAndDerivationPathForFactorSource(
@@ -42,6 +47,10 @@ interface AccessFactorSourcesProxy {
 
 // interface which acts as a mediator between the clients who need access to factor sources
 // and the viewmodels of the bottom sheet dialogs
+//
+// for example when we call this:
+// val publicKey = accessFactorSourcesProxy.getPublicKeyAndDerivationPathForFactorSource(...)
+// the AccessFactorSourcesProxyImpl is the mediator between the CreateAccountViewModel and the DerivePublicKeyViewModel
 interface AccessFactorSourcesUiProxy {
 
     fun getInput(): AccessFactorSourcesInput
@@ -51,6 +60,11 @@ interface AccessFactorSourcesUiProxy {
 
 // ----- Models for input/output ----- //
 
+// We must clearly define what is the minimum input and the minimum output.
+//
+// For example, when wallet needs to create an account,
+// we need to access factor sources in order to derive a public key,
+// therefore the public key is the output and not the whole account!
 sealed interface AccessFactorSourcesInput {
 
     data class ToDerivePublicKey(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
@@ -45,13 +45,13 @@ interface AccessFactorSourcesProxy {
     fun getTempMnemonicWithPassphrase(): MnemonicWithPassphrase?
 }
 
-// interface which acts as a proxy between the clients who need access to factor sources
-// and the viewmodels of the bottom sheet dialogs
+// interface that is passed as parameter in the viewmodels of the bottom sheet dialogs
+// when a access-factor-source-bottom-sheet dialog pops up its viewmodel
+// 1. takes the input from the accessFactorSourcesIOHandler.getInput()
+// 2. returns the output to the caller (e.g. CreateAccountViewModel) by calling accessFactorSourcesIOHandler.setOutput(...)
 //
-// for example when we call this:
-// val publicKey = accessFactorSourcesProxy.getPublicKeyAndDerivationPathForFactorSource(...)
-// the AccessFactorSourcesProxyImpl is the proxy between the CreateAccountViewModel and the DerivePublicKeyViewModel
-interface AccessFactorSourcesUiProxy {
+// This interface is also implemented in the AccessFactorSourcesProxyImpl
+interface AccessFactorSourcesIOHandler {
 
     fun getInput(): AccessFactorSourcesInput
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourcesProxyImpl.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourcesProxyImpl.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 @ActivityRetainedScoped
 class AccessFactorSourcesProxyImpl @Inject constructor(
     private val appEventBus: AppEventBus
-) : AccessFactorSourcesProxy, AccessFactorSourcesUiProxy {
+) : AccessFactorSourcesProxy, AccessFactorSourcesIOHandler {
 
     private var input: AccessFactorSourcesInput = AccessFactorSourcesInput.Init
     private val _output = MutableSharedFlow<AccessFactorSourcesOutput>()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourcesProxyImpl.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourcesProxyImpl.kt
@@ -49,6 +49,20 @@ class AccessFactorSourcesProxyImpl @Inject constructor(
         }
     }
 
+    override suspend fun getSignatures(
+        accessFactorSourcesInput: AccessFactorSourcesInput.ToGetSignatures
+    ): Result<AccessFactorSourcesOutput.Signatures> {
+        input = accessFactorSourcesInput
+        appEventBus.sendEvent(event = AppEvent.AccessFactorSources.GetSignatures)
+        val result = _output.first()
+
+        return if (result is AccessFactorSourcesOutput.Failure) {
+            Result.failure(result.error)
+        } else {
+            Result.success(result as AccessFactorSourcesOutput.Signatures)
+        }
+    }
+
     override fun getInput(): AccessFactorSourcesInput {
         return input
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
@@ -90,9 +90,9 @@ private fun GetSignaturesBottomSheetContent(
 ) {
     BottomSheetDialogWrapper(
         modifier = modifier,
-        onDismiss = {
-            onDismiss()
-        }
+        heightFraction = 0.7f,
+        centerContent = true,
+        onDismiss = onDismiss
     ) {
         Column(
             modifier = Modifier
@@ -101,7 +101,6 @@ private fun GetSignaturesBottomSheetContent(
                 .background(RadixTheme.colors.defaultBackground),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Spacer(Modifier.height(40.dp))
             Icon(
                 modifier = Modifier.size(80.dp),
                 painter = painterResource(
@@ -122,12 +121,6 @@ private fun GetSignaturesBottomSheetContent(
                         style = RadixTheme.typography.body1Regular,
                         text = stringResource(id = R.string.factorSourceActions_device_messageSignature)
                     )
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
-                    RadixTextButton(
-                        modifier = Modifier.fillMaxWidth(),
-                        text = stringResource(R.string.common_retry),
-                        onClick = onRetryClick
-                    )
                 }
 
                 is GetSignaturesViewModel.State.ShowContentForFactorSource.Ledger -> {
@@ -138,19 +131,18 @@ private fun GetSignaturesBottomSheetContent(
                         color = RadixTheme.colors.gray1,
                         textAlign = TextAlign.Center
                     )
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXLarge))
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
                     RoundLedgerItem(ledgerName = showContentForFactorSource.ledgerFactorSource.value.hint.name)
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
-                    RadixTextButton(
-                        modifier = Modifier.fillMaxWidth(),
-                        text = stringResource(R.string.common_retry),
-                        onClick = onRetryClick
-                    )
                 }
 
                 GetSignaturesViewModel.State.ShowContentForFactorSource.None -> { /* nothing */ }
             }
-            Spacer(Modifier.height(120.dp))
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+            RadixTextButton(
+                modifier = Modifier.fillMaxWidth(),
+                text = stringResource(R.string.common_retry),
+                onClick = onRetryClick
+            )
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
@@ -1,0 +1,186 @@
+package com.babylon.wallet.android.presentation.accessfactorsources.signatures
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.babylon.wallet.android.R
+import com.babylon.wallet.android.designsystem.composable.RadixTextButton
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
+import com.babylon.wallet.android.presentation.accessfactorsources.composables.RoundLedgerItem
+import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
+import com.babylon.wallet.android.utils.BiometricAuthenticationResult
+import com.babylon.wallet.android.utils.biometricAuthenticate
+import com.babylon.wallet.android.utils.formattedSpans
+import com.radixdlt.sargon.FactorSource
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import rdx.works.core.sargon.sample
+
+@Composable
+fun GetSignaturesDialog(
+    modifier: Modifier = Modifier,
+    viewModel: GetSignaturesViewModel,
+    onDismiss: () -> Unit
+) {
+    val state by viewModel.state.collectAsState()
+    val context = LocalContext.current
+
+    BackHandler {
+        viewModel.onUserDismiss()
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.oneOffEvent.collect { event ->
+            when (event) {
+                is GetSignaturesViewModel.Event.RequestBiometricToAccessDeviceFactorSource -> {
+                    context.biometricAuthenticate { biometricAuthenticationResult ->
+                        when (biometricAuthenticationResult) {
+                            BiometricAuthenticationResult.Succeeded -> viewModel.collectSignaturesForDeviceFactorSource(
+                                deviceFactorSource = event.deviceFactorSource,
+                                signers = event.signers,
+                                signRequest = event.signRequest
+                            )
+                            BiometricAuthenticationResult.Error -> { /* do nothing */ }
+                            BiometricAuthenticationResult.Failed -> { /* do nothing */ }
+                        }
+                    }
+                }
+
+                GetSignaturesViewModel.Event.AccessingFactorSourceCompleted -> onDismiss()
+                GetSignaturesViewModel.Event.UserDismissed -> onDismiss()
+            }
+        }
+    }
+
+    GetSignaturesBottomSheetContent(
+        modifier = modifier,
+        showContentForFactorSource = state.showContentForFactorSource,
+        onDismiss = viewModel::onUserDismiss,
+        onRetryClick = viewModel::onRetryClick
+    )
+}
+
+@Composable
+private fun GetSignaturesBottomSheetContent(
+    modifier: Modifier = Modifier,
+    showContentForFactorSource: GetSignaturesViewModel.State.ShowContentForFactorSource,
+    onDismiss: () -> Unit,
+    onRetryClick: () -> Unit
+) {
+    BottomSheetDialogWrapper(
+        modifier = modifier,
+        onDismiss = {
+            onDismiss()
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = RadixTheme.dimensions.paddingXLarge)
+                .background(RadixTheme.colors.defaultBackground),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(Modifier.height(40.dp))
+            Icon(
+                modifier = Modifier.size(80.dp),
+                painter = painterResource(
+                    id = com.babylon.wallet.android.designsystem.R.drawable.ic_security_key
+                ),
+                contentDescription = null,
+                tint = RadixTheme.colors.gray3
+            )
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+            Text(
+                style = RadixTheme.typography.title,
+                text = stringResource(id = R.string.factorSourceActions_signature_title)
+            )
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+            when (showContentForFactorSource) {
+                is GetSignaturesViewModel.State.ShowContentForFactorSource.Device -> {
+                    Text(
+                        style = RadixTheme.typography.body1Regular,
+                        text = stringResource(id = R.string.factorSourceActions_device_messageSignature)
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
+                    RadixTextButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = stringResource(R.string.common_retry),
+                        onClick = onRetryClick
+                    )
+                }
+
+                is GetSignaturesViewModel.State.ShowContentForFactorSource.Ledger -> {
+                    Text(
+                        text = stringResource(id = R.string.factorSourceActions_ledger_messageSignature)
+                            .formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
+                        style = RadixTheme.typography.body1Regular,
+                        color = RadixTheme.colors.gray1,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXLarge))
+                    RoundLedgerItem(ledgerName = showContentForFactorSource.ledgerFactorSource.value.hint.name)
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
+                    RadixTextButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = stringResource(R.string.common_retry),
+                        onClick = onRetryClick
+                    )
+                }
+
+                GetSignaturesViewModel.State.ShowContentForFactorSource.None -> { /* nothing */ }
+            }
+            Spacer(Modifier.height(120.dp))
+        }
+    }
+}
+
+@UsesSampleValues
+@Preview(showBackground = false)
+@Composable
+fun DerivePublicKeyDialogDevicePreview() {
+    RadixWalletTheme {
+        GetSignaturesBottomSheetContent(
+            showContentForFactorSource = GetSignaturesViewModel.State.ShowContentForFactorSource.Device(
+                deviceFactorSource = FactorSource.Device.sample()
+            ),
+            onDismiss = {},
+            onRetryClick = {}
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview(showBackground = false)
+@Composable
+fun DerivePublicKeyDialogLedgerPreview() {
+    RadixWalletTheme {
+        GetSignaturesBottomSheetContent(
+            showContentForFactorSource = GetSignaturesViewModel.State.ShowContentForFactorSource.Ledger(
+                ledgerFactorSource = FactorSource.Ledger.sample()
+            ),
+            onDismiss = {},
+            onRetryClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
@@ -29,6 +29,7 @@ import com.babylon.wallet.android.designsystem.composable.RadixTextButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.accessfactorsources.composables.RoundLedgerItem
+import com.babylon.wallet.android.presentation.accessfactorsources.signatures.GetSignaturesViewModel.State
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
@@ -53,14 +54,10 @@ fun GetSignaturesDialog(
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.collect { event ->
             when (event) {
-                is GetSignaturesViewModel.Event.RequestBiometricToAccessDeviceFactorSource -> {
+                is GetSignaturesViewModel.Event.RequestBiometricToAccessDeviceFactorSources -> {
                     context.biometricAuthenticate { biometricAuthenticationResult ->
                         when (biometricAuthenticationResult) {
-                            BiometricAuthenticationResult.Succeeded -> viewModel.collectSignaturesForDeviceFactorSource(
-                                deviceFactorSource = event.deviceFactorSource,
-                                signers = event.signers,
-                                signRequest = event.signRequest
-                            )
+                            BiometricAuthenticationResult.Succeeded -> viewModel.collectSignaturesForDeviceFactorSource()
                             BiometricAuthenticationResult.Error -> { /* do nothing */ }
                             BiometricAuthenticationResult.Failed -> { /* do nothing */ }
                         }
@@ -84,7 +81,7 @@ fun GetSignaturesDialog(
 @Composable
 private fun GetSignaturesBottomSheetContent(
     modifier: Modifier = Modifier,
-    showContentForFactorSource: GetSignaturesViewModel.State.ShowContentForFactorSource,
+    showContentForFactorSource: State.ShowContentForFactorSource,
     onDismiss: () -> Unit,
     onRetryClick: () -> Unit
 ) {
@@ -116,14 +113,14 @@ private fun GetSignaturesBottomSheetContent(
             )
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
             when (showContentForFactorSource) {
-                is GetSignaturesViewModel.State.ShowContentForFactorSource.Device -> {
+                is State.ShowContentForFactorSource.Device -> {
                     Text(
                         style = RadixTheme.typography.body1Regular,
                         text = stringResource(id = R.string.factorSourceActions_device_messageSignature)
                     )
                 }
 
-                is GetSignaturesViewModel.State.ShowContentForFactorSource.Ledger -> {
+                is State.ShowContentForFactorSource.Ledger -> {
                     Text(
                         text = stringResource(id = R.string.factorSourceActions_ledger_messageSignature)
                             .formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
@@ -135,7 +132,7 @@ private fun GetSignaturesBottomSheetContent(
                     RoundLedgerItem(ledgerName = showContentForFactorSource.ledgerFactorSource.value.hint.name)
                 }
 
-                GetSignaturesViewModel.State.ShowContentForFactorSource.None -> { /* nothing */ }
+                State.ShowContentForFactorSource.None -> { /* nothing */ }
             }
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
             RadixTextButton(
@@ -153,9 +150,7 @@ private fun GetSignaturesBottomSheetContent(
 fun DerivePublicKeyDialogDevicePreview() {
     RadixWalletTheme {
         GetSignaturesBottomSheetContent(
-            showContentForFactorSource = GetSignaturesViewModel.State.ShowContentForFactorSource.Device(
-                deviceFactorSource = FactorSource.Device.sample()
-            ),
+            showContentForFactorSource = State.ShowContentForFactorSource.Device,
             onDismiss = {},
             onRetryClick = {}
         )
@@ -168,7 +163,7 @@ fun DerivePublicKeyDialogDevicePreview() {
 fun DerivePublicKeyDialogLedgerPreview() {
     RadixWalletTheme {
         GetSignaturesBottomSheetContent(
-            showContentForFactorSource = GetSignaturesViewModel.State.ShowContentForFactorSource.Ledger(
+            showContentForFactorSource = State.ShowContentForFactorSource.Ledger(
                 ledgerFactorSource = FactorSource.Ledger.sample()
             ),
             onDismiss = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesNavGraph.kt
@@ -17,7 +17,10 @@ fun NavGraphBuilder.getSignatures(
 ) {
     dialog(
         route = ROUTE_GET_SIGNATURES,
-        dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
+        dialogProperties = DialogProperties(
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false
+        )
     ) {
         GetSignaturesDialog(
             viewModel = hiltViewModel(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesNavGraph.kt
@@ -6,15 +6,17 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.dialog
 
+private const val ROUTE_GET_SIGNATURES = "get_signatures_bottom_sheet"
+
 fun NavController.getSignatures() {
-    navigate("get_signatures_bottom_sheet")
+    navigate(ROUTE_GET_SIGNATURES)
 }
 
 fun NavGraphBuilder.getSignatures(
     onDismiss: () -> Unit
 ) {
     dialog(
-        route = "get_signatures_bottom_sheet",
+        route = ROUTE_GET_SIGNATURES,
         dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
         GetSignaturesDialog(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesNavGraph.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesNavGraph.kt
@@ -1,0 +1,25 @@
+package com.babylon.wallet.android.presentation.accessfactorsources.signatures
+
+import androidx.compose.ui.window.DialogProperties
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.dialog
+
+fun NavController.getSignatures() {
+    navigate("get_signatures_bottom_sheet")
+}
+
+fun NavGraphBuilder.getSignatures(
+    onDismiss: () -> Unit
+) {
+    dialog(
+        route = "get_signatures_bottom_sheet",
+        dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        GetSignaturesDialog(
+            viewModel = hiltViewModel(),
+            onDismiss = onDismiss
+        )
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesViewModel.kt
@@ -1,0 +1,261 @@
+package com.babylon.wallet.android.presentation.accessfactorsources.signatures
+
+import androidx.lifecycle.viewModelScope
+import com.babylon.wallet.android.di.coroutines.DefaultDispatcher
+import com.babylon.wallet.android.domain.RadixWalletException
+import com.babylon.wallet.android.domain.usecases.transaction.SignRequest
+import com.babylon.wallet.android.domain.usecases.transaction.SignWithDeviceFactorSourceUseCase
+import com.babylon.wallet.android.domain.usecases.transaction.SignWithLedgerFactorSourceUseCase
+import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesInput
+import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesOutput
+import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesUiProxy
+import com.babylon.wallet.android.presentation.common.OneOffEvent
+import com.babylon.wallet.android.presentation.common.OneOffEventHandler
+import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
+import com.babylon.wallet.android.presentation.common.StateViewModel
+import com.babylon.wallet.android.presentation.common.UiState
+import com.radixdlt.sargon.EntitySecurityState
+import com.radixdlt.sargon.FactorSource
+import com.radixdlt.sargon.FactorSourceKind
+import com.radixdlt.sargon.SignatureWithPublicKey
+import com.radixdlt.sargon.extensions.ProfileEntity
+import com.radixdlt.sargon.extensions.asGeneral
+import com.radixdlt.sargon.extensions.kind
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import rdx.works.core.sargon.factorSourceById
+import rdx.works.profile.domain.GetProfileUseCase
+import javax.inject.Inject
+
+@HiltViewModel
+class GetSignaturesViewModel @Inject constructor(
+    private val accessFactorSourcesUiProxy: AccessFactorSourcesUiProxy,
+    private val signWithDeviceFactorSourceUseCase: SignWithDeviceFactorSourceUseCase,
+    private val signWithLedgerFactorSourceUseCase: SignWithLedgerFactorSourceUseCase,
+    private val getProfileUseCase: GetProfileUseCase,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher
+) : StateViewModel<GetSignaturesViewModel.State>(),
+    OneOffEventHandler<GetSignaturesViewModel.Event> by OneOffEventHandlerImpl() {
+
+    // list to keep signatures from all factor sources. This will be returned as output once all signers are done.
+    private val signaturesWithPublicKeys = mutableListOf<SignatureWithPublicKey>()
+
+    private val isSigningWithDeviceInProgress = MutableStateFlow(false)
+    private val isSigningWithLedgerInProgress = MutableStateFlow(false)
+
+    private var collectSignaturesWithDeviceJob: Job? = null
+    private var collectSignaturesWithLedgerJob: Job? = null
+
+    override fun initialState(): State = State()
+
+    init {
+        viewModelScope.launch {
+            val input = accessFactorSourcesUiProxy.getInput() as AccessFactorSourcesInput.ToGetSignatures
+            val signersPerFactorSource = getSigningEntitiesByFactorSource(input.signers)
+
+            signersPerFactorSource.forEach { (factorSource, signers) ->
+                when (factorSource) {
+                    is FactorSource.Device -> {
+                        _state.update { state ->
+                            state.copy(
+                                showContentForFactorSource = State.ShowContentForFactorSource.Device(deviceFactorSource = factorSource)
+                            )
+                        }
+                        isSigningWithDeviceInProgress.emit(true)
+                        sendEvent(
+                            event = Event.RequestBiometricToAccessDeviceFactorSource(
+                                deviceFactorSource = factorSource,
+                                signers = signers,
+                                signRequest = input.signRequest
+                            )
+                        )
+                        // wait until the signing with device is complete
+                        isSigningWithDeviceInProgress.takeWhile { isInProgress -> isInProgress }.collect()
+                    }
+
+                    is FactorSource.Ledger -> {
+                        _state.update { state ->
+                            state.copy(
+                                showContentForFactorSource = State.ShowContentForFactorSource.Ledger(ledgerFactorSource = factorSource)
+                            )
+                        }
+                        isSigningWithLedgerInProgress.emit(true)
+                        collectSignaturesForLedgerFactorSource(
+                            ledgerFactorSource = factorSource,
+                            signers = signers,
+                            signRequest = input.signRequest
+                        )
+                        // wait until the signing with ledger is complete
+                        isSigningWithLedgerInProgress.takeWhile { isInProgress -> isInProgress }.collect()
+                    }
+                }
+            }
+
+            accessFactorSourcesUiProxy.setOutput(output = AccessFactorSourcesOutput.Signatures(signaturesWithPublicKeys))
+            sendEvent(event = Event.AccessingFactorSourceCompleted)
+        }
+    }
+
+    fun onRetryClick() {
+        viewModelScope.launch {
+            val input = accessFactorSourcesUiProxy.getInput() as AccessFactorSourcesInput.ToGetSignatures
+            val signersPerFactorSource = getSigningEntitiesByFactorSource(input.signers)
+
+            when (val content = state.value.showContentForFactorSource) {
+                is State.ShowContentForFactorSource.Device -> {
+                    val signersWithDeviceFactorSource =
+                        signersPerFactorSource[content.deviceFactorSource] ?: return@launch
+                    sendEvent(
+                        event = Event.RequestBiometricToAccessDeviceFactorSource(
+                            deviceFactorSource = content.deviceFactorSource,
+                            signers = signersWithDeviceFactorSource,
+                            signRequest = input.signRequest
+                        )
+                    )
+                }
+
+                is State.ShowContentForFactorSource.Ledger -> {
+                    val signersWithLedgerFactorSource =
+                        signersPerFactorSource[content.ledgerFactorSource] ?: return@launch
+                    collectSignaturesForLedgerFactorSource(
+                        ledgerFactorSource = content.ledgerFactorSource,
+                        signers = signersWithLedgerFactorSource,
+                        signRequest = input.signRequest
+
+                    )
+                }
+
+                State.ShowContentForFactorSource.None -> {}
+            }
+        }
+    }
+
+    fun onUserDismiss() {
+        viewModelScope.launch {
+            accessFactorSourcesUiProxy.setOutput(
+                output = AccessFactorSourcesOutput.Failure(RadixWalletException.DappRequestException.RejectedByUser)
+            )
+            sendEvent(Event.UserDismissed)
+        }
+    }
+
+    fun collectSignaturesForDeviceFactorSource(
+        deviceFactorSource: FactorSource.Device,
+        signers: List<ProfileEntity>,
+        signRequest: SignRequest
+    ) {
+        collectSignaturesWithDeviceJob?.cancel()
+        collectSignaturesWithDeviceJob = viewModelScope.launch {
+            signWithDeviceFactorSourceUseCase(
+                deviceFactorSource = deviceFactorSource,
+                signers = signers,
+                signRequest = signRequest
+            ).onSuccess { signatures ->
+                signaturesWithPublicKeys.addAll(signatures)
+            }.onFailure {
+                accessFactorSourcesUiProxy.setOutput(
+                    AccessFactorSourcesOutput.Failure(error = it)
+                )
+            }.also {
+                isSigningWithDeviceInProgress.emit(false)
+            }
+        }
+    }
+
+    private suspend fun collectSignaturesForLedgerFactorSource(
+        ledgerFactorSource: FactorSource.Ledger,
+        signers: List<ProfileEntity>,
+        signRequest: SignRequest
+    ) {
+        collectSignaturesWithLedgerJob?.cancel()
+        collectSignaturesWithLedgerJob = viewModelScope.launch {
+            signWithLedgerFactorSourceUseCase(
+                ledgerFactorSource = ledgerFactorSource,
+                signers = signers,
+                signRequest = signRequest
+            ).onSuccess { signatures ->
+                signaturesWithPublicKeys.addAll(signatures)
+            }.onFailure {
+                accessFactorSourcesUiProxy.setOutput(
+                    AccessFactorSourcesOutput.Failure(error = it)
+                )
+            }.also {
+                isSigningWithLedgerInProgress.emit(false)
+            }
+        }
+    }
+
+    @Suppress("UnsafeCallOnNullableType")
+    private suspend fun getSigningEntitiesByFactorSource(
+        signers: List<ProfileEntity>
+    ): Map<FactorSource, List<ProfileEntity>> = withContext(defaultDispatcher) {
+        val result = mutableMapOf<FactorSource, List<ProfileEntity>>()
+        val profile = getProfileUseCase()
+
+        signers.forEach { signer ->
+            when (val securityState = signer.securityState) {
+                is EntitySecurityState.Unsecured -> {
+                    val factorSourceId = securityState.value.transactionSigning.factorSourceId.asGeneral()
+                    val factorSource = requireNotNull(profile.factorSourceById(factorSourceId))
+
+                    if (factorSource.kind != FactorSourceKind.TRUSTED_CONTACT) { // trusted contact cannot sign!
+                        if (result[factorSource] != null) {
+                            result[factorSource] = result[factorSource].orEmpty() + listOf(signer)
+                        } else {
+                            result[factorSource] = listOf(signer)
+                        }
+                    }
+                }
+            }
+        }
+
+        result.keys
+            .sortedBy { factorSource ->
+                factorSource.kind.signingOrder()
+            }.associateWith { factorSource ->
+                result[factorSource]!!
+            }
+    }
+
+    private fun FactorSourceKind.signingOrder(): Int {
+        return when (this) {
+            FactorSourceKind.LEDGER_HQ_HARDWARE_WALLET -> 1
+            FactorSourceKind.DEVICE -> 0 // DEVICE should always go first since we authorize KeyStore encryption key for 30s
+            else -> Int.MAX_VALUE // it doesn't matter because we add only the ledger or device factor sources
+        }
+    }
+
+    data class State(
+        val showContentForFactorSource: ShowContentForFactorSource = ShowContentForFactorSource.None
+    ) : UiState {
+
+        sealed interface ShowContentForFactorSource {
+
+            data object None : ShowContentForFactorSource
+
+            data class Device(val deviceFactorSource: FactorSource.Device) : ShowContentForFactorSource
+
+            data class Ledger(val ledgerFactorSource: FactorSource.Ledger) : ShowContentForFactorSource
+        }
+    }
+
+    sealed interface Event : OneOffEvent {
+
+        data class RequestBiometricToAccessDeviceFactorSource(
+            val deviceFactorSource: FactorSource.Device,
+            val signers: List<ProfileEntity>,
+            val signRequest: SignRequest
+        ) : Event
+
+        data object AccessingFactorSourceCompleted : Event
+
+        data object UserDismissed : Event
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesViewModel.kt
@@ -224,10 +224,10 @@ class GetSignaturesViewModel @Inject constructor(
             }
     }
 
-    private fun FactorSourceKind.signingOrder(): Int {
+    private fun FactorSourceKind.signingOrder(): Int { // based on difficulty - most "challenging" factor comes first
         return when (this) {
-            FactorSourceKind.LEDGER_HQ_HARDWARE_WALLET -> 1
-            FactorSourceKind.DEVICE -> 0 // DEVICE should always go first since we authorize KeyStore encryption key for 30s
+            FactorSourceKind.LEDGER_HQ_HARDWARE_WALLET -> 0
+            FactorSourceKind.DEVICE -> 1
             else -> Int.MAX_VALUE // it doesn't matter because we add only the ledger or device factor sources
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesViewModel.kt
@@ -59,10 +59,12 @@ class GetSignaturesViewModel @Inject constructor(
             signersPerFactorSource.forEach { (factorSource, entities) ->
                 when (factorSource) {
                     is FactorSource.Device -> {
-                        val deviceRequest = (requests
-                            .find { request ->
-                                request is DeviceRequest
-                            } as? DeviceRequest) ?: DeviceRequest(mutableMapOf()).also {
+                        val deviceRequest = (
+                            requests
+                                .find { request ->
+                                    request is DeviceRequest
+                                } as? DeviceRequest
+                            ) ?: DeviceRequest(mutableMapOf()).also {
                             requests.add(it)
                         }
 
@@ -70,10 +72,12 @@ class GetSignaturesViewModel @Inject constructor(
                     }
 
                     is FactorSource.Ledger -> {
-                        requests.add(LedgerRequest(
-                            factorSource = factorSource,
-                            entities = entities
-                        ))
+                        requests.add(
+                            LedgerRequest(
+                                factorSource = factorSource,
+                                entities = entities
+                            )
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountViewModel.kt
@@ -138,10 +138,10 @@ class CreateAccountViewModel @Inject constructor(
 
             accessFactorSourcesProxy.getPublicKeyAndDerivationPathForFactorSource(
                 accessFactorSourcesInput = AccessFactorSourcesInput.ToDerivePublicKey(
+                    entityKind = EntityKind.ACCOUNT,
                     forNetworkId = args.networkIdToSwitch ?: getProfileUseCase().currentGateway.network.id,
                     factorSource = selectedFactorSource,
-                    isBiometricsProvided = isFirstAccount,
-                    entityKind = EntityKind.ACCOUNT
+                    isBiometricsProvided = isFirstAccount
                 )
             ).onSuccess {
                 handleAccountCreation { nameOfAccount ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -54,8 +53,6 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SimpleAccountCard
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.composables.WarningButton
-import com.babylon.wallet.android.utils.BiometricAuthenticationResult
-import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.DepositRule
@@ -297,8 +294,6 @@ private fun AccountSettingsContent(
             }
             item {
                 if (faucetState is FaucetState.Available) {
-                    val context = LocalContext.current
-
                     Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
 
                     RadixSecondaryButton(
@@ -310,13 +305,7 @@ private fun AccountSettingsContent(
                                 top = RadixTheme.dimensions.paddingDefault
                             ),
                         text = stringResource(R.string.accountSettings_getXrdTestTokens),
-                        onClick = {
-                            context.biometricAuthenticate { result ->
-                                if (result == BiometricAuthenticationResult.Succeeded) {
-                                    onGetFreeXrdClick()
-                                }
-                            }
-                        },
+                        onClick = onGetFreeXrdClick,
                         isLoading = isXrdLoading,
                         enabled = !isXrdLoading && faucetState.isEnabled
                     )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -13,6 +13,7 @@ import androidx.navigation.navArgument
 import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.presentation.accessfactorsources.deriveaccounts.deriveAccounts
 import com.babylon.wallet.android.presentation.accessfactorsources.derivepublickey.derivePublicKeyDialog
+import com.babylon.wallet.android.presentation.accessfactorsources.signatures.getSignatures
 import com.babylon.wallet.android.presentation.account.account
 import com.babylon.wallet.android.presentation.account.createaccount.ROUTE_CREATE_ACCOUNT
 import com.babylon.wallet.android.presentation.account.createaccount.confirmation.CreateAccountRequestSource
@@ -267,6 +268,11 @@ fun NavigationHost(
             }
         )
         deriveAccounts(
+            onDismiss = {
+                navController.popBackStack()
+            }
+        )
+        getSignatures(
             onDismiss = {
                 navController.popBackStack()
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaViewModel.kt
@@ -68,10 +68,10 @@ class CreatePersonaViewModel @Inject constructor(
             val factorSource = getProfileUseCase().mainBabylonFactorSource ?: return@launch
             accessFactorSourcesProxy.getPublicKeyAndDerivationPathForFactorSource(
                 accessFactorSourcesInput = AccessFactorSourcesInput.ToDerivePublicKey(
+                    entityKind = EntityKind.PERSONA,
                     forNetworkId = getProfileUseCase().currentGateway.network.id,
                     factorSource = factorSource,
-                    isBiometricsProvided = false,
-                    entityKind = EntityKind.PERSONA
+                    isBiometricsProvided = false
                 )
             ).mapCatching { hdPublicKey ->
                 createPersonaUseCase(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -17,7 +16,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -27,20 +25,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.R
-import com.babylon.wallet.android.data.transaction.InteractionState
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.model.IncomingMessage
 import com.babylon.wallet.android.domain.model.TransferableAsset
-import com.babylon.wallet.android.domain.userFriendlyMessage
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
 import com.babylon.wallet.android.presentation.settings.approveddapps.dappdetail.UnknownAddressesSheetContent
-import com.babylon.wallet.android.presentation.status.signing.FactorSourceInteractionBottomDialog
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel.State
 import com.babylon.wallet.android.presentation.transaction.composables.AccountDepositSettingsTypeContent
 import com.babylon.wallet.android.presentation.transaction.composables.FeesSheet
@@ -60,7 +54,6 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.ReceiptEdge
 import com.babylon.wallet.android.presentation.ui.composables.SlideToSignButton
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
-import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.Address
 import com.radixdlt.sargon.NetworkId
@@ -86,15 +79,19 @@ fun TransactionReviewScreen(
     onDAppClick: (DApp) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.oneOffEvent.collect { event ->
+            when (event) {
+                Event.Dismiss -> onDismiss()
+            }
+        }
+    }
+
     TransactionPreviewContent(
         onBackClick = viewModel::onBackClick,
         state = state,
-        onApproveTransaction = {
-            viewModel.approveTransaction(deviceBiometricAuthenticationProvider = {
-                context.biometricAuthenticateSuspend()
-            })
-        },
+        onApproveTransaction = viewModel::onApproveTransaction,
         onRawManifestToggle = viewModel::onRawManifestToggle,
         onMessageShown = viewModel::onMessageShown,
         modifier = modifier,
@@ -119,34 +116,6 @@ fun TransactionReviewScreen(
         dismissTransactionErrorDialog = viewModel::dismissTerminalErrorDialog,
         onAcknowledgeRawTransactionWarning = viewModel::onAcknowledgeRawTransactionWarning
     )
-
-    state.interactionState?.let {
-        when (it) {
-            is InteractionState.Ledger.Error -> {
-                BasicPromptAlertDialog(
-                    finish = { viewModel.onCancelSigningClick() },
-                    message = {
-                        Text(text = it.failure.userFriendlyMessage())
-                    },
-                    confirmText = stringResource(id = R.string.common_ok),
-                    dismissText = null
-                )
-            }
-
-            else -> FactorSourceInteractionBottomDialog(
-                modifier = Modifier.fillMaxHeight(0.8f),
-                onDismissDialogClick = viewModel::onBackClick,
-                interactionState = it
-            )
-        }
-    }
-    LaunchedEffect(Unit) {
-        viewModel.oneOffEvent.collect { event ->
-            when (event) {
-                Event.Dismiss -> onDismiss()
-            }
-        }
-    }
 }
 
 @Suppress("CyclomaticComplexMethod")

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -3,13 +3,11 @@ package com.babylon.wallet.android.presentation.transaction
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
-import com.babylon.wallet.android.data.transaction.InteractionState
 import com.babylon.wallet.android.data.transaction.model.TransactionFeePayers
 import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.model.IncomingMessage
 import com.babylon.wallet.android.domain.model.TransferableAsset
 import com.babylon.wallet.android.domain.usecases.GetDAppsUseCase
-import com.babylon.wallet.android.domain.usecases.SignTransactionUseCase
 import com.babylon.wallet.android.presentation.common.OneOffEvent
 import com.babylon.wallet.android.presentation.common.OneOffEventHandler
 import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
@@ -52,7 +50,6 @@ import javax.inject.Inject
 @HiltViewModel
 class TransactionReviewViewModel @Inject constructor(
     private val appEventBus: AppEventBus,
-    private val signTransactionUseCase: SignTransactionUseCase,
     private val analysis: TransactionAnalysisDelegate,
     private val guarantees: TransactionGuaranteesDelegate,
     private val fees: TransactionFeesDelegate,
@@ -77,6 +74,22 @@ class TransactionReviewViewModel @Inject constructor(
         submit(scope = viewModelScope, state = _state)
         submit.oneOffEventHandler = this
 
+        observeDeferredRequests()
+        processIncomingRequest()
+    }
+
+    private fun observeDeferredRequests() {
+        viewModelScope.launch {
+            appEventBus.events.filterIsInstance<AppEvent.DeferRequestHandling>().collect {
+                if (it.interactionId == args.interactionId) {
+                    sendEvent(Event.Dismiss)
+                    incomingRequestRepository.requestDeferred(args.interactionId)
+                }
+            }
+        }
+    }
+
+    private fun processIncomingRequest() {
         val request = incomingRequestRepository.getRequest(args.interactionId) as? IncomingMessage.IncomingRequest.TransactionRequest
         if (request == null) {
             viewModelScope.launch {
@@ -84,13 +97,6 @@ class TransactionReviewViewModel @Inject constructor(
             }
         } else {
             _state.update { it.copy(request = request) }
-            viewModelScope.launch {
-                signTransactionUseCase.signingState.collect { signingState ->
-                    _state.update { state ->
-                        state.copy(interactionState = signingState)
-                    }
-                }
-            }
             viewModelScope.launch {
                 analysis.analyse()
             }
@@ -103,14 +109,6 @@ class TransactionReviewViewModel @Inject constructor(
                 }
             }
         }
-        viewModelScope.launch {
-            appEventBus.events.filterIsInstance<AppEvent.DeferRequestHandling>().collect {
-                if (it.interactionId == args.interactionId) {
-                    sendEvent(Event.Dismiss)
-                    incomingRequestRepository.requestDeferred(args.interactionId)
-                }
-            }
-        }
     }
 
     fun onBackClick() {
@@ -118,10 +116,7 @@ class TransactionReviewViewModel @Inject constructor(
             _state.update { it.copy(sheetState = State.Sheet.None) }
         } else {
             viewModelScope.launch {
-                submit.onDismiss(
-                    signTransactionUseCase = signTransactionUseCase,
-                    exception = RadixWalletException.DappRequestException.RejectedByUser
-                )
+                submit.onDismiss(exception = RadixWalletException.DappRequestException.RejectedByUser)
             }
         }
     }
@@ -134,12 +129,7 @@ class TransactionReviewViewModel @Inject constructor(
         _state.update { it.copy(isRawManifestVisible = !it.isRawManifestVisible) }
     }
 
-    fun approveTransaction(deviceBiometricAuthenticationProvider: suspend () -> Boolean) {
-        submit.onSubmit(
-            signTransactionUseCase = signTransactionUseCase,
-            deviceBiometricAuthenticationProvider = deviceBiometricAuthenticationProvider
-        )
-    }
+    fun onApproveTransaction() = submit.onSubmit()
 
     fun promptForGuaranteesClick() = guarantees.onEdit()
 
@@ -158,14 +148,8 @@ class TransactionReviewViewModel @Inject constructor(
         _state.update { it.copy(sheetState = State.Sheet.None) }
     }
 
-    fun onCustomizeClick() {
-        viewModelScope.launch {
-            fees.onCustomizeClick()
-        }
-    }
-
-    fun onCancelSigningClick() {
-        signTransactionUseCase.cancelSigning()
+    fun onCustomizeClick() = viewModelScope.launch {
+        fees.onCustomizeClick()
     }
 
     fun onChangeFeePayerClick() = fees.onChangeFeePayerClick()
@@ -248,8 +232,7 @@ class TransactionReviewViewModel @Inject constructor(
         val sheetState: Sheet = Sheet.None,
         private val latestFeesMode: Sheet.CustomizeFees.FeesMode = Sheet.CustomizeFees.FeesMode.Default,
         val error: TransactionErrorMessage? = null,
-        val ephemeralNotaryPrivateKey: Curve25519SecretKey = Curve25519SecretKey.secureRandom(),
-        val interactionState: InteractionState? = null
+        val ephemeralNotaryPrivateKey: Curve25519SecretKey = Curve25519SecretKey.secureRandom()
     ) : UiState {
 
         val requestNonNull: IncomingMessage.IncomingRequest.TransactionRequest

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -209,7 +209,6 @@ class TransactionReviewViewModel @Inject constructor(
 
     fun dismissTerminalErrorDialog() {
         _state.update { it.copy(error = null) }
-        onBackClick()
     }
 
     fun onAcknowledgeRawTransactionWarning() {

--- a/app/src/main/java/com/babylon/wallet/android/utils/AppEventBusImpl.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/AppEventBusImpl.kt
@@ -27,18 +27,26 @@ class AppEventBusImpl @Inject constructor() : AppEventBus {
 }
 
 sealed interface AppEvent {
+
     data object AppNotSecure : AppEvent
+
     data object RefreshAssetsNeeded : AppEvent
+
     data object RestoredMnemonic : AppEvent
+
     data object BabylonFactorSourceDoesNotExist : AppEvent
+
     data object NPSSurveySubmitted : AppEvent
 
     data object SecureFolderWarning : AppEvent
+
     data class DeferRequestHandling(val interactionId: String) : AppEvent
+
     data object ProcessBufferedDeepLinkRequest : AppEvent
 
     data class AddressDetails(val address: ActionableAddress) : AppEvent
 
+    // events that trigger the access factor sources bottom sheet dialogs
     sealed interface AccessFactorSources : AppEvent {
 
         data class SelectedLedgerDevice(val ledgerFactorSource: FactorSource.Ledger) : AccessFactorSources
@@ -46,6 +54,8 @@ sealed interface AppEvent {
         data object DerivePublicKey : AccessFactorSources
 
         data object DeriveAccounts : AccessFactorSources
+
+        data object GetSignatures : AccessFactorSources
     }
 
     sealed class Status : AppEvent {

--- a/app/src/test/java/com/babylon/wallet/android/mockdata/Profile.kt
+++ b/app/src/test/java/com/babylon/wallet/android/mockdata/Profile.kt
@@ -1,0 +1,35 @@
+package com.babylon.wallet.android.mockdata
+
+import com.radixdlt.sargon.Account
+import com.radixdlt.sargon.AppearanceId
+import com.radixdlt.sargon.DisplayName
+import com.radixdlt.sargon.FactorSource
+import com.radixdlt.sargon.HierarchicalDeterministicPublicKey
+import com.radixdlt.sargon.NetworkId
+import com.radixdlt.sargon.Profile
+import com.radixdlt.sargon.extensions.asGeneral
+import com.radixdlt.sargon.samples.sample
+import com.radixdlt.sargon.samples.sampleMainnet
+import rdx.works.core.sargon.addAccounts
+import rdx.works.core.sargon.asIdentifiable
+import rdx.works.core.sargon.changeGatewayToNetworkId
+import rdx.works.core.sargon.initBabylon
+import rdx.works.core.sargon.sample
+
+
+fun Profile.Companion.sampleWithLedgerAccount(): Profile = with(FactorSource.Ledger.sample()) {
+    Profile.sample().let {
+        it
+            .changeGatewayToNetworkId(NetworkId.MAINNET)
+            .copy(factorSources = it.factorSources.asIdentifiable().append(this).asList())
+    }.let {
+        val newAccount = Account.initBabylon(
+            networkId = NetworkId.MAINNET,
+            displayName = DisplayName("My cool ledger"),
+            hdPublicKey = HierarchicalDeterministicPublicKey.sample(),
+            factorSourceId = value.id.asGeneral(),
+            customAppearanceId = AppearanceId(0u)
+        )
+        it.addAccounts(listOf(Account.sampleMainnet.bob, Account.sampleMainnet.alice, Account.sampleMainnet.carol, newAccount), NetworkId.MAINNET)
+    }
+}

--- a/app/src/test/java/com/babylon/wallet/android/mockdata/Profile.kt
+++ b/app/src/test/java/com/babylon/wallet/android/mockdata/Profile.kt
@@ -7,6 +7,7 @@ import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.HierarchicalDeterministicPublicKey
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.Profile
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.extensions.asGeneral
 import com.radixdlt.sargon.samples.sample
 import com.radixdlt.sargon.samples.sampleMainnet
@@ -16,7 +17,7 @@ import rdx.works.core.sargon.changeGatewayToNetworkId
 import rdx.works.core.sargon.initBabylon
 import rdx.works.core.sargon.sample
 
-
+@UsesSampleValues
 fun Profile.Companion.sampleWithLedgerAccount(): Profile = with(FactorSource.Ledger.sample()) {
     Profile.sample().let {
         it

--- a/app/src/test/java/com/babylon/wallet/android/presentation/GetSignaturesViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/GetSignaturesViewModelTest.kt
@@ -79,7 +79,7 @@ class GetSignaturesViewModelTest : StateViewModelTest<GetSignaturesViewModel>() 
             assertNotNull(factorSourceKindOfSecondSigner)
             assertTrue(factorSourceKindOfSecondSigner == FactorSourceKind.DEVICE)
         }
-        }
+    }
 
     @Test
     fun `given device factor source, when signing, then show bottom sheet content for device factors`() = runTest {

--- a/app/src/test/java/com/babylon/wallet/android/presentation/GetSignaturesViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/GetSignaturesViewModelTest.kt
@@ -1,0 +1,226 @@
+package com.babylon.wallet.android.presentation
+
+import app.cash.turbine.test
+import com.babylon.wallet.android.data.dapp.model.LedgerErrorCode
+import com.babylon.wallet.android.domain.RadixWalletException
+import com.babylon.wallet.android.domain.usecases.transaction.SignRequest
+import com.babylon.wallet.android.domain.usecases.transaction.SignWithDeviceFactorSourceUseCase
+import com.babylon.wallet.android.domain.usecases.transaction.SignWithLedgerFactorSourceUseCase
+import com.babylon.wallet.android.fakes.FakeProfileRepository
+import com.babylon.wallet.android.mockdata.sampleWithLedgerAccount
+import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesIOHandler
+import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesInput
+import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesOutput
+import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesProxy
+import com.babylon.wallet.android.presentation.accessfactorsources.signatures.GetSignaturesViewModel
+import com.radixdlt.sargon.FactorSource
+import com.radixdlt.sargon.FactorSourceKind
+import com.radixdlt.sargon.MnemonicWithPassphrase
+import com.radixdlt.sargon.Profile
+import com.radixdlt.sargon.SignatureWithPublicKey
+import com.radixdlt.sargon.TransactionIntent
+import com.radixdlt.sargon.extensions.asProfileEntity
+import com.radixdlt.sargon.extensions.kind
+import com.radixdlt.sargon.samples.sample
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import rdx.works.core.sargon.allAccountsOnCurrentNetwork
+import rdx.works.core.sargon.deviceFactorSources
+import rdx.works.profile.domain.GetProfileUseCase
+
+private val sampleProfile = Profile.sampleWithLedgerAccount()
+
+private val signers = sampleProfile.allAccountsOnCurrentNetwork.map { it.asProfileEntity() }
+private val signRequest = SignRequest.SignTransactionRequest(
+    intent = TransactionIntent.sample()
+)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetSignaturesViewModelTest : StateViewModelTest<GetSignaturesViewModel>() {
+
+    private val signWithDeviceFactorSourceUseCaseMock = mockk<SignWithDeviceFactorSourceUseCase>()
+    private val signWithLedgerFactorSourceUseCaseMock = mockk<SignWithLedgerFactorSourceUseCase>()
+
+    private val accessFactorSourcesProxyFake = AccessFactorSourcesProxyFake()
+
+    override fun initVM(): GetSignaturesViewModel {
+        return GetSignaturesViewModel(
+            accessFactorSourcesIOHandler = accessFactorSourcesProxyFake,
+            signWithDeviceFactorSourceUseCase = signWithDeviceFactorSourceUseCaseMock,
+            signWithLedgerFactorSourceUseCase = signWithLedgerFactorSourceUseCaseMock,
+            getProfileUseCase = GetProfileUseCase(profileRepository = FakeProfileRepository(sampleProfile)),
+            defaultDispatcher = StandardTestDispatcher()
+        )
+    }
+
+    @Test
+    fun `given singers with ledger and device factor sources, the first factor source to sign is always ledger`() = runTest {
+        coEvery { signWithLedgerFactorSourceUseCaseMock(any(), any(), any()) } returns Result.success(listOf())
+        coEvery { signWithDeviceFactorSourceUseCaseMock(any(), any(), any()) } returns Result.success(listOf())
+
+        val viewModel = vm.value
+        advanceUntilIdle()
+        viewModel.state.test {
+            val state = expectMostRecentItem()
+            // here we get the second signer because the first one (ledger) has already signed! (because of the mock above)
+            // Therefore the second signer must be FactorSourceKind.DEVICE
+            val factorSourceKindOfSecondSigner = state.nextSigners?.first?.kind
+            assertNotNull(factorSourceKindOfSecondSigner)
+            assertTrue(factorSourceKindOfSecondSigner == FactorSourceKind.DEVICE)
+        }
+        }
+
+    @Test
+    fun `given device factor source, when signing, then show bottom sheet content for device factors`() = runTest {
+        coEvery { signWithLedgerFactorSourceUseCaseMock(any(), any(), any()) } returns Result.success(listOf())
+        coEvery { signWithDeviceFactorSourceUseCaseMock(any(), any(), any()) } returns Result.success(listOf())
+
+        val viewModel = vm.value
+        advanceUntilIdle()
+        viewModel.state.test {
+            val state = expectMostRecentItem()
+            val showContentForFactorSource = state.showContentForFactorSource
+            assertTrue(
+                showContentForFactorSource == GetSignaturesViewModel.State.ShowContentForFactorSource.Device(
+                    deviceFactorSource = sampleProfile.deviceFactorSources[0]
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `given ledger factor source to sign, when fails with generic error, then keep the bottom sheet for ledger open`() = runTest {
+        coEvery { signWithLedgerFactorSourceUseCaseMock(any(), any(), any()) } returns Result.failure(
+            exception = RadixWalletException.LedgerCommunicationException.FailedToSignTransaction(reason = LedgerErrorCode.Generic)
+        )
+
+        val viewModel = vm.value
+        advanceUntilIdle()
+        viewModel.state.test {
+            val state = expectMostRecentItem()
+
+            val factorSourceKindOfSecondSigner = state.nextSigners?.first?.kind
+            assertNotNull(factorSourceKindOfSecondSigner)
+            assertTrue(factorSourceKindOfSecondSigner == FactorSourceKind.LEDGER_HQ_HARDWARE_WALLET)
+
+            val showContentForFactorSource = state.showContentForFactorSource
+            assertTrue(
+                showContentForFactorSource == GetSignaturesViewModel.State.ShowContentForFactorSource.Ledger(
+                    ledgerFactorSource = sampleProfile.factorSources[2] as FactorSource.Ledger
+                )
+            )
+        }
+    }
+
+
+    // caller = the WalletSignatureGatherer of the SignTransactionUseCase -> TransactionSubmitDelegate -> TransactionReviewViewModel
+    @Test
+    fun `given ledger and device factor sources to sign, when signing successfully, then return successful output to the caller`() = runTest {
+        backgroundScope.launch(Dispatchers.Default)   { // TransactionReviewScreen needs to access factor sources to get signatures
+            val result = accessFactorSourcesProxyFake.getSignatures(AccessFactorSourcesInput.ToGetSignatures(signers, signRequest))
+            assertTrue(result.isSuccess)
+            assertTrue(result.getOrNull()!!.signaturesWithPublicKey.size == 2)
+        }
+
+        val signature = SignatureWithPublicKey.sample()
+        coEvery { signWithLedgerFactorSourceUseCaseMock(any(), any(), any()) } returns Result.success(listOf(signature))
+        coEvery { signWithDeviceFactorSourceUseCaseMock(any(), any(), any()) } returns Result.success(listOf(signature))
+
+        val viewModel = vm.value
+        advanceUntilIdle()
+
+        viewModel.collectSignaturesForDeviceFactorSource(
+            deviceFactorSource = sampleProfile.factorSources[0] as FactorSource.Device,
+            signers = signers,
+            signRequest = signRequest
+        )
+        advanceUntilIdle()
+        viewModel.state.test {
+            val state = expectMostRecentItem()
+            val isSignatureCollected = state.signaturesWithPublicKeys.contains(signature)
+            assertTrue(isSignatureCollected)
+        }
+    }
+
+    // caller = the WalletSignatureGatherer of the SignTransactionUseCase -> TransactionSubmitDelegate -> TransactionReviewViewModel
+    @Test
+    fun `given ledger and device factor sources to sign, when one of the factor source sign fails, then end signing process and return failure`() = runTest {
+        backgroundScope.launch(Dispatchers.Default)  { // TransactionReviewScreen needs to access factor sources to get signatures
+            val result = accessFactorSourcesProxyFake.getSignatures(AccessFactorSourcesInput.ToGetSignatures(signers, signRequest))
+            assertTrue(result.isFailure)
+        }
+
+        val signature = SignatureWithPublicKey.sample()
+        coEvery { signWithLedgerFactorSourceUseCaseMock(any(), any(), any()) } returns Result.success(listOf(signature))
+        coEvery { signWithDeviceFactorSourceUseCaseMock(any(), any(), any()) } returns Result.failure(exception = IllegalStateException("User has no fingers"))
+
+        val viewModel = vm.value
+        advanceUntilIdle()
+
+        viewModel.collectSignaturesForDeviceFactorSource(
+            deviceFactorSource = sampleProfile.factorSources[0] as FactorSource.Device,
+            signers = signers,
+            signRequest = signRequest
+        )
+        advanceUntilIdle()
+        viewModel.state.test {
+            val state = expectMostRecentItem()
+            val isSignatureCollected = state.signaturesWithPublicKeys.contains(signature)
+            assertTrue(isSignatureCollected)
+        }
+    }
+}
+
+
+class AccessFactorSourcesProxyFake : AccessFactorSourcesProxy, AccessFactorSourcesIOHandler {
+
+    private val _output = MutableSharedFlow<AccessFactorSourcesOutput>()
+
+    override suspend fun getPublicKeyAndDerivationPathForFactorSource(accessFactorSourcesInput: AccessFactorSourcesInput.ToDerivePublicKey): Result<AccessFactorSourcesOutput.HDPublicKey> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun reDeriveAccounts(accessFactorSourcesInput: AccessFactorSourcesInput.ToReDeriveAccounts): Result<AccessFactorSourcesOutput.DerivedAccountsWithNextDerivationPath> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getSignatures(accessFactorSourcesInput: AccessFactorSourcesInput.ToGetSignatures): Result<AccessFactorSourcesOutput.Signatures> {
+        val result = _output.first()
+        return if (result is AccessFactorSourcesOutput.Failure) {
+            Result.failure(result.error)
+        } else {
+            Result.success(result as AccessFactorSourcesOutput.Signatures)
+        }
+    }
+
+    override fun setTempMnemonicWithPassphrase(mnemonicWithPassphrase: MnemonicWithPassphrase) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getTempMnemonicWithPassphrase(): MnemonicWithPassphrase? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getInput(): AccessFactorSourcesInput {
+        return AccessFactorSourcesInput.ToGetSignatures(
+            signers = signers,
+            signRequest = signRequest
+        )
+    }
+
+    override suspend fun setOutput(output: AccessFactorSourcesOutput) {
+        _output.emit(output)
+    }
+
+}

--- a/app/src/test/java/com/babylon/wallet/android/presentation/GetSignaturesViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/GetSignaturesViewModelTest.kt
@@ -13,6 +13,7 @@ import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorS
 import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesOutput
 import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesProxy
 import com.babylon.wallet.android.presentation.accessfactorsources.signatures.GetSignaturesViewModel
+import com.babylon.wallet.android.presentation.accessfactorsources.signatures.GetSignaturesViewModel.State
 import com.radixdlt.sargon.FactorSource
 import com.radixdlt.sargon.FactorSourceKind
 import com.radixdlt.sargon.MnemonicWithPassphrase
@@ -75,7 +76,8 @@ class GetSignaturesViewModelTest : StateViewModelTest<GetSignaturesViewModel>() 
             val state = expectMostRecentItem()
             // here we get the second signer because the first one (ledger) has already signed! (because of the mock above)
             // Therefore the second signer must be FactorSourceKind.DEVICE
-            val factorSourceKindOfSecondSigner = state.nextSigners?.first?.kind
+            val nextRequest = state.nextRequest as? State.FactorSourceRequest.DeviceRequest
+            val factorSourceKindOfSecondSigner = nextRequest?.deviceFactorSources?.keys?.first()?.kind
             assertNotNull(factorSourceKindOfSecondSigner)
             assertTrue(factorSourceKindOfSecondSigner == FactorSourceKind.DEVICE)
         }
@@ -91,11 +93,7 @@ class GetSignaturesViewModelTest : StateViewModelTest<GetSignaturesViewModel>() 
         viewModel.state.test {
             val state = expectMostRecentItem()
             val showContentForFactorSource = state.showContentForFactorSource
-            assertTrue(
-                showContentForFactorSource == GetSignaturesViewModel.State.ShowContentForFactorSource.Device(
-                    deviceFactorSource = sampleProfile.deviceFactorSources[0]
-                )
-            )
+            assertTrue(showContentForFactorSource == State.ShowContentForFactorSource.Device)
         }
     }
 
@@ -110,13 +108,14 @@ class GetSignaturesViewModelTest : StateViewModelTest<GetSignaturesViewModel>() 
         viewModel.state.test {
             val state = expectMostRecentItem()
 
-            val factorSourceKindOfSecondSigner = state.nextSigners?.first?.kind
+            val nextRequest = state.nextRequest as? State.FactorSourceRequest.LedgerRequest
+            val factorSourceKindOfSecondSigner = nextRequest?.factorSource?.kind
             assertNotNull(factorSourceKindOfSecondSigner)
             assertTrue(factorSourceKindOfSecondSigner == FactorSourceKind.LEDGER_HQ_HARDWARE_WALLET)
 
             val showContentForFactorSource = state.showContentForFactorSource
             assertTrue(
-                showContentForFactorSource == GetSignaturesViewModel.State.ShowContentForFactorSource.Ledger(
+                showContentForFactorSource == State.ShowContentForFactorSource.Ledger(
                     ledgerFactorSource = sampleProfile.factorSources[2] as FactorSource.Ledger
                 )
             )
@@ -140,11 +139,7 @@ class GetSignaturesViewModelTest : StateViewModelTest<GetSignaturesViewModel>() 
         val viewModel = vm.value
         advanceUntilIdle()
 
-        viewModel.collectSignaturesForDeviceFactorSource(
-            deviceFactorSource = sampleProfile.factorSources[0] as FactorSource.Device,
-            signers = signers,
-            signRequest = signRequest
-        )
+        viewModel.collectSignaturesForDeviceFactorSource()
         advanceUntilIdle()
         viewModel.state.test {
             val state = expectMostRecentItem()
@@ -168,11 +163,7 @@ class GetSignaturesViewModelTest : StateViewModelTest<GetSignaturesViewModel>() 
         val viewModel = vm.value
         advanceUntilIdle()
 
-        viewModel.collectSignaturesForDeviceFactorSource(
-            deviceFactorSource = sampleProfile.factorSources[0] as FactorSource.Device,
-            signers = signers,
-            signRequest = signRequest
-        )
+        viewModel.collectSignaturesForDeviceFactorSource()
         advanceUntilIdle()
         viewModel.state.test {
             val state = expectMostRecentItem()

--- a/app/src/test/java/com/babylon/wallet/android/presentation/status/address/AddressDetailsDialogViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/status/address/AddressDetailsDialogViewModelTest.kt
@@ -9,25 +9,19 @@ import com.babylon.wallet.android.domain.usecases.VerifyAddressOnLedgerUseCase
 import com.babylon.wallet.android.domain.usecases.assets.GetPoolsUseCase
 import com.babylon.wallet.android.domain.usecases.assets.GetValidatorsUseCase
 import com.babylon.wallet.android.fakes.FakeProfileRepository
+import com.babylon.wallet.android.mockdata.sampleWithLedgerAccount
 import com.babylon.wallet.android.presentation.StateViewModelTest
 import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.ActionableAddress
-import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.Address
 import com.radixdlt.sargon.AddressFormat
-import com.radixdlt.sargon.AppearanceId
-import com.radixdlt.sargon.DisplayName
-import com.radixdlt.sargon.FactorSource
-import com.radixdlt.sargon.HierarchicalDeterministicPublicKey
 import com.radixdlt.sargon.IdentityAddress
 import com.radixdlt.sargon.IntentHash
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.NonEmptyMax64Bytes
 import com.radixdlt.sargon.NonFungibleGlobalId
 import com.radixdlt.sargon.NonFungibleLocalId
-import com.radixdlt.sargon.NonFungibleLocalIdString
 import com.radixdlt.sargon.Profile
-import com.radixdlt.sargon.extensions.asGeneral
 import com.radixdlt.sargon.extensions.formatted
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.string
@@ -52,12 +46,8 @@ import rdx.works.core.domain.resources.Validator
 import rdx.works.core.domain.resources.sampleMainnet
 import rdx.works.core.sargon.activeAccountsOnCurrentNetwork
 import rdx.works.core.sargon.activePersonasOnCurrentNetwork
-import rdx.works.core.sargon.addAccounts
-import rdx.works.core.sargon.asIdentifiable
 import rdx.works.core.sargon.changeGatewayToNetworkId
-import rdx.works.core.sargon.initBabylon
 import rdx.works.core.sargon.isLedgerAccount
-import rdx.works.core.sargon.sample
 import rdx.works.profile.domain.GetProfileUseCase
 import kotlin.random.Random
 
@@ -544,23 +534,6 @@ class AddressDetailsDialogViewModelTest : StateViewModelTest<AddressDetailsDialo
             isVisitableInDashboard = true
         )
         every { savedStateHandle.get<String>(ARG_ACTIONABLE_ADDRESS) } returns Json.encodeToString<ActionableAddress>(actionableAddress)
-    }
-
-    private fun Profile.Companion.sampleWithLedgerAccount(): Profile = with(FactorSource.Ledger.sample()) {
-        Profile.sample().let {
-            it
-                .changeGatewayToNetworkId(NetworkId.MAINNET)
-                .copy(factorSources = it.factorSources.asIdentifiable().append(this).asList())
-        }.let {
-            val newAccount = Account.initBabylon(
-                networkId = NetworkId.MAINNET,
-                displayName = DisplayName("Ledger"),
-                hdPublicKey = HierarchicalDeterministicPublicKey.sample(),
-                factorSourceId = value.id.asGeneral(),
-                customAppearanceId = AppearanceId(0u)
-            )
-            it.addAccounts(listOf(newAccount), NetworkId.MAINNET)
-        }
     }
 
 }

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTestExperimental.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTestExperimental.kt
@@ -39,7 +39,6 @@ import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -81,9 +80,7 @@ internal class TransactionReviewViewModelTestExperimental : StateViewModelTest<T
     private val respondToIncomingRequestUseCase = mockk<RespondToIncomingRequestUseCase>()
     private val appEventBus = AppEventBusImpl()
     private val exceptionMessageProvider = mockk<ExceptionMessageProvider>()
-    private val signTransactionUseCase = mockk<SignTransactionUseCase>().apply {
-        every { signingState } returns flowOf()
-    }
+    private val signTransactionUseCase = mockk<SignTransactionUseCase>()
     private val preferencesManager = mockk<PreferencesManager>()
 
     private val profileRepository = FakeProfileRepository(profile = testProfile)
@@ -123,7 +120,7 @@ internal class TransactionReviewViewModelTestExperimental : StateViewModelTest<T
             compiledNotarizedIntent = CompiledNotarizedIntent.sample(),
             endEpoch = 0u
         )
-        coEvery { signTransactionUseCase.sign(any(), any()) } returns Result.success(notarization)
+        coEvery { signTransactionUseCase(any()) } returns Result.success(notarization)
         coEvery { transactionRepository.submitTransaction(any()) } returns Result.success(TransactionSubmitResponse(duplicate = false))
 
 

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/vectors/TransactionReviewViewModelTestExtensions.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/vectors/TransactionReviewViewModelTestExtensions.kt
@@ -55,7 +55,6 @@ internal fun testViewModel(
     savedStateHandle: SavedStateHandle,
     testScope: TestScope
 ) = TransactionReviewViewModel(
-    signTransactionUseCase = signTransactionUseCase,
     analysis = TransactionAnalysisDelegate(
         previewTypeAnalyzer = PreviewTypeAnalyzer(
             generalTransferProcessor = GeneralTransferProcessor(
@@ -100,6 +99,7 @@ internal fun testViewModel(
     guarantees = TransactionGuaranteesDelegate(),
     fees = TransactionFeesDelegate(getProfileUseCase = GetProfileUseCase(profileRepository)),
     submit = TransactionSubmitDelegate(
+        signTransactionUseCase = signTransactionUseCase,
         respondToIncomingRequestUseCase = respondToIncomingRequestUseCase,
         getCurrentGatewayUseCase = GetCurrentGatewayUseCase(profileRepository),
         incomingRequestRepository = incomingRequestRepository,


### PR DESCRIPTION
## Description
This PR is a continuation of the Access Factor Sources refactor. The purpose of this refactor is to create a module that every time it accesses the factor sources:
- it can be called from different places e.g. when signing transaction or creating entity and it takes an input
- when it is called then a bottom sheet dialog is being presented as long as wallet accessing the factor sources
- when accessing is done, it returns the **minimum** output to the caller (for example a public key in case of creating an account, not the whole account!)

--input--> [access-factor-source-dialog] --output-->

This PR fixes the transaction signing process. In short:
- adds a new method in the file `AccessFactorSourcesProxyContract` to `getSignatures` when signing
- adds a new `GetSignaturesDialog` and its viewmodel that is shown to the user when signing a transaction
- the viewmodel gets as input a list of signers and returns list of signatures (to the `TransactionReviewScreen`)

-----

### AccessFactorSourcesProxyContract.kt
It's a file that contains two interfaces `AccessFactorSourcesProxy` and `AccessFactorSourcesUiProxy` and two models `AccessFactorSourcesInput` and `AccessFactorSourcesOutput` 
- `AccessFactorSourcesProxy`: used by clients (viewmodels or usecases) as constructor parameter to access factor sources. The methods of the interface receive an input `AccessFactorSourcesInput` and return an `AccessFactorSourcesOutput`
- `AccessFactorSourcesUiProxy` interface that works as a "proxy" between the caller and the viewmodel of the bottomsheet dialog. Let's say a more elegant (or complicated 🙂  ) wrapper of the `AppEventBus` but with a very specific purpose.

In simple words:
`CreateAccountViewModel` needs a public key in order to create an account. Then in the viewmodel we just call this **suspending** function 
```
val publicKey = accessFactorSourcesProxy.getPublicKeyAndDerivationPathForFactorSource(input = DeviceFactorSource)
```
This **suspending** function will trigger the bottom sheet dialog and when accessing is done it will return the output!
That's all. 

-------

### Recap
I am not super satisfied with this design but at least we have decoupled enough the accessing of factor sources by defining in a more clear way (AccessFactorSourcesProxyContract) the input and the output, and isolating the dialogs from the rest of the screens.
Any improvement (even just renamings) would be much appreciated.

## How to test

1. Sign transactions with one or two factor sources (device & ledger)
2. You must see the dialog as long as you signing (biometric prompt for device and sign with ledger for ledger)

## Video
https://github.com/radixdlt/babylon-wallet-android/assets/118305718/f126bc65-f1a4-4b5d-9abb-a78301101647


## PR submission checklist
- [X] I have tested transaction signing with all available factor sources
