### PR TITLE
Make testnet fiat repository singleton

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -103,8 +103,10 @@ fun WalletScreen(
 
     val lifecycleState by LocalLifecycleOwner.current.lifecycle.currentStateFlow.collectAsState()
     LaunchedEffect(lifecycleState) {
-        if (lifecycleState == Lifecycle.State.RESUMED) {
-            viewModel.processBufferedDeepLinkRequest()
+        when (lifecycleState) {
+            Lifecycle.State.STARTED -> viewModel.onStart()
+            Lifecycle.State.RESUMED -> viewModel.processBufferedDeepLinkRequest()
+            else -> {}
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -51,7 +51,6 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import rdx.works.core.domain.assets.AssetPrice
@@ -124,6 +123,10 @@ class WalletViewModel @Inject constructor(
 
     override fun initialState() = State()
 
+    fun onStart() {
+        loadAssets(refreshType = RefreshType.Manual(overrideCache = false, showRefreshIndicator = false))
+    }
+
     fun popUpScreen(): StateFlow<PopUpScreen?> = popUpScreen
 
     fun onPopUpScreenDismissed() {
@@ -189,9 +192,7 @@ class WalletViewModel @Inject constructor(
     private fun observeWalletAssets() {
         combine(
             accountsFlow,
-            refreshFlow.onStart {
-                loadAssets(refreshType = RefreshType.Manual(overrideCache = false, showRefreshIndicator = false))
-            }
+            refreshFlow
         ) { accounts, refreshType ->
             _state.update { it.loadingAssets(accounts = accounts, refreshType = refreshType) }
 


### PR DESCRIPTION
## Description
When testing locally on testnet in debug builds Umair noticed that the prices were not identical when moving from account screen to wallet screen. This is due to 2 reasons:

1. We need to request for fresh fiat data when the wallet screen starts, even when it comes to foreground. So in order to always be up to date, we request for new data `onStart` instead on ViewModel's `init`.
2. The testnet cache was invalidated between screens since a new instance was always being injected, so the amounts were shown completely different. 
    1. One change is to simply make the testnet repository a singleton. This will maintain the cache of random "fake" fiat values for better and easier design testing.
    2. The price fluctuation was made smaller so to "replicate" real price fluctuations happening on real tokens. Note that XRD token in testnet still gets the price of mainnet xrd token.

## How to test
1. Navigate back and forth between account and wallet screens (if you use a previous version you will experience wildly different values between screens)
2. Notice that amounts remain consistent.
