### PR TITLE
Fix hiding fiat value in release stokenet

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -291,6 +291,10 @@ private fun WalletAccountList(
                 )
                 Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
             }
+        } else {
+            item {
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
+            }
         }
 
         itemsIndexed(state.accountUiItems) { _, accountWithAssets ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -222,7 +222,7 @@ class WalletViewModel @Inject constructor(
 
                     if (pricesError != null && pricesError is FiatPriceRepository.PricesNotSupportedInNetwork) {
                         _state.update { it.disableFiatPrices() }
-                        break
+                        return@onEach
                     }
                 }
 


### PR DESCRIPTION
## Description
* Even though the code was disabling fiat value, did not move the for loop since it used a simple `break` thus ending up enabling again the fiat prices with empty values.