### PR TITLE
Improve error handling when verifying dApp request

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -81,9 +81,11 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
             }
     }
 
-    sealed class PrepareTransactionException(cause: Throwable? = null) : RadixWalletException(
-        cause = cause
-    ), DappWalletInteractionThrowable {
+    sealed class PrepareTransactionException(cause: Throwable? = null) :
+        RadixWalletException(
+            cause = cause
+        ),
+        DappWalletInteractionThrowable {
         data object ConvertManifest : PrepareTransactionException()
         data class BuildTransactionHeader(override val cause: Throwable) : PrepareTransactionException(cause)
         data object FailedToFindAccountWithEnoughFundsToLockFee : PrepareTransactionException()

--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -394,6 +394,7 @@ fun RadixWalletException.PrepareTransactionException.toUserFriendlyMessage(conte
                         R.string.error_transactionFailure_prepare
                     }
                 }
+
             RadixWalletException.PrepareTransactionException.ReceivingAccountDoesNotAllowDeposits ->
                 R.string.error_transactionFailure_doesNotAllowThirdPartyDeposits
         }
@@ -438,18 +439,18 @@ fun RadixWalletException.userFriendlyMessage(): String {
     return toUserFriendlyMessage(LocalContext.current)
 }
 
-fun RadixWalletException.getDappMessage(): String? {
+fun Throwable.getDappMessage(): String? {
     return when (this) {
         is RadixWalletException.TransactionSubmitException -> getDappMessage()
         is RadixWalletException.DappRequestException.WrongNetwork -> {
             "Wallet is using network ID: $currentNetworkId, request sent specified network ID: $requestNetworkId"
         }
 
-        else -> null
+        else -> message
     }
 }
 
-fun RadixWalletException.toConnectorExtensionError(): ConnectorExtensionError? {
+fun Throwable.toConnectorExtensionError(): ConnectorExtensionError? {
     return (this as? ConnectorExtensionThrowable?)?.ceError
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
@@ -132,7 +132,7 @@ class AuthorizeSpecifiedPersonaUseCase @Inject constructor(
     private suspend fun respondWithInvalidPersona(incomingRequest: AuthorizedRequest) {
         respondToIncomingRequestUseCase.respondWithFailure(
             request = incomingRequest,
-            error = DappWalletInteractionErrorType.INVALID_PERSONA
+            dappWalletInteractionErrorType = DappWalletInteractionErrorType.INVALID_PERSONA
         )
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/RespondToIncomingRequestUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/RespondToIncomingRequestUseCase.kt
@@ -30,14 +30,14 @@ class RespondToIncomingRequestUseCase @Inject constructor(
 
     suspend fun respondWithFailure(
         request: IncomingMessage.IncomingRequest,
-        error: DappWalletInteractionErrorType,
+        dappWalletInteractionErrorType: DappWalletInteractionErrorType,
         message: String? = null
     ) =
         withContext(ioDispatcher) {
             val payload = WalletToDappInteractionResponse.Failure(
                 v1 = WalletToDappInteractionFailureResponse(
                     interactionId = request.interactionId,
-                    error = error,
+                    error = dappWalletInteractionErrorType,
                     message = message
                 )
             )

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/VerifyDAppUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/VerifyDAppUseCase.kt
@@ -2,14 +2,13 @@ package com.babylon.wallet.android.domain.usecases
 
 import com.babylon.wallet.android.data.repository.dapps.WellKnownDAppDefinitionRepository
 import com.babylon.wallet.android.data.repository.state.StateRepository
+import com.babylon.wallet.android.domain.ConnectorExtensionError
 import com.babylon.wallet.android.domain.RadixWalletException
-import com.babylon.wallet.android.domain.asRadixWalletException
 import com.babylon.wallet.android.domain.getDappMessage
 import com.babylon.wallet.android.domain.model.IncomingMessage.IncomingRequest
 import com.babylon.wallet.android.domain.toConnectorExtensionError
 import com.babylon.wallet.android.utils.isValidHttpsUrl
 import com.radixdlt.sargon.AccountAddress
-import com.radixdlt.sargon.DappWalletInteractionErrorType
 import com.radixdlt.sargon.extensions.init
 import rdx.works.core.domain.DApp
 import rdx.works.core.sargon.currentGateway
@@ -27,23 +26,25 @@ class VerifyDAppUseCase @Inject constructor(
     suspend operator fun invoke(request: IncomingRequest): Result<Boolean> {
         val networkId = getProfileUseCase().currentGateway.network.id
         if (networkId != request.metadata.networkId) {
+            val error = RadixWalletException.DappRequestException.WrongNetwork(
+                currentNetworkId = networkId,
+                requestNetworkId = request.metadata.networkId
+            )
             respondToIncomingRequestUseCase.respondWithFailure(
                 request = request,
-                error = DappWalletInteractionErrorType.INVALID_REQUEST
+                error = error.ceError,
+                message = error.getDappMessage()
             )
-            return Result.failure(
-                RadixWalletException.DappRequestException.WrongNetwork(
-                    currentNetworkId = networkId,
-                    requestNetworkId = request.metadata.networkId
-                )
-            )
+            return Result.failure(error)
         }
         val dAppDefinitionAddress = runCatching { AccountAddress.init(request.metadata.dAppDefinitionAddress) }.getOrElse {
+            val error = RadixWalletException.DappRequestException.InvalidRequest
             respondToIncomingRequestUseCase.respondWithFailure(
                 request = request,
-                error = DappWalletInteractionErrorType.INVALID_REQUEST
+                error = error.ceError,
+                message = "Invalid dApp definition address: ${request.metadata.dAppDefinitionAddress}"
             )
-            return Result.failure(RadixWalletException.DappRequestException.InvalidRequest)
+            return Result.failure(error)
         }
         val developerMode = getProfileUseCase().appPreferences.security.isDeveloperModeEnabled
         return if (developerMode) {
@@ -53,10 +54,10 @@ class VerifyDAppUseCase @Inject constructor(
                 origin = request.metadata.origin,
                 dAppDefinitionAddress = dAppDefinitionAddress
             ).onFailure { error ->
-                error.asRadixWalletException()?.let { radixWalletException ->
-                    val walletErrorType = radixWalletException.toConnectorExtensionError() ?: return@let
-                    respondToIncomingRequestUseCase.respondWithFailure(request, walletErrorType, radixWalletException.getDappMessage())
-                }
+                val walletErrorType =
+                    error.toConnectorExtensionError() ?: ConnectorExtensionError.UNKNOWN_DAPP_DEFINITION_ADDRESS
+                val message = error.getDappMessage()
+                respondToIncomingRequestUseCase.respondWithFailure(request, walletErrorType, message)
             }
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/VerifyDAppUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/VerifyDAppUseCase.kt
@@ -11,6 +11,7 @@ import com.babylon.wallet.android.utils.isValidHttpsUrl
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.extensions.init
 import rdx.works.core.domain.DApp
+import rdx.works.core.logNonFatalException
 import rdx.works.core.sargon.currentGateway
 import rdx.works.core.then
 import rdx.works.profile.domain.GetProfileUseCase
@@ -54,6 +55,7 @@ class VerifyDAppUseCase @Inject constructor(
                 origin = request.metadata.origin,
                 dAppDefinitionAddress = dAppDefinitionAddress
             ).onFailure { error ->
+                logNonFatalException(error)
                 val walletErrorType =
                     error.toConnectorExtensionError() ?: ConnectorExtensionError.UNKNOWN_DAPP_DEFINITION_ADDRESS
                 val message = error.getDappMessage()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -274,7 +274,11 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
                 is RadixWalletException.LedgerCommunicationException, is RadixWalletException.SignatureCancelled -> {}
 
                 else -> {
-                    respondToIncomingRequestUseCase.respondWithFailure(request, exception.ceError, exception.getDappMessage())
+                    respondToIncomingRequestUseCase.respondWithFailure(
+                        request,
+                        exception.dappWalletInteractionErrorType,
+                        exception.getDappMessage()
+                    )
                     _state.update { it.copy(failureDialog = FailureDialogState.Open(exception)) }
                 }
             }
@@ -283,7 +287,7 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
 
     fun onAcknowledgeFailureDialog() = viewModelScope.launch {
         val exception = (_state.value.failureDialog as? FailureDialogState.Open)?.dappRequestException ?: return@launch
-        respondToIncomingRequestUseCase.respondWithFailure(request, exception.ceError, exception.getDappMessage())
+        respondToIncomingRequestUseCase.respondWithFailure(request, exception.dappWalletInteractionErrorType, exception.getDappMessage())
         _state.update { it.copy(failureDialog = FailureDialogState.Closed) }
         sendEvent(Event.CloseLoginFlow)
         incomingRequestRepository.requestHandled(requestId = args.interactionId)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginViewModel.kt
@@ -168,7 +168,7 @@ class DAppUnauthorizedLoginViewModel @Inject constructor(
                 else -> {
                     respondToIncomingRequestUseCase.respondWithFailure(
                         request = request,
-                        error = exception.ceError,
+                        dappWalletInteractionErrorType = exception.dappWalletInteractionErrorType,
                         message = exception.getDappMessage()
                     )
                     _state.update { it.copy(failureDialogState = FailureDialogState.Open(exception)) }
@@ -183,7 +183,7 @@ class DAppUnauthorizedLoginViewModel @Inject constructor(
 
     fun onAcknowledgeFailureDialog() = viewModelScope.launch {
         val exception = (_state.value.failureDialogState as? FailureDialogState.Open)?.dappRequestException ?: return@launch
-        respondToIncomingRequestUseCase.respondWithFailure(request, exception.ceError, exception.getDappMessage())
+        respondToIncomingRequestUseCase.respondWithFailure(request, exception.dappWalletInteractionErrorType, exception.getDappMessage())
         _state.update { it.copy(failureDialogState = FailureDialogState.Closed) }
         sendEvent(Event.CloseLoginFlow)
         incomingRequestRepository.requestHandled(requestId = args.interactionId)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/status/transaction/TransactionStatusDialogViewModel.kt
@@ -6,7 +6,7 @@ import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
 import com.babylon.wallet.android.data.repository.TransactionStatusClient
 import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.asRadixWalletException
-import com.babylon.wallet.android.domain.toConnectorExtensionError
+import com.babylon.wallet.android.domain.toDappWalletInteractionErrorType
 import com.babylon.wallet.android.domain.usecases.RespondToIncomingRequestUseCase
 import com.babylon.wallet.android.presentation.common.OneOffEvent
 import com.babylon.wallet.android.presentation.common.OneOffEventHandler
@@ -98,7 +98,7 @@ class TransactionStatusDialogViewModel @Inject constructor(
                             incomingRequestRepository.getRequest(status.requestId)?.let { transactionRequest ->
                                 respondToIncomingRequestUseCase.respondWithFailure(
                                     request = transactionRequest,
-                                    error = exception.ceError,
+                                    dappWalletInteractionErrorType = exception.dappWalletInteractionErrorType,
                                     message = exception.getDappMessage()
                                 )
                             }
@@ -113,7 +113,7 @@ class TransactionStatusDialogViewModel @Inject constructor(
                             isInternal = status.isInternal,
                             errorMessage = exceptionMessageProvider.throwableMessage(error),
                             blockUntilComplete = status.blockUntilComplete,
-                            walletErrorType = error.asRadixWalletException()?.toConnectorExtensionError(),
+                            walletErrorType = error.asRadixWalletException()?.toDappWalletInteractionErrorType(),
                             isMobileConnect = status.isMobileConnect,
                             dAppName = status.dAppName
                         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
@@ -9,7 +9,7 @@ import com.babylon.wallet.android.domain.getDappMessage
 import com.babylon.wallet.android.domain.model.GuaranteeAssertion
 import com.babylon.wallet.android.domain.model.IncomingMessage
 import com.babylon.wallet.android.domain.model.Transferable
-import com.babylon.wallet.android.domain.toConnectorExtensionError
+import com.babylon.wallet.android.domain.toDappWalletInteractionErrorType
 import com.babylon.wallet.android.domain.usecases.RespondToIncomingRequestUseCase
 import com.babylon.wallet.android.domain.usecases.SignTransactionUseCase
 import com.babylon.wallet.android.domain.usecases.transaction.SubmitTransactionUseCase
@@ -100,7 +100,7 @@ class TransactionSubmitDelegate @Inject constructor(
             if (!request.isInternal) {
                 respondToIncomingRequestUseCase.respondWithFailure(
                     request = request,
-                    error = exception.ceError,
+                    dappWalletInteractionErrorType = exception.dappWalletInteractionErrorType,
                     message = exception.getDappMessage()
                 )
             }
@@ -203,7 +203,7 @@ class TransactionSubmitDelegate @Inject constructor(
                         isInternal = transactionRequest.isInternal,
                         errorMessage = exceptionMessageProvider.throwableMessage(radixWalletException),
                         blockUntilComplete = transactionRequest.blockUntilComplete,
-                        walletErrorType = radixWalletException.toConnectorExtensionError(),
+                        walletErrorType = radixWalletException.toDappWalletInteractionErrorType(),
                         isMobileConnect = transactionRequest.isMobileConnectRequest,
                         dAppName = _state.value.proposingDApp?.name
                     )
@@ -237,10 +237,10 @@ class TransactionSubmitDelegate @Inject constructor(
             return
         }
         error.asRadixWalletException()?.let { radixWalletException ->
-            radixWalletException.toConnectorExtensionError()?.let { walletErrorType ->
+            radixWalletException.toDappWalletInteractionErrorType()?.let { walletErrorType ->
                 respondToIncomingRequestUseCase.respondWithFailure(
                     request = currentState.requestNonNull,
-                    error = walletErrorType,
+                    dappWalletInteractionErrorType = walletErrorType,
                     message = radixWalletException.getDappMessage()
                 )
             }

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
@@ -239,7 +239,7 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
         coEvery {
             respondToIncomingRequestUseCase.respondWithFailure(
                 request = any(),
-                error = any(),
+                dappWalletInteractionErrorType = any(),
                 message = any()
             )
         } returns Result.success(IncomingRequestResponse.SuccessCE)
@@ -312,7 +312,7 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
         coVerify(exactly = 1) {
             respondToIncomingRequestUseCase.respondWithFailure(
                 request = sampleRequest,
-                error = capture(errorSlot),
+                dappWalletInteractionErrorType = capture(errorSlot),
                 message = any()
             )
         }
@@ -336,7 +336,7 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
         coVerify(exactly = 1) {
             respondToIncomingRequestUseCase.respondWithFailure(
                 request = sampleRequest,
-                error = capture(errorSlot),
+                dappWalletInteractionErrorType = capture(errorSlot),
                 message = any()
             )
         }


### PR DESCRIPTION
## Description
This PR aims to help us troubleshoot weird dApp validation error that Radquest users have seen. By always sending dApp response we are able to get CE logs and see reason of the failure. 
- always respond to dapp if we fail to verify request
- add additional information to `messsage` field
- log non fatal to crashlytics, as a backup mean

## How to test

1. I tested it with emulator, simulating very weak network. Before that change we didn't respond to dApp in case of network related failures.