### PR TITLE
Fix flicker issue in metadata view

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ExpandableText.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ExpandableText.kt
@@ -89,7 +89,7 @@ fun ExpandableText(
     }
 
     ClickableText(
-        modifier = modifier.animateContentSize(),
+        modifier = modifier,
         text = resultText,
         onClick = { offset ->
             onClick(offset)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ExpandableText.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/ExpandableText.kt
@@ -1,6 +1,5 @@
 package com.babylon.wallet.android.presentation.ui.composables
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect


### PR DESCRIPTION
## Description
* The metadata view when rendering an `ExpandableText` like a string metadata, was flickering on occasion when displayed in asset details dialog (which is a bottom sheet)
* Also observed previously in @giannis-rdx PR for #1030 when an animate modifier is used with `BottomSheetDialogWrapper` does not work properly.


## How to test

1. Check the video on the ticket to see the problem
2. Notify me to send you such NFT with such metadata or you can create an NFT with a custom string metadata with more than 2 lines of text.