### PR TITLE
Avoid NFT name truncation when displayed in account or asset details

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/model/DisplaySubtitle.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/model/DisplaySubtitle.kt
@@ -58,5 +58,5 @@ fun Resource.NonFungibleResource.displaySubtitle(): String = amount.toString()
 
 @Composable
 fun Resource.NonFungibleResource.Item.displaySubtitle(): String = remember(this) {
-    name?.takeIf { it.isNotBlank() } ?: localId.formatted()
+    nameTruncated?.takeIf { it.isNotBlank() } ?: localId.formatted()
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/AssetDialog.kt
@@ -140,7 +140,7 @@ fun Asset.displayTitle() = when (this) {
     is Asset.NonFungible -> {
         val item = resource.items.firstOrNull()
         if (item != null) {
-            item.name
+            item.nameTruncated
         } else {
             resource.name
         }

--- a/core/src/main/java/rdx/works/core/domain/resources/Resource.kt
+++ b/core/src/main/java/rdx/works/core/domain/resources/Resource.kt
@@ -213,7 +213,11 @@ sealed class Resource {
             }
 
             val name: String? by lazy {
-                metadata.name()?.truncate(maxNumberOfCharacters = NAME_MAX_CHARS)
+                metadata.name()
+            }
+
+            val nameTruncated: String? by lazy {
+                name?.truncate(maxNumberOfCharacters = NAME_MAX_CHARS)
             }
 
             val description: String? by lazy {


### PR DESCRIPTION
## Description
The name should be displayed as is when rendered in asset details metadata and account screen. When displayed as title in AssetDetails dialog or everywhere else, we keep the same logic as before
