### PR TITLE
[ABW-3653] Cache newly created NFT items for existing resource

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/state/StateRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/state/StateRepository.kt
@@ -94,6 +94,8 @@ interface StateRepository {
 
     suspend fun cacheNewlyCreatedResources(newResources: List<Resource>): Result<Unit>
 
+    suspend fun cacheNewlyCreatedNFTItems(newItems: List<Resource.NonFungibleResource.Item>): Result<Unit>
+
     suspend fun clearCachedState(): Result<Unit>
 
     sealed class Error(cause: Throwable) : Exception(cause) {
@@ -103,8 +105,6 @@ interface StateRepository {
 
         data object StateVersionMissing : Error(RuntimeException("State version missing for account."))
     }
-
-    suspend fun cacheNewlyCreatedNFTItems(newItems: List<Resource.NonFungibleResource.Item>): Result<Unit>
 }
 
 @Suppress("TooManyFunctions")

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/state/StateRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/state/StateRepository.kt
@@ -103,6 +103,8 @@ interface StateRepository {
 
         data object StateVersionMissing : Error(RuntimeException("State version missing for account."))
     }
+
+    suspend fun cacheNewlyCreatedNFTItems(newItems: List<Resource.NonFungibleResource.Item>): Result<Unit>
 }
 
 @Suppress("TooManyFunctions")
@@ -546,6 +548,13 @@ class StateRepositoryImpl @Inject constructor(
 
             val newNFTs = newResources.filterIsInstance<Resource.NonFungibleResource>().map { it.items }.flatten()
             stateDao.insertNFTs(newNFTs.map { it.asEntity(syncedAt) })
+        }
+    }
+
+    override suspend fun cacheNewlyCreatedNFTItems(newItems: List<Resource.NonFungibleResource.Item>) = withContext(dispatcher) {
+        runCatching {
+            val syncedAt = InstantGenerator()
+            stateDao.insertNFTs(newItems.map { it.asEntity(syncedAt) })
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/assets/CacheNewlyCreatedEntitiesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/assets/CacheNewlyCreatedEntitiesUseCase.kt
@@ -11,4 +11,8 @@ class CacheNewlyCreatedEntitiesUseCase @Inject constructor(
     suspend operator fun invoke(resources: List<Resource>): Result<Unit> {
         return stateRepository.cacheNewlyCreatedResources(resources)
     }
+
+    suspend fun cacheNewlyCreatedNFTs(newNfts: List<Resource.NonFungibleResource.Item>): Result<Unit> {
+        return stateRepository.cacheNewlyCreatedNFTItems(newNfts)
+    }
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/assets/CacheNewlyCreatedEntitiesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/assets/CacheNewlyCreatedEntitiesUseCase.kt
@@ -8,11 +8,11 @@ class CacheNewlyCreatedEntitiesUseCase @Inject constructor(
     private val stateRepository: StateRepository
 ) {
 
-    suspend operator fun invoke(resources: List<Resource>): Result<Unit> {
+    suspend fun forResources(resources: List<Resource>): Result<Unit> {
         return stateRepository.cacheNewlyCreatedResources(resources)
     }
 
-    suspend fun cacheNewlyCreatedNFTs(newNfts: List<Resource.NonFungibleResource.Item>): Result<Unit> {
+    suspend fun forNFTs(newNfts: List<Resource.NonFungibleResource.Item>): Result<Unit> {
         return stateRepository.cacheNewlyCreatedNFTItems(newNfts)
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialogContent.kt
@@ -13,10 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -68,8 +66,7 @@ fun NonFungibleAssetDialogContent(
     val item = asset?.resource?.items?.firstOrNull()
     Column(
         modifier = modifier
-            .background(RadixTheme.colors.defaultBackground)
-            .verticalScroll(rememberScrollState()),
+            .background(RadixTheme.colors.defaultBackground),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         if (localId != null) {
@@ -77,23 +74,29 @@ fun NonFungibleAssetDialogContent(
                 Thumbnail.NFT(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = RadixTheme.dimensions.paddingXXLarge),
+                        .padding(
+                            start = RadixTheme.dimensions.paddingXXLarge,
+                            end = RadixTheme.dimensions.paddingXXLarge,
+                            bottom = RadixTheme.dimensions.paddingLarge
+                        ),
                     nft = item,
                     cropped = false
                 )
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
             } else if (item == null) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(Thumbnail.NFTAspectRatio)
-                        .padding(horizontal = RadixTheme.dimensions.paddingXXLarge)
+                        .padding(
+                            start = RadixTheme.dimensions.paddingXXLarge,
+                            end = RadixTheme.dimensions.paddingXXLarge,
+                            bottom = RadixTheme.dimensions.paddingLarge
+                        )
                         .radixPlaceholder(
                             visible = true,
                             shape = RoundedCornerShape(Thumbnail.NFTCornerRadius)
                         )
                 )
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
             }
 
             if (!item?.description.isNullOrBlank()) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/assets/nonfungible/NonFungibleAssetDialogContent.kt
@@ -13,8 +13,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,7 +68,8 @@ fun NonFungibleAssetDialogContent(
     val item = asset?.resource?.items?.firstOrNull()
     Column(
         modifier = modifier
-            .background(RadixTheme.colors.defaultBackground),
+            .background(RadixTheme.colors.defaultBackground)
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         if (localId != null) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -139,13 +139,13 @@ class TransactionAnalysisDelegate @Inject constructor(
         }
 
         if (previewType is PreviewType.Transfer) {
-            val newlyCreated = previewType.newlyCreatedResources
-            if (newlyCreated.isNotEmpty()) {
-                cacheNewlyCreatedEntitiesUseCase(newlyCreated)
+            val newlyCreatedResources = previewType.newlyCreatedResources
+            if (newlyCreatedResources.isNotEmpty()) {
+                cacheNewlyCreatedEntitiesUseCase.forResources(newlyCreatedResources)
             }
             val newlyCreatedNFTItemsForExistingResources = previewType.newlyCreatedNFTItemsForExistingResources
             if (newlyCreatedNFTItemsForExistingResources.isNotEmpty()) {
-                cacheNewlyCreatedEntitiesUseCase.cacheNewlyCreatedNFTs(newlyCreatedNFTItemsForExistingResources)
+                cacheNewlyCreatedEntitiesUseCase.forNFTs(newlyCreatedNFTItemsForExistingResources)
             }
         }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -143,6 +143,10 @@ class TransactionAnalysisDelegate @Inject constructor(
             if (newlyCreated.isNotEmpty()) {
                 cacheNewlyCreatedEntitiesUseCase(newlyCreated)
             }
+            val newlyCreatedNFTItemsForExistingResources = previewType.newlyCreatedNFTItemsForExistingResources
+            if (newlyCreatedNFTItemsForExistingResources.isNotEmpty()) {
+                cacheNewlyCreatedEntitiesUseCase.cacheNewlyCreatedNFTs(newlyCreatedNFTItemsForExistingResources)
+            }
         }
 
         _state.update {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/GeneralTransferProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/GeneralTransferProcessor.kt
@@ -8,6 +8,7 @@ import com.radixdlt.sargon.ExecutionSummary
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import rdx.works.core.domain.resources.Resource
 import rdx.works.core.sargon.activeAccountsOnCurrentNetwork
 import rdx.works.profile.domain.GetProfileUseCase
 import javax.inject.Inject
@@ -34,7 +35,13 @@ class GeneralTransferProcessor @Inject constructor(
                 defaultGuarantee = getProfileUseCase().appPreferences.transaction.defaultDepositGuarantee
             ),
             badges = badges,
-            dApps = dApps
+            dApps = dApps,
+            newlyCreatedNFTItems = summary.newlyCreatedNonFungibles.map {
+                Resource.NonFungibleResource.Item(
+                    it.resourceAddress,
+                    it.nonFungibleLocalId
+                )
+            }
         )
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/GeneralTransferProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/GeneralTransferProcessor.kt
@@ -8,7 +8,6 @@ import com.radixdlt.sargon.ExecutionSummary
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import rdx.works.core.domain.resources.Resource
 import rdx.works.core.sargon.activeAccountsOnCurrentNetwork
 import rdx.works.profile.domain.GetProfileUseCase
 import javax.inject.Inject
@@ -36,12 +35,7 @@ class GeneralTransferProcessor @Inject constructor(
             ),
             badges = badges,
             dApps = dApps,
-            newlyCreatedNFTItems = summary.newlyCreatedNonFungibles.map {
-                Resource.NonFungibleResource.Item(
-                    it.resourceAddress,
-                    it.nonFungibleLocalId
-                )
-            }
+            newlyCreatedNFTItems = summary.newlyCreatedNonFungibleItems()
         )
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolContributionProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolContributionProcessor.kt
@@ -39,7 +39,8 @@ class PoolContributionProcessor @Inject constructor(
             from = from,
             to = to,
             badges = badges,
-            actionType = PreviewType.Transfer.Pool.ActionType.Contribution
+            actionType = PreviewType.Transfer.Pool.ActionType.Contribution,
+            newlyCreatedNFTItems = summary.newlyCreatedNonFungibleItems()
         )
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolRedemptionProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/PoolRedemptionProcessor.kt
@@ -62,7 +62,8 @@ class PoolRedemptionProcessor @Inject constructor(
             from = from,
             to = to,
             badges = badges,
-            actionType = PreviewType.Transfer.Pool.ActionType.Redemption
+            actionType = PreviewType.Transfer.Pool.ActionType.Redemption,
+            newlyCreatedNFTItems = summary.newlyCreatedNonFungibleItems()
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransactionTypeExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransactionTypeExtensions.kt
@@ -407,6 +407,7 @@ fun ExecutionSummary.resolveBadges(assets: List<Asset>): List<Badge> {
                 // In this case we need to attach the amount of the specifier to the resource since it is not resolved by GW
                 (asset.resource as? Resource.FungibleResource)?.copy(ownedAmount = specifier.amount) ?: return@mapNotNull null
             }
+
             is ResourceSpecifier.NonFungible -> asset.resource
         }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransactionTypeExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransactionTypeExtensions.kt
@@ -415,6 +415,13 @@ fun ExecutionSummary.resolveBadges(assets: List<Asset>): List<Badge> {
     }
 }
 
+fun ExecutionSummary.newlyCreatedNonFungibleItems() = newlyCreatedNonFungibles.map {
+    Item(
+        it.resourceAddress,
+        it.nonFungibleLocalId
+    )
+}
+
 private fun NewlyCreatedResource.toMetadata(): List<Metadata> {
     val metadata = mutableListOf<Metadata>()
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransferProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransferProcessor.kt
@@ -4,6 +4,7 @@ import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddres
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.radixdlt.sargon.DetailedManifestClass
 import com.radixdlt.sargon.ExecutionSummary
+import rdx.works.core.domain.resources.Resource
 import rdx.works.core.sargon.activeAccountsOnCurrentNetwork
 import rdx.works.profile.domain.GetProfileUseCase
 import javax.inject.Inject
@@ -31,7 +32,13 @@ class TransferProcessor @Inject constructor(
                 allOwnedAccounts = allOwnedAccounts,
                 defaultGuarantee = getProfileUseCase().appPreferences.transaction.defaultDepositGuarantee
             ),
-            badges = badges
+            badges = badges,
+            newlyCreatedNFTItems = summary.newlyCreatedNonFungibles.map {
+                Resource.NonFungibleResource.Item(
+                    it.resourceAddress,
+                    it.nonFungibleLocalId
+                )
+            }
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransferProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransferProcessor.kt
@@ -4,7 +4,6 @@ import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddres
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.radixdlt.sargon.DetailedManifestClass
 import com.radixdlt.sargon.ExecutionSummary
-import rdx.works.core.domain.resources.Resource
 import rdx.works.core.sargon.activeAccountsOnCurrentNetwork
 import rdx.works.profile.domain.GetProfileUseCase
 import javax.inject.Inject
@@ -33,12 +32,7 @@ class TransferProcessor @Inject constructor(
                 defaultGuarantee = getProfileUseCase().appPreferences.transaction.defaultDepositGuarantee
             ),
             badges = badges,
-            newlyCreatedNFTItems = summary.newlyCreatedNonFungibles.map {
-                Resource.NonFungibleResource.Item(
-                    it.resourceAddress,
-                    it.nonFungibleLocalId
-                )
-            }
+            newlyCreatedNFTItems = summary.newlyCreatedNonFungibleItems()
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorClaimProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorClaimProcessor.kt
@@ -57,7 +57,8 @@ class ValidatorClaimProcessor @Inject constructor(
             from = fromAccounts,
             to = toAccounts,
             badges = badges,
-            actionType = PreviewType.Transfer.Staking.ActionType.ClaimStake
+            actionType = PreviewType.Transfer.Staking.ActionType.ClaimStake,
+            newlyCreatedNFTItems = summary.newlyCreatedNonFungibleItems()
         )
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorStakeProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorStakeProcessor.kt
@@ -51,7 +51,8 @@ class ValidatorStakeProcessor @Inject constructor(
             to = toAccounts,
             badges = badges,
             validators = involvedValidators,
-            actionType = PreviewType.Transfer.Staking.ActionType.Stake
+            actionType = PreviewType.Transfer.Staking.ActionType.Stake,
+            newlyCreatedNFTItems = summary.newlyCreatedNonFungibleItems()
         )
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorUnstakeProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/ValidatorUnstakeProcessor.kt
@@ -51,7 +51,8 @@ class ValidatorUnstakeProcessor @Inject constructor(
             to = toAccounts,
             badges = badges,
             validators = involvedValidators,
-            actionType = PreviewType.Transfer.Staking.ActionType.Unstake
+            actionType = PreviewType.Transfer.Staking.ActionType.Unstake,
+            newlyCreatedNFTItems = summary.newlyCreatedNonFungibleItems()
         )
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/PoolTypeContent.kt
@@ -105,7 +105,8 @@ fun PoolTypePreview() {
                     )
                 ),
                 badges = emptyList(),
-                actionType = PreviewType.Transfer.Pool.ActionType.Contribution
+                actionType = PreviewType.Transfer.Pool.ActionType.Contribution,
+                newlyCreatedNFTItems = emptyList()
             ),
             onPromptForGuarantees = {},
             onDAppClick = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/StakeTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/StakeTypeContent.kt
@@ -108,7 +108,8 @@ fun StakeUnstakeTypePreview() {
                 ),
                 badges = emptyList(),
                 validators = emptyList(),
-                actionType = PreviewType.Transfer.Staking.ActionType.Stake
+                actionType = PreviewType.Transfer.Staking.ActionType.Stake,
+                newlyCreatedNFTItems = emptyList()
             ),
             onPromptForGuarantees = {},
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransferTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/TransferTypeContent.kt
@@ -95,7 +95,8 @@ fun TransactionPreviewTypePreview() {
                             )
                         )
                     )
-                )
+                ),
+                newlyCreatedNFTItems = emptyList()
             ),
             onPromptForGuarantees = {},
             onDAppClick = { _ -> },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
@@ -59,6 +59,7 @@ import com.babylon.wallet.android.designsystem.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.ui.modifier.applyIf
+import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
 import com.radixdlt.sargon.NonFungibleLocalId
 import com.radixdlt.sargon.Persona
 import com.radixdlt.sargon.ResourceAddress
@@ -176,7 +177,6 @@ object Thumbnail {
 
             var painterState: AsyncImagePainter.State by remember(image) { mutableStateOf(AsyncImagePainter.State.Empty) }
             val density = LocalDensity.current
-
             SubcomposeAsyncImage(
                 modifier = modifier,
                 model = request,
@@ -185,12 +185,24 @@ object Thumbnail {
             ) {
                 Image(
                     modifier = Modifier
+                        .clip(RoundedCornerShape(cornerRadius))
+                        .applyIf(
+                            condition = painterState !is AsyncImagePainter.State.Success,
+                            modifier = Modifier.background(RadixTheme.colors.gray4)
+                        )
                         .applyIf(
                             condition = cropped,
                             modifier = when (val state = painterState) {
                                 is AsyncImagePainter.State.Empty -> Modifier
                                 is AsyncImagePainter.State.Error -> Modifier.aspectRatio(maxAspectRatio)
-                                is AsyncImagePainter.State.Loading -> Modifier
+                                is AsyncImagePainter.State.Loading ->
+                                    Modifier
+                                        .aspectRatio(NFTAspectRatio)
+                                        .radixPlaceholder(
+                                            visible = true,
+                                            shape = RoundedCornerShape(NFTCornerRadius)
+                                        )
+
                                 is AsyncImagePainter.State.Success -> {
                                     val intrinsicSize = state.painter.intrinsicSize
                                     if (intrinsicSize.height > intrinsicSize.width) {
@@ -213,11 +225,6 @@ object Thumbnail {
                                 is AsyncImagePainter.State.Error -> Modifier.aspectRatio(maxAspectRatio)
                                 else -> Modifier.wrapContentHeight()
                             }
-                        )
-                        .clip(RoundedCornerShape(cornerRadius))
-                        .applyIf(
-                            condition = painterState !is AsyncImagePainter.State.Success,
-                            modifier = Modifier.background(RadixTheme.colors.gray4)
                         ),
                     painter = painter,
                     contentDescription = null,
@@ -254,6 +261,7 @@ object Thumbnail {
                 modifier = modifier,
                 token = resource
             )
+
             is Resource.NonFungibleResource -> NonFungible(
                 modifier = modifier,
                 collection = resource

--- a/app/src/test/java/com/babylon/wallet/android/domain/usecases/SearchFeePayersUseCaseTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/domain/usecases/SearchFeePayersUseCaseTest.kt
@@ -1,46 +1,30 @@
 package com.babylon.wallet.android.domain.usecases
 
-import com.babylon.wallet.android.data.repository.state.StateRepository
 import com.babylon.wallet.android.data.transaction.TransactionConfig
 import com.babylon.wallet.android.data.transaction.model.TransactionFeePayers
-import com.babylon.wallet.android.domain.model.assets.AccountWithAssets
 import com.babylon.wallet.android.fakes.FakeProfileRepository
+import com.babylon.wallet.android.fakes.StateRepositoryFake
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.AccountOrAddressOf
-import com.radixdlt.sargon.ComponentAddress
-import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.Gateway
 import com.radixdlt.sargon.NetworkId
-import com.radixdlt.sargon.NonFungibleLocalId
 import com.radixdlt.sargon.PerAssetFungibleResource
 import com.radixdlt.sargon.PerAssetFungibleTransfer
 import com.radixdlt.sargon.PerAssetTransfers
 import com.radixdlt.sargon.PerAssetTransfersOfFungibleResource
-import com.radixdlt.sargon.PoolAddress
 import com.radixdlt.sargon.Profile
-import com.radixdlt.sargon.ResourceAddress
 import com.radixdlt.sargon.TransactionManifest
-import com.radixdlt.sargon.ValidatorAddress
-import com.radixdlt.sargon.extensions.ProfileEntity
 import com.radixdlt.sargon.extensions.forNetwork
 import com.radixdlt.sargon.extensions.perAssetTransfers
 import com.radixdlt.sargon.extensions.toDecimal192
 import com.radixdlt.sargon.samples.sample
 import com.radixdlt.sargon.samples.sampleMainnet
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import rdx.works.core.domain.DApp
 import rdx.works.core.domain.TransactionManifestData
-import rdx.works.core.domain.assets.StakeClaim
-import rdx.works.core.domain.assets.ValidatorWithStakes
-import rdx.works.core.domain.resources.Pool
-import rdx.works.core.domain.resources.Resource
-import rdx.works.core.domain.resources.Validator
 import rdx.works.core.domain.resources.XrdResource
-import rdx.works.core.domain.resources.metadata.PublicKeyHash
 import rdx.works.core.sargon.activeAccountsOnCurrentNetwork
 import rdx.works.core.sargon.changeGateway
 import rdx.works.core.sargon.unHideAllEntities
@@ -50,11 +34,10 @@ class SearchFeePayersUseCaseTest {
 
     private val profile = Profile.sample().changeGateway(Gateway.forNetwork(NetworkId.MAINNET)).unHideAllEntities()
     private val account1 = profile.activeAccountsOnCurrentNetwork[0]
-    private val account2 = profile.activeAccountsOnCurrentNetwork[1]
     private val profileUseCase = GetProfileUseCase(profileRepository = FakeProfileRepository(profile))
     private val useCase = SearchFeePayersUseCase(
         profileUseCase = profileUseCase,
-        stateRepository = StateRepositoryFake
+        stateRepository = StateRepositoryFake()
     )
 
     @Test
@@ -122,84 +105,6 @@ class SearchFeePayersUseCaseTest {
             )
         )
 
-        private object StateRepositoryFake : StateRepository {
-            override fun observeAccountsOnLedger(accounts: List<Account>, isRefreshing: Boolean): Flow<List<AccountWithAssets>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun getNextNFTsPage(
-                account: Account,
-                resource: Resource.NonFungibleResource
-            ): Result<Resource.NonFungibleResource> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun updateLSUsInfo(
-                account: Account,
-                validatorsWithStakes: List<ValidatorWithStakes>
-            ): Result<List<ValidatorWithStakes>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun updateStakeClaims(account: Account, claims: List<StakeClaim>): Result<List<StakeClaim>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun getResources(
-                addresses: Set<ResourceAddress>,
-                underAccountAddress: AccountAddress?,
-                withDetails: Boolean,
-                withAllMetadata: Boolean
-            ): Result<List<Resource>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun getPools(poolAddresses: Set<PoolAddress>): Result<List<Pool>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun getValidators(validatorAddresses: Set<ValidatorAddress>): Result<List<Validator>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun getNFTDetails(
-                resourceAddress: ResourceAddress,
-                localIds: Set<NonFungibleLocalId>
-            ): Result<List<Resource.NonFungibleResource.Item>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun getOwnedXRD(accounts: List<Account>): Result<Map<Account, Decimal192>> {
-                return Result.success(accounts.associateWith {
-                    if (it == accounts.first()) {
-                        100.toDecimal192()
-                    } else {
-                        0.toDecimal192()
-                    }
-                })
-            }
-
-            override suspend fun getEntityOwnerKeys(entities: List<ProfileEntity>): Result<Map<ProfileEntity, List<PublicKeyHash>>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun getDAppsDetails(definitionAddresses: List<AccountAddress>, isRefreshing: Boolean): Result<List<DApp>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun getDAppDefinitions(componentAddresses: List<ComponentAddress>): Result<Map<ComponentAddress, AccountAddress?>> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun cacheNewlyCreatedResources(newResources: List<Resource>): Result<Unit> {
-                TODO("Not yet implemented")
-            }
-
-            override suspend fun clearCachedState(): Result<Unit> {
-                TODO("Not yet implemented")
-            }
-        }
     }
-
 
 }

--- a/app/src/test/java/com/babylon/wallet/android/presentation/dapp/login/DAppAuthorizedLoginViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/dapp/login/DAppAuthorizedLoginViewModelTest.kt
@@ -5,12 +5,11 @@ package com.babylon.wallet.android.presentation.dapp.login
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
-import com.babylon.wallet.android.data.repository.state.StateRepository
 import com.babylon.wallet.android.domain.model.IncomingMessage
-import com.babylon.wallet.android.domain.model.assets.AccountWithAssets
 import com.babylon.wallet.android.domain.usecases.BuildAuthorizedDappResponseUseCase
 import com.babylon.wallet.android.domain.usecases.RespondToIncomingRequestUseCase
 import com.babylon.wallet.android.fakes.DAppConnectionRepositoryFake
+import com.babylon.wallet.android.fakes.StateRepositoryFake
 import com.babylon.wallet.android.presentation.StateViewModelTest
 import com.babylon.wallet.android.presentation.dapp.InitialAuthorizedLoginRoute
 import com.babylon.wallet.android.presentation.dapp.authorized.account.AccountItemUiModel
@@ -18,23 +17,15 @@ import com.babylon.wallet.android.presentation.dapp.authorized.login.ARG_INTERAC
 import com.babylon.wallet.android.presentation.dapp.authorized.login.DAppAuthorizedLoginViewModel
 import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
 import com.babylon.wallet.android.utils.AppEventBusImpl
-import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.AppearanceId
 import com.radixdlt.sargon.AuthorizedDapp
-import com.radixdlt.sargon.ComponentAddress
-import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.Gateway
 import com.radixdlt.sargon.IdentityAddress
 import com.radixdlt.sargon.NetworkId
-import com.radixdlt.sargon.NonFungibleLocalId
-import com.radixdlt.sargon.PoolAddress
 import com.radixdlt.sargon.Profile
-import com.radixdlt.sargon.ResourceAddress
-import com.radixdlt.sargon.ValidatorAddress
 import com.radixdlt.sargon.extensions.AuthorizedDapps
 import com.radixdlt.sargon.extensions.Personas
-import com.radixdlt.sargon.extensions.ProfileEntity
 import com.radixdlt.sargon.extensions.ProfileNetworks
 import com.radixdlt.sargon.extensions.ReferencesToAuthorizedPersonas
 import com.radixdlt.sargon.extensions.forNetwork
@@ -46,23 +37,12 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
-import rdx.works.core.domain.DApp
-import rdx.works.core.domain.assets.StakeClaim
-import rdx.works.core.domain.assets.ValidatorWithStakes
-import rdx.works.core.domain.resources.ExplicitMetadataKey
-import rdx.works.core.domain.resources.Pool
-import rdx.works.core.domain.resources.Resource
-import rdx.works.core.domain.resources.Validator
-import rdx.works.core.domain.resources.metadata.Metadata
-import rdx.works.core.domain.resources.metadata.MetadataType
-import rdx.works.core.domain.resources.metadata.PublicKeyHash
 import rdx.works.core.sargon.asIdentifiable
 import rdx.works.core.sargon.changeGateway
 import rdx.works.core.sargon.unHideAllEntities
@@ -277,88 +257,6 @@ class DAppAuthorizedLoginViewModelTest : StateViewModelTest<DAppAuthorizedLoginV
             val item = expectMostRecentItem()
             assert(item.initialAuthorizedLoginRoute is InitialAuthorizedLoginRoute.ChooseAccount)
         }
-    }
-
-    private class StateRepositoryFake : StateRepository {
-        override fun observeAccountsOnLedger(accounts: List<Account>, isRefreshing: Boolean): Flow<List<AccountWithAssets>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun getNextNFTsPage(
-            account: Account,
-            resource: Resource.NonFungibleResource
-        ): Result<Resource.NonFungibleResource> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun updateLSUsInfo(
-            account: Account,
-            validatorsWithStakes: List<ValidatorWithStakes>
-        ): Result<List<ValidatorWithStakes>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun updateStakeClaims(account: Account, claims: List<StakeClaim>): Result<List<StakeClaim>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun getResources(
-            addresses: Set<ResourceAddress>,
-            underAccountAddress: AccountAddress?,
-            withDetails: Boolean,
-            withAllMetadata: Boolean
-        ): Result<List<Resource>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun getPools(poolAddresses: Set<PoolAddress>): Result<List<Pool>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun getValidators(validatorAddresses: Set<ValidatorAddress>): Result<List<Validator>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun getNFTDetails(
-            resourceAddress: ResourceAddress,
-            localIds: Set<NonFungibleLocalId>
-        ): Result<List<Resource.NonFungibleResource.Item>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun getOwnedXRD(accounts: List<Account>): Result<Map<Account, Decimal192>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun getEntityOwnerKeys(entities: List<ProfileEntity>): Result<Map<ProfileEntity, List<PublicKeyHash>>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun getDAppsDetails(definitionAddresses: List<AccountAddress>, isRefreshing: Boolean): Result<List<DApp>> {
-            return Result.success(
-                definitionAddresses.mapIndexed { index, accountAddress ->
-                    DApp(
-                        dAppAddress = accountAddress,
-                        metadata = listOf(
-                            Metadata.Primitive(ExplicitMetadataKey.NAME.key, "dApp $index", MetadataType.String)
-                        )
-                    )
-                }
-            )
-        }
-
-        override suspend fun getDAppDefinitions(componentAddresses: List<ComponentAddress>): Result<Map<ComponentAddress, AccountAddress?>> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun cacheNewlyCreatedResources(newResources: List<Resource>): Result<Unit> {
-            TODO("Not yet implemented")
-        }
-
-        override suspend fun clearCachedState(): Result<Unit> {
-            TODO("Not yet implemented")
-        }
-
     }
 
 }


### PR DESCRIPTION
## Description
- cache NFT items that are newly created for an EXISTING NFT collection. 

Given the structure of our transaction analysis, this solution seemed easiest. I'm open for a suggestions to improve it.

## How to test

1. See ticket description for a slack thread describing how issue manifests itself.

## PR submission checklist
- [ ] I have verified that newly created items for existing resources are cached, and that this logic does not interfere with NFT items that are created together with their NFT collection (example - sandbox NFT creation)
