### PR TITLE
Update dapp request handling logic to properly determine starting screen

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/model/DappToWalletInteractionExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/model/DappToWalletInteractionExtensions.kt
@@ -74,8 +74,7 @@ private fun DappToWalletInteractionUnauthorizedRequestItems.parseUnauthorizedReq
     )
 }
 
-fun DappToWalletInteractionPersonaDataRequestItem.toDomainModel(isOngoing: Boolean = false): PersonaRequestItem? {
-    if (isRequestingName == null && numberOfRequestedPhoneNumbers == null && numberOfRequestedEmailAddresses == null) return null
+fun DappToWalletInteractionPersonaDataRequestItem.toDomainModel(isOngoing: Boolean = false): PersonaRequestItem {
     return PersonaRequestItem(
         isRequestingName = isRequestingName == true,
         numberOfRequestedEmailAddresses = numberOfRequestedEmailAddresses?.toDomainModel(),

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/AuthorizeSpecifiedPersonaUseCase.kt
@@ -63,7 +63,7 @@ class AuthorizeSpecifiedPersonaUseCase @Inject constructor(
                     .referencesToAuthorizedPersonas
                     .firstOrNull { authorizedPersonaSimple ->
                         authorizedPersonaSimple.identityAddress.string ==
-                                (request.authRequest as? AuthorizedRequest.AuthRequest.UsePersonaRequest)?.identityAddress?.string
+                            (request.authRequest as? AuthorizedRequest.AuthRequest.UsePersonaRequest)?.identityAddress?.string
                     }
                 if (authorizedPersonaSimple == null) {
                     respondWithInvalidPersona(incomingRequest)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginScreen.kt
@@ -132,14 +132,14 @@ fun DappAuthorizedLoginScreen(
                 onMessageShown = viewModel::onMessageShown,
                 modifier = Modifier.imePadding()
             )
-            sharedState.interactionState?.let {
-                FactorSourceInteractionBottomDialog(
-                    modifier = Modifier.fillMaxHeight(0.8f),
-                    onDismissDialogClick = viewModel::onDismissSigningStatusDialog,
-                    interactionState = it
-                )
-            }
         }
+    }
+    sharedState.interactionState?.let {
+        FactorSourceInteractionBottomDialog(
+            modifier = Modifier.fillMaxHeight(0.8f),
+            onDismissDialogClick = viewModel::onDismissSigningStatusDialog,
+            interactionState = it
+        )
     }
 }
 


### PR DESCRIPTION
## Description
Re-arranged how we determine starting screen for request handling. Now it is as follow, when we hit one of those conditions, we don't examine the rest (when clause):
- if there is ongoing accounts request that is not reset and we didn't grant account access to this type of request for the dapp - we start with account permission screen
- if there is ongoing persona data request that is not reset and we didn't grant data access to this type of request for the dapp - we start with ongoing persona data screen
- if there is one time accounts request - start with chosing account screen for one time data
- if there is one time persona data request - start with persona data one time screen
If none of the above are met, we have a request with either ongoing account and (or) persona data and we already granted data to such request in the past - ask for biometrics and complete request handling.

## How to test

1. Test scenarios described in the ticket description
2. Test various random dapp requests using sandbox - it should work as it was before the changes

## PR submission checklist
- [ ] I have tested scenarios described in the ticket
- [ ] I have tested data requests/one time requests using sandbox.
