### PR TITLE
[ABW-3579] Align depositors/resources icon section

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/AccountDepositSettingsTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/AccountDepositSettingsTypeContent.kt
@@ -272,7 +272,9 @@ private fun AccountRuleChangeRow(resource: Resource?, modifier: Modifier = Modif
             modifier = Modifier.weight(0.7f),
             color = RadixTheme.colors.gray1
         )
-        trailingSection()
+        Row(modifier = Modifier.weight(0.3f), horizontalArrangement = Arrangement.Center) {
+            trailingSection()
+        }
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
@@ -154,7 +154,7 @@ class TransactionSubmitDelegate @Inject constructor(
             }
             appEventBus.sendEvent(
                 AppEvent.Status.Transaction.InProgress(
-                    requestId = transactionRequest.interactionId.toString(),
+                    requestId = transactionRequest.interactionId,
                     transactionId = notarization.intentHash.bech32EncodedTxId,
                     isInternal = transactionRequest.isInternal,
                     blockUntilComplete = transactionRequest.blockUntilComplete,
@@ -163,7 +163,7 @@ class TransactionSubmitDelegate @Inject constructor(
             )
             transactionStatusClient.pollTransactionStatus(
                 txID = notarization.intentHash.bech32EncodedTxId,
-                requestId = transactionRequest.interactionId.toString(),
+                requestId = transactionRequest.interactionId,
                 transactionType = transactionRequest.transactionType,
                 endEpoch = notarization.endEpoch
             )


### PR DESCRIPTION
## Description
Align depositors/resources icon sections on tx preview screen.


## How to test

1. Preview tx that changes both resource rule and depositor and verify icons are centered.

## Screenshot

<img src="https://github.com/user-attachments/assets/6bb1eb2b-046e-4e2c-8a63-f09e4fa71c19" width=30%>

## PR submission checklist
- [x] I have tested account deposit settings preview
