### PR TITLE
Add missing headers to all http clients that need it

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/dapps/WellKnownDAppDefinitionRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/dapps/WellKnownDAppDefinitionRepository.kt
@@ -4,7 +4,7 @@ import com.babylon.wallet.android.data.gateway.apis.DAppDefinitionApi
 import com.babylon.wallet.android.data.gateway.model.WellKnownDAppDefinitionResponse
 import com.babylon.wallet.android.data.repository.toResult
 import com.babylon.wallet.android.di.JsonConverterFactory
-import com.babylon.wallet.android.di.SimpleHttpClient
+import com.babylon.wallet.android.di.GatewayHttpClient
 import com.babylon.wallet.android.di.buildApi
 import com.babylon.wallet.android.di.coroutines.IoDispatcher
 import com.babylon.wallet.android.domain.DappDefinition
@@ -25,7 +25,7 @@ interface WellKnownDAppDefinitionRepository {
 }
 
 class WellKnownDAppDefinitionRepositoryImpl @Inject constructor(
-    @SimpleHttpClient private val okHttpClient: OkHttpClient,
+    @GatewayHttpClient private val okHttpClient: OkHttpClient,
     @JsonConverterFactory private val jsonConverterFactory: Converter.Factory,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : WellKnownDAppDefinitionRepository {

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/dapps/WellKnownDAppDefinitionRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/dapps/WellKnownDAppDefinitionRepository.kt
@@ -3,8 +3,8 @@ package com.babylon.wallet.android.data.repository.dapps
 import com.babylon.wallet.android.data.gateway.apis.DAppDefinitionApi
 import com.babylon.wallet.android.data.gateway.model.WellKnownDAppDefinitionResponse
 import com.babylon.wallet.android.data.repository.toResult
-import com.babylon.wallet.android.di.JsonConverterFactory
 import com.babylon.wallet.android.di.GatewayHttpClient
+import com.babylon.wallet.android.di.JsonConverterFactory
 import com.babylon.wallet.android.di.buildApi
 import com.babylon.wallet.android.di.coroutines.IoDispatcher
 import com.babylon.wallet.android.domain.DappDefinition

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/networkinfo/NetworkInfoRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/networkinfo/NetworkInfoRepository.kt
@@ -2,8 +2,8 @@ package com.babylon.wallet.android.data.repository.networkinfo
 
 import com.babylon.wallet.android.data.gateway.apis.StatusApi
 import com.babylon.wallet.android.data.repository.toResult
-import com.babylon.wallet.android.di.JsonConverterFactory
 import com.babylon.wallet.android.di.GatewayHttpClient
+import com.babylon.wallet.android.di.JsonConverterFactory
 import com.babylon.wallet.android.di.buildApi
 import com.babylon.wallet.android.domain.model.NetworkInfo
 import com.radixdlt.sargon.NetworkId

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/networkinfo/NetworkInfoRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/networkinfo/NetworkInfoRepository.kt
@@ -3,7 +3,7 @@ package com.babylon.wallet.android.data.repository.networkinfo
 import com.babylon.wallet.android.data.gateway.apis.StatusApi
 import com.babylon.wallet.android.data.repository.toResult
 import com.babylon.wallet.android.di.JsonConverterFactory
-import com.babylon.wallet.android.di.SimpleHttpClient
+import com.babylon.wallet.android.di.GatewayHttpClient
 import com.babylon.wallet.android.di.buildApi
 import com.babylon.wallet.android.domain.model.NetworkInfo
 import com.radixdlt.sargon.NetworkId
@@ -17,7 +17,7 @@ interface NetworkInfoRepository {
 }
 
 class NetworkInfoRepositoryImpl @Inject constructor(
-    @SimpleHttpClient private val okHttpClient: OkHttpClient,
+    @GatewayHttpClient private val okHttpClient: OkHttpClient,
     @JsonConverterFactory private val jsonConverterFactory: Converter.Factory,
 ) : NetworkInfoRepository {
 

--- a/app/src/main/java/com/babylon/wallet/android/di/ApplicationModule.kt
+++ b/app/src/main/java/com/babylon/wallet/android/di/ApplicationModule.kt
@@ -90,7 +90,7 @@ object ApplicationModule {
     @Singleton
     fun provideRadixConnectMobile(
         @ApplicationContext context: Context,
-        @SimpleHttpClient httpClient: OkHttpClient
+        @GatewayHttpClient httpClient: OkHttpClient
     ): RadixConnectMobile = RadixConnectMobile.init(
         context = context,
         okHttpClient = httpClient

--- a/app/src/main/java/com/babylon/wallet/android/di/HttpModule.kt
+++ b/app/src/main/java/com/babylon/wallet/android/di/HttpModule.kt
@@ -163,7 +163,7 @@ object NetworkModule {
         }
     }
 
-    class HeaderInterceptor @Inject constructor(): Interceptor {
+    class HeaderInterceptor @Inject constructor() : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
             val request = chain.request().newBuilder()
                 .addHeader(HEADER_RDX_CLIENT_NAME, HEADER_VALUE_RDX_CLIENT_NAME)
@@ -172,7 +172,6 @@ object NetworkModule {
 
             return chain.proceed(request)
         }
-
     }
 
     private const val SHORT_TIMEOUT_SECONDS = 5L

--- a/app/src/main/java/com/babylon/wallet/android/di/HttpModule.kt
+++ b/app/src/main/java/com/babylon/wallet/android/di/HttpModule.kt
@@ -20,6 +20,7 @@ import rdx.works.profile.data.repository.ProfileRepository
 import retrofit2.Converter.Factory
 import retrofit2.Retrofit
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -35,26 +36,21 @@ annotation class JsonConverterFactory
  */
 @Retention(AnnotationRetention.BINARY)
 @Qualifier
-annotation class CurrentGatewayHttpClient
+annotation class DynamicGatewayHttpClient
 
+/**
+ * Same as [DynamicGatewayHttpClient] but with shorter timeout
+ */
 @Retention(AnnotationRetention.BINARY)
 @Qualifier
-annotation class ShortTimeoutGatewayHttpClient
-
-@Retention(AnnotationRetention.BINARY)
-@Qualifier
-annotation class StandardStateApi
-
-@Retention(AnnotationRetention.BINARY)
-@Qualifier
-annotation class ShortTimeoutStateApi
+annotation class ShortTimeoutDynamicGatewayHttpClient
 
 /**
  * A simple [OkHttpClient] **without** dynamic change of the base url.
  */
 @Retention(AnnotationRetention.BINARY)
 @Qualifier
-annotation class SimpleHttpClient
+annotation class GatewayHttpClient
 
 private const val HEADER_RDX_CLIENT_NAME = "RDX-Client-Name"
 private const val HEADER_RDX_CLIENT_VERSION = "RDX-Client-Version"
@@ -95,11 +91,44 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    @SimpleHttpClient
-    fun provideSimpleHttpClient(
+    @GatewayHttpClient
+    fun provideGatewayHttpClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+        headerInterceptor: HeaderInterceptor
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(headerInterceptor)
+            .addInterceptor(httpLoggingInterceptor)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    @DynamicGatewayHttpClient
+    fun provideDynamicGatewayHttpClient(
+        baseUrlInterceptor: BaseUrlInterceptor,
+        headerInterceptor: HeaderInterceptor,
         httpLoggingInterceptor: HttpLoggingInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
+            .addInterceptor(baseUrlInterceptor)
+            .addInterceptor(headerInterceptor)
+            .addInterceptor(httpLoggingInterceptor)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    @ShortTimeoutDynamicGatewayHttpClient
+    fun provideShortTimeoutDynamicGatewayHttpClient(
+        baseUrlInterceptor: BaseUrlInterceptor,
+        headerInterceptor: HeaderInterceptor,
+        httpLoggingInterceptor: HttpLoggingInterceptor
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .callTimeout(SHORT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .addInterceptor(baseUrlInterceptor)
+            .addInterceptor(headerInterceptor)
             .addInterceptor(httpLoggingInterceptor)
             .build()
     }
@@ -129,10 +158,22 @@ object NetworkModule {
 
             val request = chain.request().newBuilder()
                 .url(updatedUrl)
-                .addHeader(HEADER_RDX_CLIENT_NAME, HEADER_VALUE_RDX_CLIENT_NAME)
-                .addHeader(HEADER_RDX_CLIENT_VERSION, "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
                 .build()
             return chain.proceed(request)
         }
     }
+
+    class HeaderInterceptor @Inject constructor(): Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val request = chain.request().newBuilder()
+                .addHeader(HEADER_RDX_CLIENT_NAME, HEADER_VALUE_RDX_CLIENT_NAME)
+                .addHeader(HEADER_RDX_CLIENT_VERSION, "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+                .build()
+
+            return chain.proceed(request)
+        }
+
+    }
+
+    private const val SHORT_TIMEOUT_SECONDS = 5L
 }

--- a/app/src/main/java/com/babylon/wallet/android/di/NetworkApiModule.kt
+++ b/app/src/main/java/com/babylon/wallet/android/di/NetworkApiModule.kt
@@ -17,14 +17,12 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
-import okhttp3.logging.HttpLoggingInterceptor
 import rdx.works.core.sargon.currentGateway
 import rdx.works.core.sargon.default
 import rdx.works.peerdroid.data.PeerdroidConnector
 import rdx.works.peerdroid.di.IoDispatcher
 import rdx.works.profile.data.repository.ProfileRepository
 import retrofit2.Converter
-import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 import javax.inject.Singleton
 

--- a/app/src/main/java/com/babylon/wallet/android/di/NetworkApiModule.kt
+++ b/app/src/main/java/com/babylon/wallet/android/di/NetworkApiModule.kt
@@ -25,38 +25,16 @@ import rdx.works.peerdroid.di.IoDispatcher
 import rdx.works.profile.data.repository.ProfileRepository
 import retrofit2.Converter
 import java.util.concurrent.TimeUnit
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class ShortTimeoutStateApi
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkApiModule {
-
-    @Provides
-    @Singleton
-    @CurrentGatewayHttpClient
-    fun provideCurrentGatewayHttpClient(
-        baseUrlInterceptor: NetworkModule.BaseUrlInterceptor,
-        httpLoggingInterceptor: HttpLoggingInterceptor
-    ): OkHttpClient {
-        return OkHttpClient.Builder()
-            .addInterceptor(baseUrlInterceptor)
-            .addInterceptor(httpLoggingInterceptor)
-            .build()
-    }
-
-    @Provides
-    @Singleton
-    @ShortTimeoutGatewayHttpClient
-    fun provideShortTimeoutGatewayHttpClient(
-        baseUrlInterceptor: NetworkModule.BaseUrlInterceptor,
-        httpLoggingInterceptor: HttpLoggingInterceptor
-    ): OkHttpClient {
-        return OkHttpClient.Builder()
-            .callTimeout(SHORT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .addInterceptor(baseUrlInterceptor)
-            .addInterceptor(httpLoggingInterceptor)
-            .build()
-    }
 
     @Provides
     @Singleton
@@ -72,7 +50,7 @@ object NetworkApiModule {
 
     @Provides
     fun provideStateApi(
-        @CurrentGatewayHttpClient okHttpClient: OkHttpClient,
+        @DynamicGatewayHttpClient okHttpClient: OkHttpClient,
         @JsonConverterFactory jsonConverterFactory: Converter.Factory,
         profileRepository: ProfileRepository
     ): StateApi = buildApi(
@@ -84,7 +62,7 @@ object NetworkApiModule {
     @Provides
     @ShortTimeoutStateApi
     fun provideStateApiWithShortTimeout(
-        @ShortTimeoutGatewayHttpClient okHttpClient: OkHttpClient,
+        @ShortTimeoutDynamicGatewayHttpClient okHttpClient: OkHttpClient,
         @JsonConverterFactory jsonConverterFactory: Converter.Factory,
         profileRepository: ProfileRepository
     ): StateApi = buildApi(
@@ -95,7 +73,7 @@ object NetworkApiModule {
 
     @Provides
     fun provideTransactionApi(
-        @CurrentGatewayHttpClient okHttpClient: OkHttpClient,
+        @DynamicGatewayHttpClient okHttpClient: OkHttpClient,
         @JsonConverterFactory jsonConverterFactory: Converter.Factory,
         profileRepository: ProfileRepository
     ): TransactionApi = buildApi(
@@ -106,7 +84,7 @@ object NetworkApiModule {
 
     @Provides
     fun provideStreamApi(
-        @CurrentGatewayHttpClient okHttpClient: OkHttpClient,
+        @DynamicGatewayHttpClient okHttpClient: OkHttpClient,
         @JsonConverterFactory jsonConverterFactory: Converter.Factory,
         profileRepository: ProfileRepository
     ): StreamApi = buildApi(
@@ -117,7 +95,7 @@ object NetworkApiModule {
 
     @Provides
     fun provideTokenPriceApi(
-        @SimpleHttpClient okHttpClient: OkHttpClient,
+        @GatewayHttpClient okHttpClient: OkHttpClient,
         @JsonConverterFactory jsonConverterFactory: Converter.Factory
     ): TokenPriceApi = buildApi(
         baseUrl = TokenPriceApi.BASE_URL,
@@ -127,7 +105,7 @@ object NetworkApiModule {
 
     @Provides
     fun provideNPSSurveyApi(
-        @SimpleHttpClient okHttpClient: OkHttpClient,
+        @GatewayHttpClient okHttpClient: OkHttpClient,
         @JsonConverterFactory jsonConverterFactory: Converter.Factory
     ): NPSSurveyApi = buildApi(
         baseUrl = BuildConfig.NPS_SURVEY_URL,
@@ -135,5 +113,3 @@ object NetworkApiModule {
         jsonConverterFactory = jsonConverterFactory
     )
 }
-
-private const val SHORT_TIMEOUT_SECONDS = 5L


### PR DESCRIPTION
## Description
* Required headers are also included to the previously named "SimpleHttpClient"
* Renamed the annotations to depict the state of the client
* Moved the appropriate providers to http module
* Separated `BaseUrlInterceptor` with `HeaderInterceptor` since the first one is only used in dynamic gateway apis.
