### PR TITLE
Fix p2p links not being reconnected after wallet reset

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
@@ -94,7 +94,6 @@ class MainViewModel @Inject constructor(
                 else -> p2PLinksRepository.observeP2PLinks().drop(1)
             }
         }
-        .distinctUntilChanged()
         .map { p2pLinks ->
             Timber.d("found ${p2pLinks.size} p2p links")
             p2pLinks.asList().forEach { p2PLink ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.cancellable
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flatMapLatest


### PR DESCRIPTION
## Description
This PR fixes p2p links connection re-establishing after factory reset.


## How to test

1. Add a p2p link
2. Troubleshooting -> Factory reset
3. Create a new wallet or restore one
4. Make sure the p2p links are connected
