### PR TITLE
Clear home cards state when resetting wallet

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/homecards/HomeCardsObserverWrapper.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/homecards/HomeCardsObserverWrapper.kt
@@ -10,6 +10,8 @@ import javax.inject.Inject
 interface HomeCardsObserverWrapper : HomeCardsObserver {
 
     fun observeHomeCards(): Flow<List<HomeCard>>
+
+    suspend fun clearCache()
 }
 
 class HomeCardsObserverWrapperImpl @Inject constructor() : HomeCardsObserverWrapper {
@@ -23,5 +25,9 @@ class HomeCardsObserverWrapperImpl @Inject constructor() : HomeCardsObserverWrap
 
     override fun handleCardsUpdate(cards: List<HomeCard>) {
         homeCardsFlow.tryEmit(cards)
+    }
+
+    override suspend fun clearCache() {
+        homeCardsFlow.emit(emptyList())
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/homecards/HomeCardsRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/homecards/HomeCardsRepository.kt
@@ -20,6 +20,8 @@ interface HomeCardsRepository {
     suspend fun walletCreated()
 
     suspend fun cardDismissed(card: HomeCard)
+
+    suspend fun clearCache()
 }
 
 class HomeCardsRepositoryImpl @Inject constructor(
@@ -62,5 +64,9 @@ class HomeCardsRepositoryImpl @Inject constructor(
                 .onFailure { Timber.w("Failed to dismiss home card. Error: $it") }
                 .onSuccess { Timber.d("$card dismissed") }
         }
+    }
+
+    override suspend fun clearCache() {
+        homeCardsObserver.clearCache()
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/DeleteWalletUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/DeleteWalletUseCase.kt
@@ -1,6 +1,7 @@
 package com.babylon.wallet.android.domain.usecases
 
 import com.babylon.wallet.android.data.dapp.PeerdroidClient
+import com.babylon.wallet.android.data.repository.homecards.HomeCardsRepository
 import com.babylon.wallet.android.data.repository.state.StateRepository
 import rdx.works.core.KeystoreManager
 import rdx.works.profile.cloudbackup.data.GoogleSignInManager
@@ -13,7 +14,8 @@ class DeleteWalletUseCase @Inject constructor(
     private val keystoreManager: KeystoreManager,
     private val googleSignInManager: GoogleSignInManager,
     private val stateRepository: StateRepository,
-    private val peerdroidClient: PeerdroidClient
+    private val peerdroidClient: PeerdroidClient,
+    private val homeCardsRepository: HomeCardsRepository
 ) {
 
     suspend operator fun invoke() {
@@ -24,5 +26,6 @@ class DeleteWalletUseCase @Inject constructor(
         keystoreManager.removeKeys().onFailure {
             Timber.d(it, "Failed to delete encryption keys")
         }
+        homeCardsRepository.clearCache()
     }
 }


### PR DESCRIPTION
## Description
This PR fixes the issue of unnecessarily displaying the home cards after factory resetting the wallet and creating a new one.


## How to test

1. Create a new wallet
2. Make sure the link connector home card is displayed
3. Troubleshooting -> Factory reset
4. Restore a backup
5. Make sure there are no home cards displayed
