### PR TITLE
Update radio buttons

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
@@ -30,8 +30,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Tab
@@ -74,6 +72,8 @@ import com.babylon.wallet.android.presentation.ui.composables.BottomDialogHeader
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButtonDefaults
 import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
@@ -265,9 +265,11 @@ fun AddAssetSheet(
                 error = null
             )
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingMedium)) {
+            Row(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+            ) {
                 LabeledRadioButton(
-                    modifier = Modifier.weight(1f),
                     label = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetAllow),
                     selected = asset.rule == DepositAddressExceptionRule.ALLOW,
                     onSelected = {
@@ -275,7 +277,6 @@ fun AddAssetSheet(
                     }
                 )
                 LabeledRadioButton(
-                    modifier = Modifier.weight(1f),
                     label = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetDeny),
                     selected = asset.rule == DepositAddressExceptionRule.DENY,
                     onSelected = {
@@ -298,25 +299,22 @@ fun AddAssetSheet(
 }
 
 @Composable
-private fun LabeledRadioButton(modifier: Modifier, label: String, selected: Boolean, onSelected: () -> Unit) {
+private fun LabeledRadioButton(
+    modifier: Modifier = Modifier,
+    label: String,
+    selected: Boolean,
+    onSelected: () -> Unit
+) {
     Row(
-        modifier = modifier.clickable {
-            onSelected()
-        },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceAround
+        modifier = modifier.clickable { onSelected() },
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        RadioButton(
+        RadixRadioButton(
             selected = selected,
-            colors = RadioButtonDefaults.colors(
-                selectedColor = RadixTheme.colors.gray1,
-                unselectedColor = RadixTheme.colors.gray3,
-                disabledSelectedColor = Color.White
-            ),
+            colors = RadixRadioButtonDefaults.darkColors(),
             onClick = onSelected,
         )
         Text(
-            modifier = Modifier.fillMaxWidth(),
             text = label,
             style = RadixTheme.typography.body1HighImportance,
             color = RadixTheme.colors.gray1,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/AccountSelectionCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/AccountSelectionCard.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,6 +16,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButtonDefaults
 import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.ActionableAddressView
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.Address
@@ -61,15 +61,11 @@ fun AccountSelectionCard(
         }
         Spacer(modifier = Modifier.weight(0.1f))
         if (isSingleChoice) {
-            RadioButton(
+            RadixRadioButton(
                 selected = checked,
-                colors = RadioButtonDefaults.colors(
-                    selectedColor = RadixTheme.colors.gray1,
-                    unselectedColor = RadixTheme.colors.white,
-                    disabledSelectedColor = RadixTheme.colors.white
-                ),
                 onClick = radioButtonClicked,
-                enabled = isEnabledForSelection
+                enabled = isEnabledForSelection,
+                colors = RadixRadioButtonDefaults.lightColors()
             )
         } else {
             Checkbox(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
@@ -25,8 +25,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
@@ -63,6 +61,8 @@ import com.babylon.wallet.android.domain.model.Selectable
 import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
 import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButtonDefaults
 import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
@@ -418,12 +418,9 @@ private fun RestoredProfileListItem(
                 )
             }
 
-            RadioButton(
+            RadixRadioButton(
                 selected = isRestoringProfileSelected,
-                colors = RadioButtonDefaults.colors(
-                    selectedColor = RadixTheme.colors.gray1,
-                    unselectedColor = RadixTheme.colors.gray2,
-                ),
+                colors = RadixRadioButtonDefaults.darkColors(),
                 onClick = onRadioButtonClick
             )
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/accountrecoveryscan/chooseseed/ChooseSeedPhraseScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/accountrecoveryscan/chooseseed/ChooseSeedPhraseScreen.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Icon
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -43,6 +40,8 @@ import com.babylon.wallet.android.presentation.ui.composables.BackIconType
 import com.babylon.wallet.android.presentation.ui.composables.DSR
 import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButtonDefaults
 import com.babylon.wallet.android.presentation.ui.composables.SimpleAccountCard
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
@@ -236,13 +235,9 @@ fun SeedPhraseCard(
                     overflow = TextOverflow.Ellipsis
                 )
             }
-            RadioButton(
+            RadixRadioButton(
                 selected = selected,
-                colors = RadioButtonDefaults.colors(
-                    selectedColor = RadixTheme.colors.gray1,
-                    unselectedColor = RadixTheme.colors.gray3,
-                    disabledSelectedColor = Color.White
-                ),
+                colors = RadixRadioButtonDefaults.darkColors(),
                 onClick = onSelectionChanged,
             )
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -33,6 +31,8 @@ import com.babylon.wallet.android.data.transaction.model.TransactionFeePayers
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.gradient
 import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButtonDefaults
 import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.ActionableAddressView
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.radixdlt.sargon.Account
@@ -156,13 +156,9 @@ private fun FeePayerCard(
                 maxLines = 2
             )
 
-            RadioButton(
+            RadixRadioButton(
                 selected = candidate.account.address == selectedCandidateAddress,
-                colors = RadioButtonDefaults.colors(
-                    selectedColor = RadixTheme.colors.gray1,
-                    unselectedColor = RadixTheme.colors.gray3,
-                    disabledSelectedColor = Color.White
-                ),
+                colors = RadixRadioButtonDefaults.darkColors(),
                 onClick = {
                     onPayerSelected(candidate.account)
                 },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionContent.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
@@ -125,8 +126,11 @@ private fun FeePayerCard(
                 .throttleClickable {
                     onPayerSelected(candidate.account)
                 }
-                .padding(start = RadixTheme.dimensions.paddingDefault)
-                .padding(vertical = RadixTheme.dimensions.paddingSmall),
+                .padding(
+                    start = RadixTheme.dimensions.paddingDefault,
+                    end = RadixTheme.dimensions.paddingSmall
+                )
+                .padding(vertical = RadixTheme.dimensions.paddingDefault),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
@@ -156,12 +160,15 @@ private fun FeePayerCard(
                 maxLines = 2
             )
 
+            Spacer(modifier = Modifier.width(RadixTheme.dimensions.paddingXSmall))
+
             RadixRadioButton(
                 selected = candidate.account.address == selectedCandidateAddress,
                 colors = RadixRadioButtonDefaults.darkColors(),
                 onClick = {
                     onPayerSelected(candidate.account)
                 },
+                size = 18.dp
             )
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/LedgerListItem.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/LedgerListItem.kt
@@ -5,13 +5,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -65,13 +62,9 @@ fun LedgerListItem(
             )
         }
         if (selected != null) {
-            RadioButton(
+            RadixRadioButton(
                 selected = selected,
-                colors = RadioButtonDefaults.colors(
-                    selectedColor = RadixTheme.colors.gray1,
-                    unselectedColor = RadixTheme.colors.gray3,
-                    disabledSelectedColor = Color.White
-                ),
+                colors = RadixRadioButtonDefaults.darkColors(),
                 onClick = {
                     onLedgerSelected?.invoke(ledgerFactorSource)
                 },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/RadixRadioButton.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/RadixRadioButton.kt
@@ -1,0 +1,241 @@
+package com.babylon.wallet.android.presentation.ui.composables
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
+
+private val RADIO_BUTTON_PADDING = 2.dp
+private val RADIO_BUTTON_DOT_SIZE = 8.dp
+private val RADIO_STROKE_WIDTH = 1.dp
+
+private const val RADIO_ANIMATION_DURATION = 100
+
+@Composable
+fun RadixRadioButton(
+    selected: Boolean,
+    onClick: (() -> Unit)?,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    colors: RadixRadioButtonColors = RadixRadioButtonDefaults.darkColors(),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    val iconSize = 20.dp
+    val dotRadius = animateDpAsState(
+        targetValue = RADIO_BUTTON_DOT_SIZE / 2,
+        animationSpec = tween(durationMillis = RADIO_ANIMATION_DURATION)
+    )
+    val dotColor = colors.dotColors.radioColor(enabled, selected)
+    val backgroundColor = colors.backgroundColors.radioColor(enabled, selected)
+    val borderColor = colors.borderColors.radioColor(enabled, selected)
+    val selectableModifier =
+        if (onClick != null) {
+            @Suppress("DEPRECATION_ERROR")
+            Modifier.selectable(
+                selected = selected,
+                onClick = onClick,
+                enabled = enabled,
+                role = Role.RadioButton,
+                interactionSource = interactionSource,
+                indication = androidx.compose.material.ripple.rememberRipple(
+                    bounded = false,
+                    radius = iconSize
+                )
+            )
+        } else {
+            Modifier
+        }
+    Canvas(
+        modifier
+            .then(
+                if (onClick != null) {
+                    Modifier.size(32.dp)
+                } else {
+                    Modifier
+                }
+            )
+            .then(selectableModifier)
+            .wrapContentSize(Alignment.Center)
+            .padding(RADIO_BUTTON_PADDING)
+            .requiredSize(iconSize)
+    ) {
+        // Draw the border
+        val strokeWidth = RADIO_STROKE_WIDTH.toPx()
+        val outerCircleSize = (iconSize / 2).toPx() - strokeWidth / 2
+        drawCircle(
+            color = borderColor.value,
+            radius = outerCircleSize,
+            style = Stroke(strokeWidth)
+        )
+        // Draw the background
+        drawCircle(
+            color = backgroundColor.value,
+            radius = outerCircleSize,
+            style = Fill
+        )
+        // Draw the dot
+        drawCircle(
+            color = dotColor.value,
+            radius = dotRadius.value.toPx(),
+            style = Fill
+        )
+    }
+}
+
+object RadixRadioButtonDefaults {
+
+    @Composable
+    fun lightColors(
+        dotColors: RadixRadioButtonColors.ComponentColors = RadixRadioButtonColors.ComponentColors(
+            selectedColor = RadixTheme.colors.gray1,
+            unselectedColor = Color.Transparent,
+            disabledSelectedColor = RadixTheme.colors.gray3,
+            disabledUnselectedColor = Color.Transparent
+        ),
+        backgroundColors: RadixRadioButtonColors.ComponentColors = RadixRadioButtonColors.ComponentColors(
+            selectedColor = RadixTheme.colors.white,
+            unselectedColor = RadixTheme.colors.white.copy(alpha = 0.5f),
+            disabledSelectedColor = RadixTheme.colors.white.copy(alpha = 0.5f),
+            disabledUnselectedColor = RadixTheme.colors.white.copy(alpha = 0.5f)
+        ),
+        borderColors: RadixRadioButtonColors.ComponentColors = RadixRadioButtonColors.ComponentColors(
+            selectedColor = RadixTheme.colors.white,
+            unselectedColor = RadixTheme.colors.white,
+            disabledSelectedColor = RadixTheme.colors.gray3,
+            disabledUnselectedColor = RadixTheme.colors.gray3
+        )
+    ): RadixRadioButtonColors = RadixRadioButtonColors(
+        dotColors = dotColors,
+        backgroundColors = backgroundColors,
+        borderColors = borderColors
+    )
+
+    @Composable
+    fun darkColors(
+        dotColors: RadixRadioButtonColors.ComponentColors = RadixRadioButtonColors.ComponentColors(
+            selectedColor = RadixTheme.colors.white,
+            unselectedColor = Color.Transparent,
+            disabledSelectedColor = RadixTheme.colors.gray3,
+            disabledUnselectedColor = Color.Transparent
+        ),
+        backgroundColors: RadixRadioButtonColors.ComponentColors = RadixRadioButtonColors.ComponentColors(
+            selectedColor = RadixTheme.colors.gray1,
+            unselectedColor = Color.Transparent,
+            disabledSelectedColor = Color.Transparent,
+            disabledUnselectedColor = Color.Transparent
+        ),
+        borderColors: RadixRadioButtonColors.ComponentColors = RadixRadioButtonColors.ComponentColors(
+            selectedColor = RadixTheme.colors.gray1,
+            unselectedColor = RadixTheme.colors.gray2,
+            disabledSelectedColor = RadixTheme.colors.gray3,
+            disabledUnselectedColor = RadixTheme.colors.gray3
+        )
+    ): RadixRadioButtonColors = RadixRadioButtonColors(
+        dotColors = dotColors,
+        backgroundColors = backgroundColors,
+        borderColors = borderColors
+    )
+}
+
+data class RadixRadioButtonColors(
+    val dotColors: ComponentColors,
+    val backgroundColors: ComponentColors,
+    val borderColors: ComponentColors
+) {
+
+    @Immutable
+    data class ComponentColors(
+        val selectedColor: Color,
+        val unselectedColor: Color,
+        val disabledSelectedColor: Color,
+        val disabledUnselectedColor: Color
+    ) {
+
+        @Composable
+        fun radioColor(enabled: Boolean, selected: Boolean): State<Color> {
+            val target = when {
+                enabled && selected -> selectedColor
+                enabled && !selected -> unselectedColor
+                !enabled && selected -> disabledSelectedColor
+                else -> disabledUnselectedColor
+            }
+
+            // If not enabled 'snap' to the disabled state, as there should be no animations between
+            // enabled / disabled.
+            return if (enabled) {
+                animateColorAsState(target, tween(durationMillis = RADIO_ANIMATION_DURATION))
+            } else {
+                rememberUpdatedState(target)
+            }
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun RadixRadioButtonSelectedLightColorsPreview() {
+    RadixWalletPreviewTheme {
+        RadixRadioButton(
+            selected = true,
+            colors = RadixRadioButtonDefaults.lightColors(),
+            onClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun RadixRadioButtonNotSelectedLightColorsPreview() {
+    RadixWalletPreviewTheme {
+        RadixRadioButton(
+            selected = false,
+            colors = RadixRadioButtonDefaults.lightColors(),
+            onClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun RadixRadioButtonSelectedDarkColorsPreview() {
+    RadixWalletPreviewTheme {
+        RadixRadioButton(
+            selected = true,
+            colors = RadixRadioButtonDefaults.darkColors(),
+            onClick = {}
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun RadixRadioButtonNotSelectedDarkColorsPreview() {
+    RadixWalletPreviewTheme {
+        RadixRadioButton(
+            selected = false,
+            colors = RadixRadioButtonDefaults.darkColors(),
+            onClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/RadixRadioButton.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/RadixRadioButton.kt
@@ -22,10 +22,12 @@ import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
 
+private val RADIO_BUTTON_SIZE = 20.dp
 private val RADIO_BUTTON_PADDING = 2.dp
 private val RADIO_BUTTON_DOT_SIZE = 8.dp
 private val RADIO_STROKE_WIDTH = 1.dp
@@ -39,9 +41,9 @@ fun RadixRadioButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     colors: RadixRadioButtonColors = RadixRadioButtonDefaults.darkColors(),
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    size: Dp = RADIO_BUTTON_SIZE
 ) {
-    val iconSize = 20.dp
     val dotRadius = animateDpAsState(
         targetValue = RADIO_BUTTON_DOT_SIZE / 2,
         animationSpec = tween(durationMillis = RADIO_ANIMATION_DURATION)
@@ -60,7 +62,7 @@ fun RadixRadioButton(
                 interactionSource = interactionSource,
                 indication = androidx.compose.material.ripple.rememberRipple(
                     bounded = false,
-                    radius = iconSize
+                    radius = size
                 )
             )
         } else {
@@ -78,11 +80,11 @@ fun RadixRadioButton(
             .then(selectableModifier)
             .wrapContentSize(Alignment.Center)
             .padding(RADIO_BUTTON_PADDING)
-            .requiredSize(iconSize)
+            .requiredSize(size)
     ) {
         // Draw the border
         val strokeWidth = RADIO_STROKE_WIDTH.toPx()
-        val outerCircleSize = (iconSize / 2).toPx() - strokeWidth / 2
+        val outerCircleSize = (size / 2).toPx() - strokeWidth / 2
         drawCircle(
             color = borderColor.value,
             radius = outerCircleSize,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/PersonaCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/PersonaCard.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -31,6 +29,8 @@ import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.usecases.SecurityPromptType
 import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.PersonaUiModel
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButtonDefaults
 import com.babylon.wallet.android.presentation.ui.composables.SecurityPromptLabel
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
@@ -133,15 +133,12 @@ fun PersonaSelectableCard(modifier: Modifier, persona: PersonaUiModel, onSelectP
                 style = RadixTheme.typography.secondaryHeader,
                 color = RadixTheme.colors.gray1
             )
-            RadioButton(
+            RadixRadioButton(
                 selected = persona.selected,
                 onClick = {
                     onSelectPersona(persona.persona)
                 },
-                colors = RadioButtonDefaults.colors(
-                    selectedColor = RadixTheme.colors.gray1,
-                    unselectedColor = RadixTheme.colors.gray4
-                ),
+                colors = RadixRadioButtonDefaults.darkColors(),
             )
         }
         persona.lastUsedOn?.let {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/persona/PersonaDetailCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/persona/PersonaDetailCard.kt
@@ -10,8 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,6 +20,8 @@ import com.babylon.wallet.android.designsystem.composable.RadixPrimaryButton
 import com.babylon.wallet.android.designsystem.composable.RadixSecondaryButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.PersonaUiModel
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButtonDefaults
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.radixdlt.sargon.Persona
 import kotlinx.collections.immutable.ImmutableList
@@ -59,15 +59,12 @@ fun PersonaDetailCard(
             )
             if (onSelectPersona != null) {
                 Spacer(modifier = Modifier.weight(1f))
-                RadioButton(
+                RadixRadioButton(
                     selected = persona.selected,
                     onClick = {
                         onSelectPersona(persona.persona)
                     },
-                    colors = RadioButtonDefaults.colors(
-                        selectedColor = RadixTheme.colors.gray1,
-                        unselectedColor = RadixTheme.colors.gray4
-                    ),
+                    colors = RadixRadioButtonDefaults.darkColors()
                 )
             }
         }


### PR DESCRIPTION
## Description
This PR updates all the radio buttons in the app to match the design.

## Screenshot
<img width="542" alt="Screenshot 2024-07-31 at 10 29 19" src="https://github.com/user-attachments/assets/a69d9071-bab4-4a65-920f-02a7059ba614">
<img width="270" alt="Screenshot 2024-07-31 at 10 28 03" src="https://github.com/user-attachments/assets/ce89a13a-6eec-4cea-a915-8775a7986580">

## PR submission checklist
- [ ] I have tested single choice account selection
- [ ] I have tested specific assets adding from account third party deposits settings
- [ ] I have tested backup selection from restore backup screen
- [ ] I have tested persona selection from dApp login screen
