### PR TITLE
Fix NFTs pages request after account refresh

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -412,7 +412,6 @@ class TransferViewModel @Inject constructor(
                 val isFiatBalancesEnabled: Boolean = true,
                 val assetsWithAssetsPrices: Map<Asset, AssetPrice?>? = null,
                 private val initialAssetAddress: ImmutableSet<String>, // Used to compute the difference between chosen assets
-                val nonFungiblesWithPendingNFTs: Set<ResourceAddress> = setOf(),
                 val pendingStakeUnits: Boolean = false,
                 val targetAccount: TargetAccount,
                 val assetsViewState: AssetsViewState = AssetsViewState.init(),
@@ -436,7 +435,7 @@ class TransferViewModel @Inject constructor(
                     get() = targetAccount.spendingAssets.size
 
                 fun onNFTsLoading(forResource: Resource.NonFungibleResource): ChooseAssets {
-                    return copy(nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs + forResource.address)
+                    return copy(assetsViewState = assetsViewState.nextPagePending(forResource.address))
                 }
 
                 fun onNFTsReceived(forResource: Resource.NonFungibleResource): ChooseAssets {
@@ -451,14 +450,14 @@ class TransferViewModel @Inject constructor(
                                 mutation = { NonFungibleCollection(forResource) }
                             )
                         ),
-                        nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs - forResource.address
+                        assetsViewState = assetsViewState.nextPageReceived(forResource.address)
                     )
                 }
 
                 fun onNFTsError(forResource: Resource.NonFungibleResource, error: Throwable): ChooseAssets {
                     if (assets?.nonFungibles == null) return this
                     return copy(
-                        nonFungiblesWithPendingNFTs = nonFungiblesWithPendingNFTs - forResource.address,
+                        assetsViewState = assetsViewState.nextPageReceived(forResource.address),
                         uiMessage = UiMessage.ErrorMessage(error = error)
                     )
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
@@ -114,7 +114,7 @@ class AssetsChooserDelegate @Inject constructor(
     fun onNextNFTsPageRequest(resource: Resource.NonFungibleResource) {
         val sheet = _state.value.sheet as? Sheet.ChooseAssets ?: return
         val account = _state.value.fromAccount ?: return
-        if (resource.address !in sheet.nonFungiblesWithPendingNFTs) {
+        if (resource.address !in sheet.assetsViewState.fetchingNFTsPerCollection) {
             updateSheetState { state -> state.onNFTsLoading(resource) }
             viewModelScope.launch {
                 getNextNFTsPageUseCase(account, resource)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsView.kt
@@ -95,9 +95,11 @@ private fun LazyListScope.loadingAssets() {
 
 data class AssetsViewState(
     val selectedTab: AssetsTab,
-    val collapsedCollections: Map<String, Boolean>
+    val collapsedCollections: Map<String, Boolean>,
+    val fetchingNFTsPerCollection: Set<ResourceAddress>,
 ) {
     fun isCollapsed(collectionId: String) = collapsedCollections.getOrDefault(collectionId, true)
+
     fun onCollectionToggle(collectionId: String): AssetsViewState {
         val isCollapsed = isCollapsed(collectionId)
         val collapsedCollections = collapsedCollections.toMutableMap().apply {
@@ -106,11 +108,21 @@ data class AssetsViewState(
 
         return copy(collapsedCollections = collapsedCollections)
     }
+
+    fun nextPagePending(collectionId: ResourceAddress): AssetsViewState = copy(
+        fetchingNFTsPerCollection = fetchingNFTsPerCollection.toMutableSet().apply { add(collectionId) }
+    )
+
+    fun nextPageReceived(collectionId: ResourceAddress): AssetsViewState = copy(
+        fetchingNFTsPerCollection = fetchingNFTsPerCollection.toMutableSet().apply { remove(collectionId) }
+    )
+
     companion object {
         fun init(selectedTab: AssetsTab = AssetsTab.Tokens): AssetsViewState {
             return AssetsViewState(
                 selectedTab = selectedTab,
-                collapsedCollections = emptyMap()
+                collapsedCollections = emptyMap(),
+                fetchingNFTsPerCollection = emptySet()
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
@@ -67,7 +67,7 @@ fun LazyListScope.nftsTab(
             key = { index -> "${nonFungible.collection.address}$index" },
             contentType = { "nft" }
         ) { index ->
-            NFTItem(index, nonFungible.collection, action)
+            NFTItem(index, nonFungible.collection, state, action)
         }
     }
 }
@@ -76,6 +76,7 @@ fun LazyListScope.nftsTab(
 private fun NFTItem(
     index: Int,
     collection: Resource.NonFungibleResource,
+    state: AssetsViewState,
     action: AssetsViewAction
 ) {
     AssetCard(
@@ -94,9 +95,8 @@ private fun NFTItem(
                 action = action
             )
         } else {
-            LaunchedEffect(index, collection.items.size) {
-                // First shimmering item
-                if (index == collection.items.size) {
+            LaunchedEffect(collection.address, state.fetchingNFTsPerCollection) {
+                if (collection.address !in state.fetchingNFTsPerCollection) {
                     action.onNextNFtsPageRequest(collection)
                 }
             }


### PR DESCRIPTION
## Description
* NFTs list was relying on triggering NFTs page when the index of the shimmering view was the the same as the current collections' size. So that used to mean that when the user scrolls to the bottom, the next page was received.
* In the current bug, since the account refresh was requested, the items were invalidated, making the collection having 0 items. So in order for the next page to be triggered, the user should scroll back to the first item.
* Clearly this logic was wrong. Now whenever a shimmering view is appeared, meaning that we lack of needed data to display the NFT collection, we need to request for the next nfts page. We should also mark this specific collection as pending so, multiple renders to the list do not cause the request to be triggered constantly.


## How to test
1. Add an NFT collection with many NFTs in your account. I personally tried it with 60 NFT items. So that the client requests 2 pages of data. (this is not so important though)
2. Scroll the list of NFTs down so the first NFT is totally hidden.
3. Wait 1 minute for account to be refreshed on the background.
4. Now you should be able to see the items again, instead seeing the shimmering effect.
5. The same applies to the transfer screen's select assets sheet.
