### PR TITLE
Update transaction status screen dismissal behavior

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,7 @@ android {
         minSdk rootProject.ext.minSdk
         targetSdk rootProject.ext.targetSdk
         versionCode 46
-        versionName "1.8.0"
+        versionName "1.8.1"
         buildConfigField "boolean", "DEBUG_MODE", "true"
         buildConfigField "boolean", "CRASH_REPORTING_AVAILABLE", "false"
         buildConfigField "boolean", "EXPERIMENTAL_FEATURES_ENABLED", "true"

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/dapp/DappInteractionDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/dapp/DappInteractionDialogViewModel.kt
@@ -19,14 +19,9 @@ class DappInteractionDialogViewModel @Inject constructor(
 ) : StateViewModel<DappInteractionDialogViewModel.State>(),
     OneOffEventHandler<DappInteractionDialogViewModel.Event> by OneOffEventHandlerImpl() {
 
-    private var isRequestHandled = false
-
     init {
         viewModelScope.launch {
-            if (incomingRequestRepository.getAmountOfRequests() == 1) {
-                incomingRequestRepository.requestHandled(state.value.requestId)
-                isRequestHandled = true
-            }
+            incomingRequestRepository.requestHandled(state.value.requestId)
         }
     }
 
@@ -40,9 +35,6 @@ class DappInteractionDialogViewModel @Inject constructor(
 
     fun onDismiss() {
         viewModelScope.launch {
-            if (!isRequestHandled) {
-                incomingRequestRepository.requestHandled(state.value.requestId)
-            }
             sendEvent(Event.DismissDialog)
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
@@ -92,6 +92,8 @@ class TransactionStatusDialogViewModel @Inject constructor(
                             isMobileConnect = status.isMobileConnect
                         )
                     )
+                    incomingRequestRepository.requestHandled(state.value.status.requestId)
+                    isRequestHandled = true
                 }.onFailure { error ->
                     if (!status.isInternal) {
                         (error as? RadixWalletException.TransactionSubmitException)?.let { exception ->
@@ -119,10 +121,6 @@ class TransactionStatusDialogViewModel @Inject constructor(
                     )
                 }
                 transactionStatusClient.statusHandled(status.transactionId)
-                if (incomingRequestRepository.getAmountOfRequests() == 1) {
-                    incomingRequestRepository.requestHandled(state.value.status.requestId)
-                    isRequestHandled = true
-                }
             }
         }
     }


### PR DESCRIPTION
## Description
This PR updates the transaction status screen dismissal behavior.


## How to test

1. Launch a transfer and keep staying on the Review Transaction screen
2. Launch a gumball transfer
3. Launch a gumball account sharing transaction
4. Complete the transfer launched from the app
5. Verify that after the transaction is completed the next one is immediately displayed and the success screen is not shown
6. Verify the same for the next transaction
7. Verify that if there are no pending transactions in the queue, the success screen is shown

## Video

https://github.com/user-attachments/assets/fc2762d7-2aa8-4245-bd47-a895191a049e


