### PR TITLE
Fix long names issue for accounts in SimpleAccountCard

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SimpleAccountCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SimpleAccountCard.kt
@@ -89,10 +89,10 @@ fun SimpleAccountCard(
                 vertical = RadixTheme.dimensions.paddingDefault
             ),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingMedium)
     ) {
         Text(
-            modifier = Modifier.padding(end = RadixTheme.dimensions.paddingMedium),
+            modifier = Modifier.weight(1f),
             text = account.displayName.value,
             style = RadixTheme.typography.body1Header,
             maxLines = 1,


### PR DESCRIPTION
## Description
* Long display names were pushing the address to the end of the row.

## How to test

1. Rename an account using a long name
2. Check the account settings and see that the name does not push the address far to the end.