### PR TITLE
Fix spinner not hiding when disabling fiat prices

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -435,7 +435,10 @@ class WalletViewModel @Inject constructor(
             )
         )
 
-        fun disableFiatPrices() = copy(prices = PricesState.Disabled)
+        fun disableFiatPrices() = copy(
+            prices = PricesState.Disabled,
+            refreshType = RefreshType.None,
+        )
 
         enum class AccountTag {
             LEDGER_BABYLON, DAPP_DEFINITION, LEDGER_LEGACY, LEGACY_SOFTWARE


### PR DESCRIPTION
## Description
* When in release mode on stokenet, since fiat prices need to be disabled, after the wallet is refreshed, the spinner needs to hide.

