### PR TITLE
Fix crash when popping persona creation flow.

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaNav.kt
@@ -31,7 +31,6 @@ fun NavController.personaInfoScreen() {
     navigate(ROUTE_PERSONA_INFO)
 }
 
-@Suppress("SwallowedException")
 fun NavController.popPersonaCreation() {
     val entryToPop = runCatching { getBackStackEntry(ROUTE_PERSONA_INFO) }.flatMapError {
         runCatching { getBackStackEntry(ROUTE_CREATE_PERSONA) }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaNav.kt
@@ -11,6 +11,7 @@ import com.babylon.wallet.android.presentation.navigation.markAsHighPriority
 import com.babylon.wallet.android.presentation.settings.personas.PersonasScreen
 import com.babylon.wallet.android.presentation.settings.personas.personadetail.ROUTE_PERSONA_DETAIL
 import com.radixdlt.sargon.IdentityAddress
+import rdx.works.core.flatMapError
 
 const val ROUTE_CREATE_PERSONA = "create_persona_route"
 const val ROUTE_PERSONA_INFO = "persona_info_route"
@@ -32,12 +33,14 @@ fun NavController.personaInfoScreen() {
 
 @Suppress("SwallowedException")
 fun NavController.popPersonaCreation() {
-    val entryToPop = try {
-        getBackStackEntry(ROUTE_PERSONA_INFO)
-    } catch (e: java.lang.IllegalArgumentException) {
-        getBackStackEntry(ROUTE_CREATE_PERSONA)
+    val entryToPop = runCatching { getBackStackEntry(ROUTE_PERSONA_INFO) }.flatMapError {
+        runCatching { getBackStackEntry(ROUTE_CREATE_PERSONA) }
+    }.getOrNull()
+    if (entryToPop == null) {
+        popBackStack()
+    } else {
+        popBackStack(entryToPop.destination.id, true)
     }
-    popBackStack(entryToPop.destination.id, true)
 }
 
 fun NavGraphBuilder.personaInfoScreen(


### PR DESCRIPTION
## Description
Crash hapened when user was on persona confirmation screen, popping screen to get back to the flow that started persona creation. Stacktrace says that current screen when crash occured is persona selection in dapp request handling flow. I was not able to reproduce, but it is clear from the report that it happened at `getBackStackEntry(ROUTE_CREATE_PERSONA)` which throws if route is not on the backstack. Wrapped calls to `getBackStackEntry` in runCatching, and if we can't find root screen of the flow for some reason (entry == null), just pop current screen.


## How to test

1. I tried regular persona creation flow in dApp request handling - couldn't reproduce
2. While being at persona creation confirmation screen, moved app to the background, simulated process death with `adb shell am kill <package_name>` and re-opened app from the Recent - still, was not able to crash the wallet.

Any feedback on potential way of reproducing is welcomed
