### PR TITLE
[ABW-3669] Make uploadAuthKeyInteractionId nullable

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailViewModel.kt
@@ -53,7 +53,7 @@ class PersonaDetailViewModel @Inject constructor(
 
     private val args = PersonaDetailScreenArgs(savedStateHandle)
     private var authSigningFactorInstance: HierarchicalDeterministicFactorInstance? = null
-    private lateinit var uploadAuthKeyRequestId: WalletInteractionId
+    private var uploadAuthKeyInteractionId: WalletInteractionId? = null
 
     init {
         viewModelScope.launch {
@@ -84,7 +84,7 @@ class PersonaDetailViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            appEventBus.events.filterIsInstance<AppEvent.Status.Transaction>().filter { it.requestId == uploadAuthKeyRequestId.toString() }
+            appEventBus.events.filterIsInstance<AppEvent.Status.Transaction>().filter { it.requestId == uploadAuthKeyInteractionId }
                 .collect { event ->
                     when (event) {
                         is AppEvent.Status.Transaction.Fail -> {
@@ -129,10 +129,11 @@ class PersonaDetailViewModel @Inject constructor(
                                 _state.update { state -> state.copy(loading = false) }
                                 return@launch
                             }
-                        uploadAuthKeyRequestId = UUID.randomUUID().toString()
+                        val interactionId = UUID.randomUUID().toString()
+                        uploadAuthKeyInteractionId = interactionId
                         incomingRequestRepository.add(
                             manifest.prepareInternalTransactionRequest(
-                                requestId = uploadAuthKeyRequestId
+                                requestId = interactionId
                             )
                         )
                     }


### PR DESCRIPTION
## Description
- when app is left on persona details when transaction comes in and is signed - app crashes on status dialog
This is caused by listening for transaction status in that particular screen, and it's filter clause used `lateinit` variable that is not initialized

## How to test

1. Open app on persona details screen - the one where we have button to create auth key.
2. Send any transaction from a dApp (sandbox/dashboard) and sign transaction
3. App crashes before the fix
