### PR TITLE
update dApp detail view

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/ApprovedDappsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/ApprovedDappsViewModel.kt
@@ -27,13 +27,13 @@ class ApprovedDappsViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             _state.update { it.copy(isLoading = true) }
-            dAppConnectionRepository.getAuthorizedDApps().collect { authorisedDApps ->
-                val addresses = authorisedDApps.map { it.dappDefinitionAddress }.toSet()
+            dAppConnectionRepository.getAuthorizedDApps().collect { approvedDapps ->
+                val addresses = approvedDapps.map { it.dappDefinitionAddress }.toSet()
                 getDAppsUseCase(
                     definitionAddresses = addresses,
                     needMostRecentData = false
                 ).onSuccess { dApps ->
-                    val result = authorisedDApps.mapNotNull { authorisedDApp ->
+                    val result = approvedDapps.mapNotNull { authorisedDApp ->
                         dApps.find { it.dAppAddress == authorisedDApp.dappDefinitionAddress }
                     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailViewModel.kt
@@ -91,7 +91,6 @@ class DappDetailViewModel @Inject constructor(
         viewModelScope.launch {
             dAppConnectionRepository.getAuthorizedDAppFlow(args.dappDefinitionAddress).collect {
                 if (it == null) {
-                    sendEvent(DappDetailEvent.LastPersonaDeleted)
                     return@collect
                 } else {
                     authorizedDapp = checkNotNull(dAppConnectionRepository.getAuthorizedDApp(args.dappDefinitionAddress))
@@ -174,8 +173,12 @@ class DappDetailViewModel @Inject constructor(
     }
 
     fun onDisconnectPersona(persona: Persona) {
+        val lastPersona = _state.value.personas.size == 1 && _state.value.personas.first().address == persona.address
         viewModelScope.launch {
             dAppConnectionRepository.deletePersonaForDApp(args.dappDefinitionAddress, persona.address)
+            if (lastPersona) {
+                sendEvent(DappDetailEvent.DappDeleted)
+            }
         }
     }
 
@@ -245,7 +248,6 @@ sealed interface DappDetailEvent : OneOffEvent {
     data class EditPersona(val personaAddress: IdentityAddress, val requiredPersonaFields: RequiredPersonaFields? = null) :
         DappDetailEvent
 
-    data object LastPersonaDeleted : DappDetailEvent
     data object DappDeleted : DappDetailEvent
     data class OnFungibleClick(val resource: Resource.FungibleResource) : DappDetailEvent
     data class OnNonFungibleClick(val resource: Resource.NonFungibleResource) : DappDetailEvent

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SlideToSignButton.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SlideToSignButton.kt
@@ -105,7 +105,12 @@ fun SlideToSignButton(
                         drawContent()
                         drawRect(
                             buttonColor,
-                            size = Size(draggableState.requireOffset().roundToInt() + indicatorWidthPx - textPositionInRoot.x, size.height)
+                            size = Size(
+                                draggableState
+                                    .requireOffset()
+                                    .roundToInt() + indicatorWidthPx - textPositionInRoot.x,
+                                size.height
+                            )
                         )
                     }
                 },
@@ -136,7 +141,8 @@ fun SlideToSignButton(
             modifier = Modifier
                 .offset {
                     IntOffset(
-                        draggableState.requireOffset()
+                        draggableState
+                            .requireOffset()
                             .roundToInt()
                             .coerceIn(0, maxWidthPx.roundToInt()),
                         0

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/WarningButton.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/WarningButton.kt
@@ -1,18 +1,20 @@
 package com.babylon.wallet.android.presentation.ui.composables
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 
 @Composable
 fun WarningButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
     Button(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth().heightIn(min = 50.dp),
         onClick = onClick,
         shape = RadixTheme.shapes.roundedRectSmall,
         colors = ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/DappCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/DappCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -20,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.composables.displayName
+import com.babylon.wallet.android.presentation.ui.modifier.defaultCardShadow
 import rdx.works.core.domain.DApp
 
 @Composable
@@ -31,7 +31,7 @@ fun DappCard(
 ) {
     Row(
         modifier = modifier
-            .shadow(elevation = elevation, shape = RadixTheme.shapes.roundedRectMedium)
+            .defaultCardShadow(elevation = elevation)
             .clip(RadixTheme.shapes.roundedRectMedium)
             .fillMaxWidth()
             .background(RadixTheme.colors.white, shape = RadixTheme.shapes.roundedRectMedium)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/FungibleCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/FungibleCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -20,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.model.displayTitleAsToken
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
+import com.babylon.wallet.android.presentation.ui.modifier.defaultCardShadow
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import rdx.works.core.domain.resources.Resource
 
@@ -33,7 +33,7 @@ fun FungibleCard(
 ) {
     Row(
         modifier = modifier
-            .shadow(elevation = elevation, shape = RadixTheme.shapes.roundedRectMedium)
+            .defaultCardShadow(elevation = elevation)
             .clip(RadixTheme.shapes.roundedRectMedium)
             .fillMaxWidth()
             .background(RadixTheme.colors.white, shape = RadixTheme.shapes.roundedRectMedium)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/NonFungibleCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/NonFungibleCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -21,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
+import com.babylon.wallet.android.presentation.ui.modifier.defaultCardShadow
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import rdx.works.core.domain.resources.Resource
 
@@ -34,7 +34,7 @@ fun NonFungibleCard(
 ) {
     Row(
         modifier = modifier
-            .shadow(elevation = elevation, shape = RadixTheme.shapes.roundedRectMedium)
+            .defaultCardShadow(elevation = elevation)
             .clip(RadixTheme.shapes.roundedRectMedium)
             .fillMaxWidth()
             .background(RadixTheme.colors.white, shape = RadixTheme.shapes.roundedRectMedium)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/PersonaCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/PersonaCard.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -33,6 +32,7 @@ import com.babylon.wallet.android.domain.usecases.SecurityPromptType
 import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.PersonaUiModel
 import com.babylon.wallet.android.presentation.ui.composables.SecurityPromptLabel
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
+import com.babylon.wallet.android.presentation.ui.modifier.defaultCardShadow
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.radixdlt.sargon.Persona
 import com.radixdlt.sargon.annotation.UsesSampleValues
@@ -51,7 +51,7 @@ fun PersonaCard(
 ) {
     Column(
         modifier = modifier
-            .shadow(elevation = elevation, shape = RadixTheme.shapes.roundedRectMedium)
+            .defaultCardShadow(elevation = elevation)
             .clip(RadixTheme.shapes.roundedRectMedium)
             .fillMaxWidth()
             .background(RadixTheme.colors.white, shape = RadixTheme.shapes.roundedRectMedium)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/modifier/DefaultCardShadow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/modifier/DefaultCardShadow.kt
@@ -1,0 +1,22 @@
+package com.babylon.wallet.android.presentation.ui.modifier
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+
+fun Modifier.defaultCardShadow(
+    elevation: Dp,
+    shape: Shape? = null,
+    color: Color? = null
+) = composed {
+    this.shadow(
+        elevation = elevation,
+        shape = shape ?: RadixTheme.shapes.roundedRectMedium,
+        ambientColor = color ?: RadixTheme.colors.gray2,
+        spotColor = color ?: RadixTheme.colors.gray2
+    )
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/modifier/RadixPlaceHolder.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/modifier/RadixPlaceHolder.kt
@@ -14,7 +14,7 @@ fun Modifier.radixPlaceholder(
     shape: Shape? = null,
     color: Color? = null
 ) = composed {
-    placeholder(
+    this.placeholder(
         visible = visible,
         color = color ?: RadixTheme.colors.gray4,
         shape = shape ?: RadixTheme.shapes.roundedRectDefault,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/modifier/ThrottleClickable.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/modifier/ThrottleClickable.kt
@@ -14,7 +14,7 @@ fun Modifier.throttleClickable(
 ): Modifier {
     return composed {
         val lastClickMs = remember { mutableLongStateOf(0L) }
-        clickable(enabled = enabled) {
+        this.clickable(enabled = enabled) {
             ClickListenerUtils.throttleOnClick(
                 lastClickMs = lastClickMs,
                 onClick = onClick,


### PR DESCRIPTION
## Description
Tickets 
https://radixdlt.atlassian.net/browse/ABW-3548
https://radixdlt.atlassian.net/browse/ABW-3551
https://radixdlt.atlassian.net/browse/ABW-3609

- updated UI of dApp detail screen based on zeplin designs. Added bunch of previews to account for situation when some data is missing
- minor UI changes to approved dapps screen
- added default card composable trying to get as close to zeplin design as I could with shadow color
- fixed navigation issue when forgetting the Dapp, also Android copy on the confirmation dialog was wrong - updated as well
- we use dimensions as multiplies of 4.dp, some Zeplin screens had inonsistent paddings, like for example 18 (made it 16.dp), 21 (made it 24.dp) and so on.


## How to test

1. Go through dApp details screen/approved dApps
2. Test ABW-3609 according to steps provided there
