### PR TITLE
Preselect the newly created persona

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaViewModel.kt
@@ -10,13 +10,12 @@ import com.babylon.wallet.android.presentation.common.UiState
 import com.babylon.wallet.android.utils.LAST_USED_DATE_FORMAT_SHORT_MONTH
 import com.babylon.wallet.android.utils.toEpochMillis
 import com.radixdlt.sargon.AuthorizedDapp
-import com.radixdlt.sargon.AuthorizedPersonaSimple
 import com.radixdlt.sargon.IdentityAddress
 import com.radixdlt.sargon.Persona
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.collections.immutable.toPersistentList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
@@ -34,113 +33,119 @@ class SelectPersonaViewModel @Inject constructor(
     private val dAppConnectionRepository: DAppConnectionRepository,
     private val getProfileUseCase: GetProfileUseCase,
     private val preferencesManager: PreferencesManager
-) : StateViewModel<SelectPersonaUiState>(), OneOffEventHandler<DAppSelectPersonaEvent> by OneOffEventHandlerImpl() {
+) : StateViewModel<SelectPersonaViewModel.State>(), OneOffEventHandler<SelectPersonaViewModel.Event> by OneOffEventHandlerImpl() {
 
     private val args = SelectPersonaArgs(savedStateHandle)
 
-    private var authorizedDapp: AuthorizedDapp? = null
-
-    override fun initialState(): SelectPersonaUiState = SelectPersonaUiState()
+    override fun initialState(): State = State()
 
     init {
-        viewModelScope.launch {
-            authorizedDapp = dAppConnectionRepository.getAuthorizedDApp(args.dappDefinitionAddress)
-            val allAuthorizedPersonas = authorizedDapp?.referencesToAuthorizedPersonas
-            _state.update { state ->
-                val personas = generatePersonasListForDisplay(
-                    allAuthorizedPersonas,
-                    state.personaListToDisplay
-                ).toPersistentList()
-                val selected = personas.any { it.selected }
-                state.copy(
-                    firstTimeLogin = authorizedDapp == null,
-                    personaListToDisplay = personas,
-                    continueButtonEnabled = selected,
-                    isLoading = false
-                )
-            }
-        }
         observePersonas()
     }
 
     private fun observePersonas() {
         viewModelScope.launch {
-            getProfileUseCase.flow.map { it.activePersonasOnCurrentNetwork }.collect { personas ->
-                authorizedDapp = dAppConnectionRepository.getAuthorizedDApp(args.dappDefinitionAddress)
-                val allAuthorizedPersonas = authorizedDapp?.referencesToAuthorizedPersonas
-                _state.update { state ->
-                    val personasListForDisplay = generatePersonasListForDisplay(
-                        allAuthorizedPersonas,
-                        personas.map { it.toUiModel() }
-                    )
-                    val selected = personasListForDisplay.any { it.selected }
-                    state.copy(
-                        personaListToDisplay = personasListForDisplay.toPersistentList(),
-                        continueButtonEnabled = selected
-                    )
+            getProfileUseCase
+                .flow
+                .map { it.activePersonasOnCurrentNetwork }
+                .collect { personas ->
+                    val authorizedDApp = dAppConnectionRepository.getAuthorizedDApp(args.dappDefinitionAddress)
+                    _state.update {
+                        it.onProfileUpdated(
+                            authorizedDApp = authorizedDApp,
+                            profilePersonas = personas
+                        )
+                    }
                 }
-            }
-        }
-    }
-
-    private suspend fun generatePersonasListForDisplay(
-        allAuthorizedPersonas: List<AuthorizedPersonaSimple>?,
-        profilePersonas: List<PersonaUiModel>
-    ): List<PersonaUiModel> {
-        val updatedPersonas = profilePersonas.map { personaUiModel ->
-            val matchingAuthorizedPersona = allAuthorizedPersonas?.firstOrNull {
-                personaUiModel.persona.address == it.identityAddress
-            }
-            if (matchingAuthorizedPersona != null) {
-                val localDateTime = matchingAuthorizedPersona.lastLogin.toLocalDateTime()
-                personaUiModel.copy(
-                    lastUsedOn = localDateTime
-                        ?.format(DateTimeFormatter.ofPattern(LAST_USED_DATE_FORMAT_SHORT_MONTH)),
-                    lastUsedOnTimestamp = localDateTime?.toEpochMillis() ?: 0
-                )
-            } else {
-                personaUiModel
-            }
-        }.sortedByDescending { it.lastUsedOnTimestamp }
-        var currentlySelectedPersona = state.value.personaListToDisplay.firstOrNull { it.selected }
-            ?: updatedPersonas.firstOrNull { it.lastUsedOn != null }
-
-        // When we have a single persona and there are no pre-selected ones, pre-select it.
-        if (currentlySelectedPersona == null && updatedPersonas.size == 1) {
-            currentlySelectedPersona = updatedPersonas[0]
-        }
-
-        currentlySelectedPersona?.persona?.let {
-            sendEvent(DAppSelectPersonaEvent.PersonaSelected(it))
-        }
-
-        return updatedPersonas.map { p ->
-            p.copy(selected = p.persona.address == currentlySelectedPersona?.persona?.address)
         }
     }
 
     fun onSelectPersona(personaAddress: IdentityAddress) {
-        val updatedPersonas = state.value.personaListToDisplay.map {
-            it.copy(selected = it.persona.address == personaAddress)
-        }.toPersistentList()
-        _state.update { it.copy(personaListToDisplay = updatedPersonas, continueButtonEnabled = true) }
+        _state.update { it.onPersonaSelected(personaAddress) }
     }
 
     fun onCreatePersona() {
         viewModelScope.launch {
-            sendEvent(DAppSelectPersonaEvent.CreatePersona(preferencesManager.firstPersonaCreated.first()))
+            sendEvent(Event.CreatePersona(preferencesManager.firstPersonaCreated.first()))
+        }
+    }
+
+    sealed interface Event : OneOffEvent {
+        data class CreatePersona(val firstPersonaCreated: Boolean) : Event
+    }
+
+    data class State(
+        val isLoading: Boolean = true,
+        private val authorizedDApp: AuthorizedDapp? = null,
+        val personas: ImmutableList<PersonaUiModel> = persistentListOf()
+    ) : UiState {
+
+        val selectedPersona: Persona? = personas.find { it.selected }?.persona
+
+        val isFirstTimeLogin: Boolean
+            get() = authorizedDApp == null
+
+        val isContinueButtonEnabled: Boolean
+            get() = selectedPersona != null
+
+        fun onPersonaSelected(identityAddress: IdentityAddress): State = copy(
+            personas = personas.map {
+                it.copy(selected = identityAddress == it.persona.address)
+            }.toImmutableList()
+        )
+
+        fun onProfileUpdated(
+            authorizedDApp: AuthorizedDapp?,
+            profilePersonas: List<Persona>,
+        ): State {
+            val authorizedPersonas = authorizedDApp?.referencesToAuthorizedPersonas
+
+            val models = profilePersonas.map { persona ->
+                val authorized = authorizedPersonas?.find { it.identityAddress == persona.address }
+
+                persona.toUiModel().let { model ->
+                    if (authorized != null) {
+                        val localDateTime = authorized.lastLogin.toLocalDateTime()
+                        model.copy(
+                            lastUsedOn = localDateTime
+                                ?.format(DateTimeFormatter.ofPattern(LAST_USED_DATE_FORMAT_SHORT_MONTH)),
+                            lastUsedOnTimestamp = localDateTime?.toEpochMillis() ?: 0
+                        )
+                    } else {
+                        model
+                    }
+                }
+            }.sortedByDescending {
+                it.lastUsedOnTimestamp
+            }
+
+            val modelsWithSelectedInfo = if (selectedPersona == null) {
+                // When the view model is first created, or no personas exists, no prior selection exists
+                // so we decide to pre-select the first one
+                models.mapIndexed { index, personaUiModel ->
+                    personaUiModel.copy(selected = index == 0)
+                }
+            } else {
+                val previousPersonaAddresses = personas.map { it.persona.address }.toSet()
+                val currentPersonaAddresses = profilePersonas.map { it.address }.toSet()
+
+                val personaToSelect = currentPersonaAddresses.minus(previousPersonaAddresses).firstOrNull()
+
+                // When a newly created persona is detected, we preselect that one
+                if (personaToSelect != null) {
+                    models.map {
+                        it.copy(selected = it.persona.address == personaToSelect)
+                    }
+                } else {
+                    models
+                }
+            }
+
+            return copy(
+                authorizedDApp = authorizedDApp,
+                personas = modelsWithSelectedInfo.toImmutableList(),
+                isLoading = false
+            )
         }
     }
 }
-
-sealed interface DAppSelectPersonaEvent : OneOffEvent {
-    data class PersonaSelected(val persona: Persona) : DAppSelectPersonaEvent
-    data class CreatePersona(val firstPersonaCreated: Boolean) : DAppSelectPersonaEvent
-}
-
-data class SelectPersonaUiState(
-    val isLoading: Boolean = true,
-    val continueButtonEnabled: Boolean = false,
-    val firstTimeLogin: Boolean = true,
-    val personaListToDisplay: ImmutableList<PersonaUiModel> = persistentListOf()
-) : UiState

--- a/app/src/test/java/com/babylon/wallet/android/presentation/dapp/selectpersona/SelectPersonaViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/dapp/selectpersona/SelectPersonaViewModelTest.kt
@@ -106,9 +106,9 @@ internal class SelectPersonaViewModelTest : StateViewModelTest<SelectPersonaView
         advanceUntilIdle()
         vm.state.test {
             val item = expectMostRecentItem()
-            assert(item.continueButtonEnabled)
-            assert(item.personaListToDisplay.size == 2)
-            val onePersonaAuthorized = item.personaListToDisplay.count { it.lastUsedOn != null } == 1
+            assert(item.isContinueButtonEnabled)
+            assert(item.personas.size == 2)
+            val onePersonaAuthorized = item.personas.count { it.lastUsedOn != null } == 1
             assert(onePersonaAuthorized)
         }
     }
@@ -120,9 +120,9 @@ internal class SelectPersonaViewModelTest : StateViewModelTest<SelectPersonaView
         advanceUntilIdle()
         vm.state.test {
             val item = expectMostRecentItem()
-            assert(!item.continueButtonEnabled)
-            assert(item.personaListToDisplay.size == 2)
-            val noPersonaAuthorized = item.personaListToDisplay.all { it.lastUsedOn == null }
+            assert(!item.isContinueButtonEnabled)
+            assert(item.personas.size == 2)
+            val noPersonaAuthorized = item.personas.all { it.lastUsedOn == null }
             assert(noPersonaAuthorized)
         }
     }


### PR DESCRIPTION
## Description
This PR adds to the #1029. The logic for pre-selecting a persona will be:
* Preselect the first one if none is selected.
* Be sure to sort the personas based on the last used timestamp if some of them were authorised by the dApp in the past.
* If a new persona is created, select that.

That way the user doesn't have to do an extra click while logging in to a dApp.
