### PR TITLE
update insets on modal dialogs

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -178,6 +180,7 @@ fun CreatePersonaContent(
     if (state.isAddFieldBottomSheetVisible) {
         DefaultModalSheetLayout(
             modifier = modifier,
+            windowInsets = WindowInsets.systemBars.exclude(WindowInsets.navigationBars),
             sheetState = bottomSheetState,
             sheetContent = {
                 AddFieldSheet(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personaedit/PersonaEditScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personaedit/PersonaEditScreen.kt
@@ -5,12 +5,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -217,6 +219,7 @@ private fun PersonaEditContent(
 
     if (state.isAddFieldBottomSheetVisible) {
         DefaultModalSheetLayout(
+            windowInsets = WindowInsets.systemBars.exclude(WindowInsets.navigationBars),
             sheetState = bottomSheetState,
             sheetContent = {
                 AddFieldSheet(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
@@ -7,11 +7,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -90,6 +93,7 @@ fun GatewaysScreen(
 
     state.addGatewayInput?.let { input ->
         DefaultModalSheetLayout(
+            windowInsets = WindowInsets.systemBars.exclude(WindowInsets.navigationBars),
             sheetState = bottomSheetState,
             showDragHandle = true,
             wrapContent = true,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeePayerSelectionSheet.kt
@@ -5,11 +5,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -65,6 +69,7 @@ fun FeePayerSelectionSheet(
     onDismiss: () -> Unit
 ) {
     DefaultModalSheetLayout(
+        windowInsets = WindowInsets.systemBars.exclude(WindowInsets.navigationBars),
         modifier = modifier.fillMaxSize(),
         sheetState = sheetState,
         enableImePadding = true,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DefaultModalSheetLayout.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DefaultModalSheetLayout.kt
@@ -33,7 +33,8 @@ fun DefaultModalSheetLayout(
     sheetContent: @Composable () -> Unit,
     showDragHandle: Boolean = true,
     containerColor: Color = RadixTheme.colors.defaultBackground,
-    onDismissRequest: () -> Unit
+    windowInsets: WindowInsets = WindowInsets.systemBars,
+    onDismissRequest: () -> Unit,
 ) {
     BoxWithConstraints(
         modifier = modifier
@@ -50,7 +51,7 @@ fun DefaultModalSheetLayout(
             },
             // The insets are the system bars (nav bars + status bars), no need to inset the dev banner since the
             // modal is rendered above it in the z-axis.
-            windowInsets = WindowInsets.systemBars,
+            windowInsets = windowInsets,
             shape = RadixTheme.shapes.roundedRectTopDefault,
             content = {
                 Box(


### PR DESCRIPTION
## Description
- in some dialogs it looks like navigation bar insets are included twice, once by a default modal sheet dialog, and 2nd time from RadixBottomBar. 

## How to test

1. See persona edit/persona create/gateway update and fee payer selection dialogs before the fix - bottom padding is too big compare to zeplin.
2. Padding should be fine after the fix
