### PR TITLE
Show Asset Details from transfer screen

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -399,7 +399,7 @@ fun NavigationHost(
             onBackClick = {
                 navController.popBackStack()
             },
-            onAssetClicked = { spendingAsset, fromAccount ->
+            onShowAssetDetails = { spendingAsset, fromAccount ->
                 when (spendingAsset) {
                     is SpendingAsset.Fungible -> navController.fungibleAssetDialog(
                         resourceAddress = spendingAsset.resourceAddress,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -77,6 +77,7 @@ import com.babylon.wallet.android.presentation.status.transaction.transactionSta
 import com.babylon.wallet.android.presentation.survey.npsSurveyDialog
 import com.babylon.wallet.android.presentation.transaction.transactionReview
 import com.babylon.wallet.android.presentation.transaction.transactionReviewScreen
+import com.babylon.wallet.android.presentation.transfer.SpendingAsset
 import com.babylon.wallet.android.presentation.transfer.transfer
 import com.babylon.wallet.android.presentation.transfer.transferScreen
 import com.babylon.wallet.android.presentation.walletclaimed.claimedByAnotherDevice
@@ -397,6 +398,20 @@ fun NavigationHost(
         transferScreen(
             onBackClick = {
                 navController.popBackStack()
+            },
+            onAssetClicked = { spendingAsset, fromAccount ->
+                when (spendingAsset) {
+                    is SpendingAsset.Fungible -> navController.fungibleAssetDialog(
+                        resourceAddress = spendingAsset.resourceAddress,
+                        amounts = spendingAsset.resource.ownedAmount?.let { mapOf(spendingAsset.resourceAddress to it) }.orEmpty(),
+                        underAccountAddress = fromAccount.address
+                    )
+                    is SpendingAsset.NFT -> navController.nftAssetDialog(
+                        resourceAddress = spendingAsset.resourceAddress,
+                        localId = spendingAsset.item.localId,
+                        underAccountAddress = fromAccount.address
+                    )
+                }
             }
         )
         accountSettings(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TargetAccountCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TargetAccountCard.kt
@@ -50,6 +50,7 @@ fun TargetAccountCard(
     onAddAssetsClick: () -> Unit,
     onRemoveAssetClicked: (SpendingAsset) -> Unit,
     onAmountTyped: (SpendingAsset, String) -> Unit,
+    onAssetClick: (SpendingAsset) -> Unit,
     onMaxAmountClicked: (SpendingAsset) -> Unit,
     onDeleteClick: () -> Unit,
     isDeletable: Boolean = false,
@@ -189,6 +190,9 @@ fun TargetAccountCard(
                         },
                         onMaxClicked = {
                             onMaxAmountClicked(spendingAsset)
+                        },
+                        onItemClick = {
+                            onAssetClick(spendingAsset)
                         }
                     )
 
@@ -257,6 +261,7 @@ fun TargetAccountCardPreview() {
                 onAddAssetsClick = {},
                 onRemoveAssetClicked = {},
                 onAmountTyped = { _, _ -> },
+                onAssetClick = {},
                 onMaxAmountClicked = {},
                 onDeleteClick = {},
                 targetAccount = TargetAccount.Skeleton()
@@ -267,6 +272,7 @@ fun TargetAccountCardPreview() {
                 onAddAssetsClick = {},
                 onRemoveAssetClicked = {},
                 onAmountTyped = { _, _ -> },
+                onAssetClick = {},
                 onMaxAmountClicked = {},
                 onDeleteClick = {},
                 targetAccount = TargetAccount.Owned(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TargetAccountCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TargetAccountCard.kt
@@ -108,13 +108,13 @@ fun TargetAccountCard(
                         Icon(
                             modifier = Modifier.size(18.dp),
                             painter = painterResource(id = DSR.ic_entity),
-                            tint = RadixTheme.colors.blue1,
+                            tint = RadixTheme.colors.blue2,
                             contentDescription = null
                         )
                         Text(
                             text = stringResource(id = R.string.assetTransfer_receivingAccount_chooseAccountButton),
                             style = RadixTheme.typography.body1Header,
-                            color = RadixTheme.colors.blue1,
+                            color = RadixTheme.colors.blue2,
                         )
                     }
                 }
@@ -152,7 +152,7 @@ fun TargetAccountCard(
                     Icon(
                         imageVector = Icons.Filled.Clear,
                         contentDescription = "clear",
-                        tint = if (targetAccount.validatedAddress != null) RadixTheme.colors.white else RadixTheme.colors.gray1,
+                        tint = if (targetAccount.validatedAddress != null) RadixTheme.colors.white else RadixTheme.colors.gray2,
                     )
                 }
             }
@@ -196,17 +196,20 @@ fun TargetAccountCard(
                         }
                     )
 
-                    IconButton(
-                        onClick = {
-                            onRemoveAssetClicked(spendingAsset)
-                        }
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Clear,
-                            tint = RadixTheme.colors.gray2,
-                            contentDescription = "clear"
-                        )
-                    }
+                    Icon(
+                        modifier = Modifier
+                            .padding(
+                                start = RadixTheme.dimensions.paddingSmall,
+                                end = RadixTheme.dimensions.paddingMedium
+                            )
+                            .size(20.dp)
+                            .clickable {
+                                onRemoveAssetClicked(spendingAsset)
+                            },
+                        imageVector = Icons.Filled.Clear,
+                        tint = RadixTheme.colors.gray2,
+                        contentDescription = "clear"
+                    )
                 }
                 if (targetAccount.isSignatureRequiredForTransfer(resourceAddress = spendingAsset.resourceAddress)) {
                     Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXSmall))
@@ -241,7 +244,7 @@ fun TargetAccountCard(
                 modifier = Modifier.padding(RadixTheme.dimensions.paddingMedium),
                 style = RadixTheme.typography.body1Header,
                 text = " + " + stringResource(id = R.string.assetTransfer_receivingAccount_addAssetsButton),
-                color = RadixTheme.colors.blue1
+                color = RadixTheme.colors.blue2
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferNav.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.babylon.wallet.android.presentation.navigation.markAsHighPriority
+import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.extensions.init
 import com.radixdlt.sargon.extensions.string
@@ -29,6 +30,7 @@ fun NavController.transfer(accountId: AccountAddress) {
 
 fun NavGraphBuilder.transferScreen(
     onBackClick: () -> Unit,
+    onAssetClicked: (SpendingAsset, Account) -> Unit
 ) {
     markAsHighPriority(ROUTE_TRANSFER)
     composable(
@@ -39,7 +41,8 @@ fun NavGraphBuilder.transferScreen(
     ) {
         TransferScreen(
             viewModel = hiltViewModel(),
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onAssetClicked = onAssetClicked
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferNav.kt
@@ -30,7 +30,7 @@ fun NavController.transfer(accountId: AccountAddress) {
 
 fun NavGraphBuilder.transferScreen(
     onBackClick: () -> Unit,
-    onAssetClicked: (SpendingAsset, Account) -> Unit
+    onShowAssetDetails: (SpendingAsset, Account) -> Unit
 ) {
     markAsHighPriority(ROUTE_TRANSFER)
     composable(
@@ -42,7 +42,7 @@ fun NavGraphBuilder.transferScreen(
         TransferScreen(
             viewModel = hiltViewModel(),
             onBackClick = onBackClick,
-            onAssetClicked = onAssetClicked
+            onShowAssetDetails = onShowAssetDetails
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -65,14 +65,14 @@ fun TransferScreen(
     modifier: Modifier = Modifier,
     viewModel: TransferViewModel,
     onBackClick: () -> Unit,
-    onAssetClicked: (SpendingAsset, Account) -> Unit
+    onShowAssetDetails: (SpendingAsset, Account) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.collect { event ->
             when (event) {
-                is TransferViewModel.Event.OnAssetClicked -> onAssetClicked(event.asset, event.fromAccount)
+                is TransferViewModel.Event.ShowAssetDetails -> onShowAssetDetails(event.asset, event.fromAccount)
             }
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -65,8 +65,17 @@ fun TransferScreen(
     modifier: Modifier = Modifier,
     viewModel: TransferViewModel,
     onBackClick: () -> Unit,
+    onAssetClicked: (SpendingAsset, Account) -> Unit
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.oneOffEvent.collect { event ->
+            when (event) {
+                is TransferViewModel.Event.OnAssetClicked -> onAssetClicked(event.asset, event.fromAccount)
+            }
+        }
+    }
 
     TransferContent(
         modifier = modifier,
@@ -93,6 +102,7 @@ fun TransferScreen(
         onMaxAmountApplied = viewModel::onMaxAmountApplied,
         onLessThanFeeApplied = viewModel::onLessThanFeeApplied,
         onAssetSelectionChanged = viewModel::onAssetSelectionChanged,
+        onAssetClicked = viewModel::onAssetClicked,
         onUiMessageShown = viewModel::onUiMessageShown,
         onChooseAssetsSubmitted = viewModel::onChooseAssetsSubmitted,
         onNextNFTsPageRequest = viewModel::onNextNFTsPageRequest,
@@ -128,6 +138,7 @@ fun TransferContent(
     onMaxAmountApplied: (Boolean) -> Unit,
     onLessThanFeeApplied: (Boolean) -> Unit,
     onAssetSelectionChanged: (SpendingAsset, Boolean) -> Unit,
+    onAssetClicked: (SpendingAsset) -> Unit,
     onNextNFTsPageRequest: (Resource.NonFungibleResource) -> Unit,
     onStakesRequest: () -> Unit,
     onUiMessageShown: () -> Unit,
@@ -307,6 +318,9 @@ fun TransferContent(
                     onDeleteClick = {
                         deleteAccountClick(targetAccount)
                     },
+                    onAssetClick = { asset ->
+                        onAssetClicked(asset)
+                    },
                     isDeletable = !(targetAccount is TargetAccount.Skeleton && index == 0),
                     targetAccount = targetAccount
                 )
@@ -461,6 +475,7 @@ fun TransferContentPreview() {
             onMaxAmountApplied = {},
             onLessThanFeeApplied = {},
             onAssetSelectionChanged = { _, _ -> },
+            onAssetClicked = {},
             onUiMessageShown = {},
             onChooseAssetsSubmitted = {},
             onNextNFTsPageRequest = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -2,6 +2,9 @@ package com.babylon.wallet.android.presentation.transfer
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.babylon.wallet.android.presentation.common.OneOffEvent
+import com.babylon.wallet.android.presentation.common.OneOffEventHandler
+import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
 import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.UiState
@@ -59,7 +62,7 @@ class TransferViewModel @Inject constructor(
     private val assetsChooserDelegate: AssetsChooserDelegate,
     private val prepareManifestDelegate: PrepareManifestDelegate,
     savedStateHandle: SavedStateHandle,
-) : StateViewModel<TransferViewModel.State>() {
+) : StateViewModel<TransferViewModel.State>(), OneOffEventHandler<TransferViewModel.Event> by OneOffEventHandlerImpl() {
 
     internal val args = TransferArgs(savedStateHandle)
 
@@ -236,6 +239,14 @@ class TransferViewModel @Inject constructor(
         asset = asset,
         isChecked = isSelected
     )
+
+    fun onAssetClicked(asset: SpendingAsset) {
+        val account = _state.value.fromAccount ?: return
+
+        viewModelScope.launch {
+            sendEvent(Event.OnAssetClicked(asset, account))
+        }
+    }
 
     fun onUiMessageShown() {
         if (_state.value.sheet is State.Sheet.ChooseAssets) {
@@ -485,6 +496,10 @@ class TransferViewModel @Inject constructor(
             val maxAccountAmountLessThanFee: Boolean
                 get() = maxAccountAmount < 1.toDecimal192()
         }
+    }
+
+    sealed interface Event : OneOffEvent {
+        data class OnAssetClicked(val asset: SpendingAsset, val fromAccount: Account) : Event
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -244,7 +244,7 @@ class TransferViewModel @Inject constructor(
         val account = _state.value.fromAccount ?: return
 
         viewModelScope.launch {
-            sendEvent(Event.OnAssetClicked(asset, account))
+            sendEvent(Event.ShowAssetDetails(asset, account))
         }
     }
 
@@ -499,7 +499,7 @@ class TransferViewModel @Inject constructor(
     }
 
     sealed interface Event : OneOffEvent {
-        data class OnAssetClicked(val asset: SpendingAsset, val fromAccount: Account) : Event
+        data class ShowAssetDetails(val asset: SpendingAsset, val fromAccount: Account) : Event
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/SpendingAssetItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/SpendingAssetItem.kt
@@ -289,12 +289,6 @@ private fun NonFungibleSpendingAsset(
         )
         Spacer(modifier = Modifier.width(RadixTheme.dimensions.paddingDefault))
         Column {
-            Text(
-                text = nft.localId.formatted(),
-                color = RadixTheme.colors.gray2,
-                style = RadixTheme.typography.body2Regular
-            )
-
             nft.name?.let {
                 Text(
                     text = it,
@@ -302,6 +296,12 @@ private fun NonFungibleSpendingAsset(
                     style = RadixTheme.typography.body1HighImportance
                 )
             }
+
+            Text(
+                text = nft.localId.formatted(),
+                color = RadixTheme.colors.gray2,
+                style = RadixTheme.typography.body2Regular
+            )
 
             AnimatedVisibility(
                 visible = isExceedingBalance,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/SpendingAssetItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/SpendingAssetItem.kt
@@ -51,6 +51,7 @@ import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.transfer.SpendingAsset
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
+import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.radixdlt.sargon.NonFungibleLocalId
 import com.radixdlt.sargon.ResourceAddress
 import com.radixdlt.sargon.annotation.UsesSampleValues
@@ -70,6 +71,7 @@ import rdx.works.core.domain.resources.sampleMainnet
 fun SpendingAssetItem(
     modifier: Modifier = Modifier,
     asset: SpendingAsset,
+    onItemClick: () -> Unit,
     onAmountTyped: (String) -> Unit,
     onMaxClicked: () -> Unit
 ) {
@@ -102,13 +104,15 @@ fun SpendingAssetItem(
                 onEditStateChanged = {
                     isEditingState.value = it
                 },
-                onMaxClicked = onMaxClicked
+                onMaxClicked = onMaxClicked,
+                onItemClick = onItemClick
             )
 
             is SpendingAsset.NFT -> NonFungibleSpendingAsset(
                 resource = asset.resource,
                 nft = asset.item,
                 isExceedingBalance = asset.exceedingBalance,
+                onItemClick = onItemClick
             )
         }
     }
@@ -124,7 +128,8 @@ private fun ColumnScope.FungibleSpendingAsset(
     focusRequester: FocusRequester,
     isEditing: Boolean,
     onEditStateChanged: (Boolean) -> Unit,
-    onMaxClicked: () -> Unit
+    onMaxClicked: () -> Unit,
+    onItemClick: () -> Unit
 ) {
     Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
     Row(
@@ -132,13 +137,20 @@ private fun ColumnScope.FungibleSpendingAsset(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Thumbnail.Fungible(
-            modifier = Modifier.size(24.dp),
+            modifier = Modifier
+                .size(24.dp)
+                .throttleClickable {
+                    onItemClick()
+                },
             token = resource
         )
         Spacer(modifier = Modifier.width(RadixTheme.dimensions.paddingSmall))
         Text(
             modifier = Modifier
-                .weight(1f),
+                .weight(1f)
+                .throttleClickable {
+                    onItemClick()
+                },
             text = resource.displayTitle.ifEmpty {
                 stringResource(id = R.string.transactionReview_unknown)
             },
@@ -259,12 +271,16 @@ private fun NonFungibleSpendingAsset(
     resource: Resource.NonFungibleResource,
     nft: Resource.NonFungibleResource.Item,
     isExceedingBalance: Boolean,
+    onItemClick: () -> Unit
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .heightIn(min = 69.dp)
-            .padding(RadixTheme.dimensions.paddingSmall),
+            .padding(RadixTheme.dimensions.paddingSmall)
+            .throttleClickable {
+                onItemClick()
+            },
         verticalAlignment = Alignment.CenterVertically
     ) {
         Thumbnail.NonFungible(
@@ -328,7 +344,8 @@ fun SpendingAssetItemsPreview() {
                 },
                 onMaxClicked = {
                     firstAmount = "10"
-                }
+                },
+                onItemClick = {}
             )
 
             var secondAmount by remember { mutableStateOf("3.4") }
@@ -343,7 +360,8 @@ fun SpendingAssetItemsPreview() {
                 },
                 onMaxClicked = {
                     secondAmount = "10"
-                }
+                },
+                onItemClick = {}
             )
 
             val item = Resource.NonFungibleResource.Item(
@@ -376,7 +394,8 @@ fun SpendingAssetItemsPreview() {
                 },
                 onMaxClicked = {
                     secondAmount = "10"
-                }
+                },
+                onItemClick = {}
             )
 
             SpendingAssetItem(
@@ -390,7 +409,8 @@ fun SpendingAssetItemsPreview() {
                 },
                 onMaxClicked = {
                     secondAmount = "10"
-                }
+                },
+                onItemClick = {}
             )
         }
     }


### PR DESCRIPTION
## Description
* Each so called "spending asset" can be clicked and display its details with the already existing Asset Dialog.
* The clickable area for NFTs is the whole box, but for fungibles it is only the icon and the text since the rest is the area that needs to focus the text field.
* In order to invoke the dialog we need to also pass the `fromAccount.address` which is the account these assets belong to and are being prepared to transfer somewhere else.

## How to test

1. Do a transfer with multiple assets, fungibles, NFTs, LSUs, Pool Units and claims.
2. Click on them
3. The amount displayed in the dialog for fungibles, is the owned amount the from account owns.

## Video
<video src="https://github.com/radixdlt/babylon-wallet-android/assets/125959264/54b29bbe-ecb3-4e07-a517-befb865392b3">


## PR submission checklist
- [X] I have tested account to account transfer flow and have confirmed that it works
