### PR TITLE
Implement ui changes for all QR code scanners

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -502,7 +502,7 @@ private fun ScanQrPage(
                 )
             }
             Text(
-                text = stringResource(id = R.string.importOlympiaAccounts_scanQR_instructions),
+                text = stringResource(id = R.string.scanQR_importOlympia_instructions),
                 style = RadixTheme.typography.body1Regular,
                 color = RadixTheme.colors.gray1,
                 overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
@@ -3,6 +3,7 @@ package com.babylon.wallet.android.presentation.transfer.accounts
 import android.Manifest
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -41,6 +42,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.PlatformImeOptions
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixPrimaryButton
@@ -324,22 +326,23 @@ fun ScanQRContent(
     onAddressDecoded: (String) -> Unit
 ) {
     Column(
-        modifier = modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally
+        modifier = modifier
+            .fillMaxSize()
+            .padding(RadixTheme.dimensions.paddingXXLarge),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
     ) {
         Text(
-            modifier = Modifier
-                .padding(RadixTheme.dimensions.paddingDefault),
-            text = stringResource(id = R.string.assetTransfer_qrScanInstructions),
+            text = stringResource(id = R.string.scanQR_account_instructions),
             style = RadixTheme.typography.body1Regular,
-            color = RadixTheme.colors.gray1
+            color = RadixTheme.colors.gray1,
+            textAlign = TextAlign.Center
         )
 
         CameraPreview(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f)
-                .padding(horizontal = RadixTheme.dimensions.paddingDefault)
                 .clip(RadixTheme.shapes.roundedRectMedium),
             disableBackHandler = false
         ) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLinkConnectorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLinkConnectorScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -39,6 +38,7 @@ import com.babylon.wallet.android.presentation.ui.composables.linkedconnector.Li
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
+import kotlinx.collections.immutable.persistentListOf
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
@@ -108,6 +108,7 @@ private fun AddLinkConnectorContent(
                         )
                     }
                 }
+
                 is AddLinkConnectorUiState.Content.ApproveNewLinkConnector -> {
                     LinkedConnectorMessageScreen(
                         title = stringResource(id = R.string.linkedConnectors_approveNewConnector_title),
@@ -117,6 +118,7 @@ private fun AddLinkConnectorContent(
                         onNegativeClick = onCloseClick
                     )
                 }
+
                 is AddLinkConnectorUiState.Content.UpdateLinkConnector -> {
                     LinkedConnectorMessageScreen(
                         title = stringResource(id = R.string.linkedConnectors_approveExistingConnector_title),
@@ -126,6 +128,7 @@ private fun AddLinkConnectorContent(
                         onNegativeClick = onCloseClick
                     )
                 }
+
                 is AddLinkConnectorUiState.Content.NameLinkConnector -> {
                     NameNewConnector(
                         content = state.content,
@@ -148,6 +151,7 @@ private fun AddLinkConnectorContent(
                 message = stringResource(id = R.string.linkedConnectors_incorrectQrMessage),
                 onDismiss = onErrorDismiss
             )
+
             is AddLinkConnectorUiState.Error.Other -> ConnectionErrorDialog(
                 title = stringResource(id = R.string.linkedConnectors_linkFailedErrorTitle),
                 message = it.message.getMessage(),
@@ -165,11 +169,13 @@ private fun ScanQrCode(
     onQrCodeScanFailure: (Throwable) -> Unit
 ) {
     Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally
+        modifier = modifier
     ) {
         Text(
-            modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = RadixTheme.dimensions.paddingXXLarge)
+                .padding(bottom = RadixTheme.dimensions.paddingDefault),
             text = stringResource(id = R.string.linkedConnectors_linkNewConnector),
             style = RadixTheme.typography.title,
             color = RadixTheme.colors.gray1,
@@ -177,8 +183,10 @@ private fun ScanQrCode(
         )
 
         Text(
-            modifier = Modifier.padding(RadixTheme.dimensions.paddingLarge),
-            text = stringResource(id = R.string.linkedConnectors_newConnection_subtitle),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = RadixTheme.dimensions.paddingXXLarge),
+            text = stringResource(id = R.string.scanQR_connectorExtension_instructions),
             style = RadixTheme.typography.body1Regular,
             color = RadixTheme.colors.gray1,
             textAlign = TextAlign.Center
@@ -189,14 +197,34 @@ private fun ScanQrCode(
                 .fillMaxWidth()
                 .aspectRatio(1f)
                 .padding(
-                    horizontal = RadixTheme.dimensions.paddingLarge,
-                    vertical = RadixTheme.dimensions.paddingDefault
+                    horizontal = RadixTheme.dimensions.paddingXXLarge,
+                    vertical = RadixTheme.dimensions.paddingLarge
                 )
                 .clip(RadixTheme.shapes.roundedRectMedium),
             disableBackHandler = false,
             isVisible = isCameraOn,
             onQrCodeDetected = onQrCodeScanned,
             onError = onQrCodeScanFailure
+        )
+
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = RadixTheme.dimensions.paddingXXLarge)
+                .padding(bottom = RadixTheme.dimensions.paddingDefault),
+            text = stringResource(id = R.string.scanQR_connectorExtension_disclosureTitle),
+            style = RadixTheme.typography.body2Header,
+            color = RadixTheme.colors.gray1
+        )
+
+        NumberedValuesList(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = RadixTheme.dimensions.paddingXXLarge),
+            values = persistentListOf(
+                stringResource(id = R.string.scanQR_connectorExtension_disclosureItem1),
+                stringResource(id = R.string.scanQR_connectorExtension_disclosureItem2)
+            )
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/NumberedValuesList.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/NumberedValuesList.kt
@@ -1,0 +1,80 @@
+package com.babylon.wallet.android.presentation.ui.composables
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.ConstraintSet
+import androidx.constraintlayout.compose.Dimension
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.utils.formattedSpans
+import kotlinx.collections.immutable.ImmutableList
+
+@Suppress("SpreadOperator")
+@Composable
+fun NumberedValuesList(
+    modifier: Modifier = Modifier,
+    style: TextStyle = RadixTheme.typography.body2Regular,
+    color: Color = RadixTheme.colors.gray1,
+    values: ImmutableList<String>
+) {
+    val constraints = ConstraintSet {
+        val idRefs = List(values.size) { index ->
+            createRefFor("id$index")
+        }
+
+        val valueRefs = List(values.size) { index ->
+            createRefFor("value$index")
+        }
+
+        val idsBarrier = createEndBarrier(*idRefs.toTypedArray(), margin = 4.dp)
+        values.forEachIndexed { index, _ ->
+            val idRef = idRefs[index]
+            constrain(idRef) {
+                if (index == 0) {
+                    start.linkTo(parent.start, margin = 4.dp)
+                    top.linkTo(parent.top)
+                } else {
+                    start.linkTo(idRefs[index - 1].start)
+                    top.linkTo(valueRefs[index - 1].bottom, margin = 4.dp)
+                }
+            }
+
+            val valueRef = valueRefs[index]
+            constrain(valueRef) {
+                start.linkTo(idsBarrier)
+                top.linkTo(idRef.top)
+                end.linkTo(parent.end)
+
+                width = Dimension.fillToConstraints
+            }
+        }
+    }
+
+    ConstraintLayout(
+        modifier = modifier,
+        constraintSet = constraints
+    ) {
+        values.forEachIndexed { index, value ->
+            Text(
+                modifier = Modifier.layoutId("id$index"),
+                text = "${index + 1}.",
+                style = style,
+                color = color
+            )
+
+            Text(
+                modifier = Modifier.layoutId("value$index"),
+                text = value.formattedSpans(
+                    boldStyle = RadixTheme.typography.body2HighImportance.toSpanStyle()
+                ),
+                style = style,
+                color = color
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description
* We have 3 occasions the QR code scanner is invoked.
    1. When linking a connector extension
    2. When importing from legacy wallet.
    3. When scanning for account address in assets transfer.
* Some paddings and alignments changed.
* Specifically for connector extension linking some instructions were added at the bottom  

## How to test

1. Try linking a connector extension, either from settings or when trying to add a ledger device when there is no CE connected yet.
2. Try the transfer flow and click on the QR icon when trying to type an account address.
3. Try opening the legacy wallet scanner
