### PR TITLE
Don't fail transaction preview when signers are not found in profile 

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -85,7 +85,6 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
         data object ConvertManifest : PrepareTransactionException()
         data class BuildTransactionHeader(override val cause: Throwable) : PrepareTransactionException(cause)
         data object FailedToFindAccountWithEnoughFundsToLockFee : PrepareTransactionException()
-        data object FailedToFindSigningEntities : PrepareTransactionException()
         data object CompileTransactionIntent : PrepareTransactionException()
         data class SignCompiledTransactionIntent(override val cause: Throwable? = null) :
             PrepareTransactionException(cause)
@@ -99,7 +98,6 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
         override val ceError: ConnectorExtensionError
             get() = when (this) {
                 is BuildTransactionHeader -> DappWalletInteractionErrorType.FAILED_TO_PREPARE_TRANSACTION
-                is FailedToFindSigningEntities -> DappWalletInteractionErrorType.FAILED_TO_PREPARE_TRANSACTION
                 is ConvertManifest -> DappWalletInteractionErrorType.FAILED_TO_PREPARE_TRANSACTION
                 is PrepareNotarizedTransaction -> DappWalletInteractionErrorType.FAILED_TO_SIGN_TRANSACTION
                 is SubmitNotarizedTransaction -> DappWalletInteractionErrorType.FAILED_TO_SUBMIT_TRANSACTION
@@ -372,9 +370,6 @@ fun RadixWalletException.PrepareTransactionException.toUserFriendlyMessage(conte
         when (this) {
             is RadixWalletException.PrepareTransactionException.BuildTransactionHeader -> R.string.error_transactionFailure_header
             is RadixWalletException.PrepareTransactionException.ConvertManifest -> R.string.error_transactionFailure_manifest
-            is RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities ->
-                R.string.error_transactionFailure_missingSigners
-
             is RadixWalletException.PrepareTransactionException.PrepareNotarizedTransaction -> R.string.error_transactionFailure_prepare
             is RadixWalletException.PrepareTransactionException.SubmitNotarizedTransaction -> R.string.error_transactionFailure_submit
             is RadixWalletException.PrepareTransactionException.FailedToFindAccountWithEnoughFundsToLockFee ->

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/ResolveNotaryAndSignersUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/ResolveNotaryAndSignersUseCase.kt
@@ -1,7 +1,6 @@
 package com.babylon.wallet.android.domain.usecases
 
 import com.babylon.wallet.android.data.transaction.NotaryAndSigners
-import com.babylon.wallet.android.domain.RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.IdentityAddress
 import com.radixdlt.sargon.extensions.Curve25519SecretKey
@@ -23,10 +22,10 @@ class ResolveNotaryAndSignersUseCase @Inject constructor(
         val accounts = profileUseCase().activeAccountsOnCurrentNetwork
         val personas = profileUseCase().activePersonasOnCurrentNetwork
 
-        accountsAddressesRequiringAuth.map { address ->
-            accounts.find { it.address == address }?.asProfileEntity() ?: throw FailedToFindSigningEntities
-        } + personaAddressesRequiringAuth.map { address ->
-            personas.find { it.address == address }?.asProfileEntity() ?: throw FailedToFindSigningEntities
+        accountsAddressesRequiringAuth.mapNotNull { address ->
+            accounts.find { it.address == address }?.asProfileEntity()
+        } + personaAddressesRequiringAuth.mapNotNull { address ->
+            personas.find { it.address == address }?.asProfileEntity()
         }
     }.map {
         NotaryAndSigners(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/model/TransactionErrorMessage.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/model/TransactionErrorMessage.kt
@@ -19,7 +19,6 @@ data class TransactionErrorMessage(
     val isTerminalError: Boolean
         get() = isNoMnemonicErrorVisible ||
             error is RadixWalletException.PrepareTransactionException.ReceivingAccountDoesNotAllowDeposits ||
-            error is RadixWalletException.PrepareTransactionException.FailedToFindSigningEntities ||
             error is RadixWalletException.LedgerCommunicationException.FailedToSignTransaction ||
             error is RadixWalletException.PrepareTransactionException.SignCompiledTransactionIntent
 


### PR DESCRIPTION
## Description
- if we don't find signers in a profile - we run tx through gateway anyway. 

## How to test

1. Follow the thread [here](https://rdxworks.slack.com/archives/C05V4202J90/p1720906856387759?thread_ts=1720795701.179099&cid=C05V4202J90) and use two previews provided by users to test the bug.
2. First manifest is creating advanced account controlled by a badge and depositing some XRD into it. To make preview work, replace account in 1st and last instruction with account you control, and add empty tuple to value marked as an error - using manifest editor on the left pane.
3. Write down created entities.
4. Open 2nd manifest, modify account in 1st and last instruction to be the one you control. Use created badge address as resource address in 1st instruction. Use created advanced account address as account address in 2nd instruction.
5. Both transaction should complete after the fix, before the fix 2nd transaction will fail on preview.

Contact me in case of assistance needed in testing.

## PR submission checklist
- [x] I have tested scenario described by the user.
