### PR TITLE
Fetch XRD amount when vault info is not available

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/StateEntityDetailsApiHelper.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/StateEntityDetailsApiHelper.kt
@@ -98,6 +98,59 @@ suspend fun StateApi.fetchAccountGatewayDetails(
     items
 }
 
+/**
+ * Fetches how much of the [resourceAddress] the [accounts] own.
+ *
+ * We first need to chunk the account addresses since the entity details request can only load
+ * up to [ENTITY_DETAILS_PAGE_LIMIT]. Then for each account we need to find details about the input [resourceAddress].
+ * Resources are paginated too. If the [resourceAddress] is not found in the first page and more pages exist, the method
+ * paginates until the resource is found. If the resource is found then attaches the amount to the account address and skips any more
+ * pages and resources for this account, continuing the loop for the next account. This method aims to make the minimum
+ * requests in order to be able to answer the input.
+ */
+suspend fun StateApi.fetchFungibleAmountPerAccount(
+    accounts: Set<AccountAddress>,
+    resourceAddress: ResourceAddress,
+    onStateVersion: Long?,
+) = runCatching {
+    val resourceAddressString = resourceAddress.string
+    val resourceAmountPerAccountAddress = mutableMapOf<AccountAddress, Decimal192>()
+
+    paginateDetails(
+        addresses = accounts.map { it.string }.toSet(),
+        stateVersion = onStateVersion
+    ) { chunkedAccounts ->
+        chunkedAccounts.items.forEach { accountItem ->
+            val resourceFound = accountItem.fungibleResources?.items?.find { it.resourceAddress == resourceAddressString }
+
+            if (resourceFound != null) {
+                resourceAmountPerAccountAddress[AccountAddress.init(accountItem.address)] = resourceFound.amountDecimal
+                return@forEach
+            } else {
+                var nextCursor = accountItem.fungibleResources?.nextCursor
+                while (nextCursor != null) {
+                    val pageResponse = entityFungiblesPage(
+                        StateEntityFungiblesPageRequest(
+                            address = accountItem.address,
+                            cursor = nextCursor,
+                            aggregationLevel = ResourceAggregationLevel.Vault,
+                            atLedgerState = LedgerStateSelector(stateVersion = chunkedAccounts.ledgerState.stateVersion)
+                        )
+                    ).toResult().getOrNull()
+                    nextCursor = pageResponse?.nextCursor
+
+                    pageResponse?.items?.find { it.resourceAddress == resourceAddressString }?.let { resource ->
+                        resourceAmountPerAccountAddress[AccountAddress.init(accountItem.address)] = resource.amountDecimal
+                        return@forEach
+                    }
+                }
+            }
+        }
+    }
+
+    resourceAmountPerAccountAddress
+}
+
 @Suppress("LongMethod")
 suspend fun StateApi.fetchPools(
     poolAddresses: Set<PoolAddress>,

--- a/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/StateEntityDetailsApiHelper.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/StateEntityDetailsApiHelper.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package com.babylon.wallet.android.data.gateway.extensions
 
 import com.babylon.wallet.android.data.gateway.apis.StateApi
@@ -112,7 +114,7 @@ suspend fun StateApi.fetchFungibleAmountPerAccount(
     accounts: Set<AccountAddress>,
     resourceAddress: ResourceAddress,
     onStateVersion: Long?,
-) = runCatching {
+): Result<Map<AccountAddress, Decimal192>> = runCatching {
     val resourceAddressString = resourceAddress.string
     val resourceAmountPerAccountAddress = mutableMapOf<AccountAddress, Decimal192>()
 

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/state/AccountsStateCache.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/state/AccountsStateCache.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.data.repository.state
 
 import com.babylon.wallet.android.data.gateway.apis.StateApi
 import com.babylon.wallet.android.data.gateway.extensions.fetchAccountGatewayDetails
+import com.babylon.wallet.android.data.gateway.extensions.fetchFungibleAmountPerAccount
 import com.babylon.wallet.android.data.gateway.extensions.fetchPools
 import com.babylon.wallet.android.data.gateway.extensions.fetchValidators
 import com.babylon.wallet.android.data.gateway.extensions.fetchVaultDetails
@@ -20,11 +21,13 @@ import com.babylon.wallet.android.domain.model.assets.AccountWithAssets
 import com.babylon.wallet.android.utils.truncatedHash
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.AccountAddress
+import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.PoolAddress
 import com.radixdlt.sargon.ValidatorAddress
+import com.radixdlt.sargon.VaultAddress
 import com.radixdlt.sargon.extensions.formatted
 import com.radixdlt.sargon.extensions.init
-import com.radixdlt.sargon.extensions.orZero
+import com.radixdlt.sargon.extensions.toDecimal192
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -134,21 +137,53 @@ class AccountsStateCache @Inject constructor(
         }
         .flowOn(dispatcher)
 
-    suspend fun getOwnedXRD(accounts: List<Account>) = withContext(dispatcher) {
-        if (accounts.isEmpty()) return@withContext Result.success(emptyMap())
-
-        val xrdAddress = XrdResource.address(networkId = accounts.first().networkId)
-
-        val accountsWithXRDVaults = accounts.associateWith { account ->
-            dao.getAccountResourceJoin(accountAddress = account.address, resourceAddress = xrdAddress)?.vaultAddress
-        }
-
+    /**
+     * First checks if we have a vault address cached for XRD. If so we can immediately request [fetchVaultDetails] in order to query
+     * the XRD amount at that vault directly. If no vault information is found, we need to make the more expensive request
+     * of fetching account entity details. For more info about this method check [fetchFungibleAmountPerAccount].
+     */
+    suspend fun getOwnedXRD(accounts: List<Account>): Result<Map<Account, Decimal192>> = withContext(dispatcher) {
         runCatching {
-            val vaultsWithAmounts = api.fetchVaultDetails(accountsWithXRDVaults.mapNotNull { it.value }.toSet())
+            if (accounts.isEmpty()) return@withContext Result.success(emptyMap())
 
-            accountsWithXRDVaults.mapValues { entry ->
-                entry.value?.let { vaultsWithAmounts[it] }.orZero()
+            val xrdAddress = XrdResource.address(networkId = accounts.first().networkId)
+            // Initialize requesting accounts with 0 amounts
+            val result = accounts.associateWith { 0.toDecimal192() }.toMutableMap()
+
+            val accountsWithMaybeXRDVaults: Map<Account, VaultAddress?> = accounts.associateWith { account ->
+                dao.getAccountResourceJoin(accountAddress = account.address, resourceAddress = xrdAddress)?.vaultAddress
             }
+
+            // For accounts that we know the vault address were the XRD is stored, we can query directly
+            val vaultsPerAccount = accountsWithMaybeXRDVaults.filter { it.value != null }.map {
+                it.value!! to it.key
+            }.toMap()
+            api.fetchVaultDetails(vaultsPerAccount.keys).forEach { entry ->
+                val xrdAmount = entry.value
+                val account = vaultsPerAccount[entry.key]
+
+                if (account != null) {
+                    result[account] = xrdAmount
+                }
+            }
+
+            // For accounts with no vault information, we need to find the resource while requesting entity details for such accounts
+            val accountsWithNoVaults = accountsWithMaybeXRDVaults.filter { it.value == null }.map { it.key }.toSet()
+            if (accountsWithNoVaults.isNotEmpty()) {
+                api.fetchFungibleAmountPerAccount(
+                    accounts = accountsWithNoVaults.map { it.address }.toSet(),
+                    resourceAddress = xrdAddress,
+                    onStateVersion = null
+                ).getOrNull()?.forEach { entry ->
+                    val account = accountsWithNoVaults.find { it.address == entry.key }
+
+                    if (account != null) {
+                        result[account] = entry.value
+                    }
+                }
+            }
+
+            result
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/state/AccountsStateCache.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/state/AccountsStateCache.kt
@@ -156,7 +156,7 @@ class AccountsStateCache @Inject constructor(
 
             // For accounts that we know the vault address were the XRD is stored, we can query directly
             val vaultsPerAccount = accountsWithMaybeXRDVaults.filter { it.value != null }.map {
-                it.value!! to it.key
+                requireNotNull(it.value) to it.key
             }.toMap()
             api.fetchVaultDetails(vaultsPerAccount.keys).forEach { entry ->
                 val xrdAmount = entry.value


### PR DESCRIPTION
## Description
* When opening transaction review, we need to fetch XRD information for all our accounts that can pay for fees. We need to do that as quick as possible.
* When vault information for XRD is cached we can directly look at the vault on GW.
* But when none such info exists, we need to fetch entity details for the account and find the XRD amount. This is a bit more slow but the only alternative when the wallet hasn't yet fetched any prior information about XRD.
* This PR fixes the method in `AccountsStateCache` to take care of this case and also introduces a simple method on api that fetches any amount information for accounts for a specific resource address. Please look at the documentation for more details.