### PR TITLE
Show close button when a blocking transaction completed

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
@@ -120,6 +120,7 @@ class TransactionStatusDialogViewModel @Inject constructor(
                         )
                     )
                 }
+                _state.update { it.copy(blockUntilComplete = false) }
                 transactionStatusClient.statusHandled(status.transactionId)
             }
         }


### PR DESCRIPTION
When there is a blocking transaction like 3rd party deposits account change, after the transaction completes, display the X button.