### PR TITLE
Use body instead of query params when submitting NPS survey

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/gateway/survey/NPSSurveyApi.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/gateway/survey/NPSSurveyApi.kt
@@ -1,5 +1,7 @@
 package com.babylon.wallet.android.data.gateway.survey
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import retrofit2.Call
@@ -14,6 +16,7 @@ interface NPSSurveyApi {
     ): Call<SurveyResponse>
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SurveyRequest(
     @SerialName("id")
@@ -22,11 +25,13 @@ data class SurveyRequest(
     @SerialName("form_uuid")
     val formUuid: String,
 
+    @EncodeDefault(mode = EncodeDefault.Mode.NEVER)
     @SerialName("nps")
-    val nps: String,
+    val nps: Int? = null,
 
+    @EncodeDefault(mode = EncodeDefault.Mode.NEVER)
     @SerialName("what_do_you_value_most_about_our_service")
-    val whatDoYouValue: String
+    val whatDoYouValue: String? = null
 
 )
 

--- a/app/src/main/java/com/babylon/wallet/android/data/gateway/survey/NPSSurveyApi.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/gateway/survey/NPSSurveyApi.kt
@@ -3,23 +3,32 @@ package com.babylon.wallet.android.data.gateway.survey
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import retrofit2.Call
+import retrofit2.http.Body
 import retrofit2.http.POST
-import retrofit2.http.QueryMap
 
 interface NPSSurveyApi {
 
     @POST("v1/responses")
     fun storeSurveyResponse(
-        @QueryMap params: Map<String, String>
+        @Body request: SurveyRequest
     ): Call<SurveyResponse>
-
-    companion object {
-        const val PARAM_ID = "id"
-        const val PARAM_FORM_UUID = "form_uuid"
-        const val PARAM_NPS = "nps"
-        const val PARAM_WHAT_DO_YOU_VALUE = "what_do_you_value_most_about_our_service"
-    }
 }
+
+@Serializable
+data class SurveyRequest(
+    @SerialName("id")
+    val id: String,
+
+    @SerialName("form_uuid")
+    val formUuid: String,
+
+    @SerialName("nps")
+    val nps: String,
+
+    @SerialName("what_do_you_value_most_about_our_service")
+    val whatDoYouValue: String
+
+)
 
 @Serializable
 data class SurveyResponse(

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/NPSSurveyRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/NPSSurveyRepository.kt
@@ -13,8 +13,8 @@ import javax.inject.Inject
 interface NPSSurveyRepository {
 
     suspend fun submitSurveyResponse(
-        npsQuestion: String,
-        reason: String,
+        npsScore: Int? = null,
+        reason: String? = null
     ): Result<SurveyResponse>
 }
 
@@ -25,8 +25,8 @@ class NPSSurveyRepositoryImpl @Inject constructor(
 ) : NPSSurveyRepository {
 
     override suspend fun submitSurveyResponse(
-        npsQuestion: String,
-        reason: String,
+        npsScore: Int?,
+        reason: String?
     ): Result<SurveyResponse> {
         return with(ioDispatcher) {
             val uuid = preferencesManager.surveyUuid.first()
@@ -34,7 +34,7 @@ class NPSSurveyRepositoryImpl @Inject constructor(
                 SurveyRequest(
                     id = uuid,
                     formUuid = BuildConfig.REFINER_FORM_UUID,
-                    nps = npsQuestion,
+                    nps = npsScore,
                     whatDoYouValue = reason
                 )
             ).toResult()

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/NPSSurveyRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/NPSSurveyRepository.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.data.repository
 
 import com.babylon.wallet.android.BuildConfig
 import com.babylon.wallet.android.data.gateway.survey.NPSSurveyApi
+import com.babylon.wallet.android.data.gateway.survey.SurveyRequest
 import com.babylon.wallet.android.data.gateway.survey.SurveyResponse
 import com.babylon.wallet.android.di.coroutines.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
@@ -30,11 +31,11 @@ class NPSSurveyRepositoryImpl @Inject constructor(
         return with(ioDispatcher) {
             val uuid = preferencesManager.surveyUuid.first()
             nPSSurveyApi.storeSurveyResponse(
-                params = mapOf(
-                    NPSSurveyApi.PARAM_ID to uuid,
-                    NPSSurveyApi.PARAM_FORM_UUID to BuildConfig.REFINER_FORM_UUID,
-                    NPSSurveyApi.PARAM_NPS to npsQuestion,
-                    NPSSurveyApi.PARAM_WHAT_DO_YOU_VALUE to reason
+                SurveyRequest(
+                    id = uuid,
+                    formUuid = BuildConfig.REFINER_FORM_UUID,
+                    nps = npsQuestion,
+                    whatDoYouValue = reason
                 )
             ).toResult()
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/survey/NPSSurveyViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/survey/NPSSurveyViewModel.kt
@@ -77,7 +77,7 @@ class NPSSurveyViewModel @Inject constructor(
 
     fun onBackPress() {
         appScope.launch {
-            nPSSurveyRepository.submitSurveyResponse("", "")
+            nPSSurveyRepository.submitSurveyResponse()
             appEventBus.sendEvent(AppEvent.NPSSurveySubmitted)
         }
         viewModelScope.launch {
@@ -94,8 +94,8 @@ class NPSSurveyViewModel @Inject constructor(
         val isSubmitButtonEnabled: Boolean
             get() = scores.any { it.selected }
 
-        val scoreSelected: String
-            get() = scores.find { it.selected }?.data?.score.toString()
+        val scoreSelected: Int?
+            get() = scores.find { it.selected }?.data?.score
     }
 }
 


### PR DESCRIPTION
## How to test

For testing, you should check that NPS event is received in our refiner project (dev/prod) and that `nps` score is an Int, by visiting `Reporting Dashboards` tab and checking if submitted score contributes to report. In case of dismissing the dialog, only `id` and `form_uuid` should be sent. 
In case of assistance needed in accessing the dashboard, let me know

## PR submission checklist
- [x] I have tested NPS score submission when sending request as a body instead of query params
