### PR TITLE
Fix fiat value on error

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
@@ -403,7 +403,9 @@ class AccountViewModel @Inject constructor(
             data class Enabled(
                 val prices: Map<Asset, AssetPrice?>
             ) : PricesState {
-                override val totalPrice: FiatPrice = run {
+                override val totalPrice: FiatPrice? = run {
+                    if (prices.isEmpty()) return@run null
+
                     var total = 0.toDecimal192()
                     var currency = SupportedCurrency.USD
                     prices.values.mapNotNull { it }
@@ -443,7 +445,12 @@ class AccountViewModel @Inject constructor(
 
         fun onAssetsError(error: Throwable): State = copy(
             refreshType = RefreshType.None,
-            uiMessage = if (refreshType is RefreshType.Automatic) null else UiMessage.ErrorMessage(error = error)
+            uiMessage = if (refreshType is RefreshType.Automatic) null else UiMessage.ErrorMessage(error = error),
+            pricesState = if (pricesState is PricesState.None) {
+                PricesState.Enabled(emptyMap())
+            } else {
+                pricesState
+            }
         )
 
         fun onAssetsReceived(assets: Assets?): State = copy(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/TroubleshootingSettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/TroubleshootingSettingsViewModel.kt
@@ -1,7 +1,6 @@
 package com.babylon.wallet.android.presentation.settings.troubleshooting
 
 import androidx.lifecycle.viewModelScope
-import com.babylon.wallet.android.BuildConfig
 import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiState
 import com.babylon.wallet.android.presentation.settings.SettingsItem
@@ -44,7 +43,7 @@ class TroubleshootingSettingsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            if (getProfileUseCase().currentGateway.network.id != NetworkId.MAINNET && !BuildConfig.EXPERIMENTAL_FEATURES_ENABLED) {
+            if (getProfileUseCase().currentGateway.network.id != NetworkId.MAINNET) {
                 _state.update { state ->
                     val updatedSettings =
                         state.settings.filterNot {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -414,6 +414,17 @@ class WalletViewModel @Inject constructor(
                 } else {
                     accountWithAssets
                 }
+            },
+            prices = if (prices is PricesState.None) {
+                // In case that prices were never received, show an error
+                // in the prices state
+                PricesState.Enabled(
+                    pricesPerAccount = accountsWithAssets?.associate {
+                        it.account.address to null
+                    }.orEmpty()
+                )
+            } else {
+                prices
             }
         )
 


### PR DESCRIPTION
## Description
* When an error is occurred the first time we try to resolve assets and no fiat values are yet received we need to show an error in the fiat value too. This was not handled in both wallet and account screen.
* Disabled Olympia recovery in debug builds. If you try to recover olympia accounts while you are on stokenet, you will import "mainnet" accounts while in stokenet. This will result in an error from GW. This is why this bug was surfaced.

## How to test
1. Try to force an error while opening the app with no prior cache. You can maybe do that by importing an old wallet, or importing Umair's wallet that has mainnet accounts in stokenet.
2. See that the fiat value displays as error instead of shimerring.