### PR TITLE
[ABW-3674] - Fix third party deposits text field contextual menu

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/SpecificAssetsDepositsScreen.kt
@@ -5,7 +5,6 @@ package com.babylon.wallet.android.presentation.account.settings.specificassets
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -67,12 +66,9 @@ import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.model.displayTitleAsNFTCollection
 import com.babylon.wallet.android.presentation.model.displayTitleAsToken
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
-import com.babylon.wallet.android.presentation.ui.composables.BottomDialogHeader
-import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
+import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
-import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
-import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButtonDefaults
 import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
@@ -183,26 +179,19 @@ fun SpecificAssetsDepositsScreen(
     )
 
     if (state.isAddAssetSheetVisible) {
-        DefaultModalSheetLayout(
-            sheetState = sheetState,
-            wrapContent = true,
-            onDismissRequest = { hideCallback() },
-            sheetContent = {
-                AddAssetSheet(
-                    onResourceAddressChanged = sharedViewModel::assetExceptionAddressTyped,
-                    asset = state.assetExceptionToAdd,
-                    onAddAsset = {
-                        hideCallback()
-                        sharedViewModel.onAddAssetException()
-                    },
-                    modifier = Modifier
-                        .imePadding()
-                        .fillMaxWidth()
-                        .clip(RadixTheme.shapes.roundedRectTopDefault),
-                    onAssetExceptionRuleChanged = sharedViewModel::onAssetExceptionRuleChanged,
-                    onDismiss = { hideCallback() }
-                )
-            }
+        AddAssetSheet(
+            onResourceAddressChanged = sharedViewModel::assetExceptionAddressTyped,
+            asset = state.assetExceptionToAdd,
+            onAddAsset = {
+                hideCallback()
+                sharedViewModel.onAddAssetException()
+            },
+            modifier = Modifier
+                .imePadding()
+                .fillMaxWidth()
+                .clip(RadixTheme.shapes.roundedRectTopDefault),
+            onAssetExceptionRuleChanged = sharedViewModel::onAssetExceptionRuleChanged,
+            onDismiss = { hideCallback() }
         )
     }
 }
@@ -213,123 +202,99 @@ private fun AddAssetSheet(
     asset: AssetType.ExceptionType,
     onAddAsset: () -> Unit,
     modifier: Modifier = Modifier,
-    onDismiss: () -> Unit,
-    onAssetExceptionRuleChanged: (DepositAddressExceptionRule) -> Unit
+    onAssetExceptionRuleChanged: (DepositAddressExceptionRule) -> Unit,
+    onDismiss: () -> Unit
 ) {
     val inputFocusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) {
         inputFocusRequester.requestFocus()
     }
 
-    Column(
-        modifier = modifier
-            .verticalScroll(rememberScrollState())
-            .imePadding(),
-        verticalArrangement = Arrangement.Center,
+    BottomSheetDialogWrapper(
+        addScrim = true,
+        showDragHandle = true,
+        onDismiss = onDismiss,
+        showDefaultTopBar = true
     ) {
-        BottomDialogHeader(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = RadixTheme.dimensions.paddingSmall),
-            onDismissRequest = onDismiss
-        )
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(
-                    start = RadixTheme.dimensions.paddingDefault,
-                    end = RadixTheme.dimensions.paddingDefault,
-                    bottom = RadixTheme.dimensions.paddingDefault
-                )
+            modifier = modifier
+                .verticalScroll(rememberScrollState())
+                .imePadding(),
+            verticalArrangement = Arrangement.Center,
         ) {
-            Text(
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = RadixTheme.dimensions.paddingDefault),
-                text = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetTitle),
-                style = RadixTheme.typography.title,
-                color = RadixTheme.colors.gray1,
-                textAlign = TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = RadixTheme.dimensions.paddingLarge),
-                text = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetSubtitle),
-                style = RadixTheme.typography.body1Regular,
-                color = RadixTheme.colors.gray1,
-                textAlign = TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-            RadixTextField(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = RadixTheme.dimensions.paddingDefault)
-                    .focusRequester(inputFocusRequester),
-                onValueChanged = onResourceAddressChanged,
-                value = asset.addressToDisplay,
-                hint = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetInputHint),
-                hintColor = RadixTheme.colors.gray2,
-                singleLine = true,
-                error = null
-            )
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-            Row(
-                modifier = Modifier.align(Alignment.CenterHorizontally),
-                horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+                    .fillMaxSize()
+                    .padding(
+                        start = RadixTheme.dimensions.paddingDefault,
+                        end = RadixTheme.dimensions.paddingDefault,
+                        bottom = RadixTheme.dimensions.paddingDefault
+                    )
             ) {
-                LabeledRadioButton(
-                    label = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetAllow),
-                    selected = asset.rule == DepositAddressExceptionRule.ALLOW,
-                    onSelected = {
-                        onAssetExceptionRuleChanged(DepositAddressExceptionRule.ALLOW)
-                    }
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+                    text = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetTitle),
+                    style = RadixTheme.typography.title,
+                    color = RadixTheme.colors.gray1,
+                    textAlign = TextAlign.Center
                 )
-                LabeledRadioButton(
-                    label = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetDeny),
-                    selected = asset.rule == DepositAddressExceptionRule.DENY,
-                    onSelected = {
-                        onAssetExceptionRuleChanged(DepositAddressExceptionRule.DENY)
-                    }
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingLarge),
+                    text = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetSubtitle),
+                    style = RadixTheme.typography.body1Regular,
+                    color = RadixTheme.colors.gray1,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                RadixTextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+                        .focusRequester(inputFocusRequester),
+                    onValueChanged = onResourceAddressChanged,
+                    value = asset.addressToDisplay,
+                    hint = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetInputHint),
+                    hintColor = RadixTheme.colors.gray2,
+                    singleLine = true,
+                    error = null
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                Row(
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                    horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+                ) {
+                    LabeledRadioButton(
+                        label = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetAllow),
+                        selected = asset.rule == DepositAddressExceptionRule.ALLOW,
+                        onSelected = {
+                            onAssetExceptionRuleChanged(DepositAddressExceptionRule.ALLOW)
+                        }
+                    )
+                    LabeledRadioButton(
+                        label = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetDeny),
+                        selected = asset.rule == DepositAddressExceptionRule.DENY,
+                        onSelected = {
+                            onAssetExceptionRuleChanged(DepositAddressExceptionRule.DENY)
+                        }
+                    )
+                }
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXLarge))
+                RadixPrimaryButton(
+                    text = stringResource(R.string.accountSettings_specificAssetsDeposits_addAnAssetButton),
+                    onClick = {
+                        onAddAsset()
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = asset.addressValid,
+                    isLoading = false
                 )
             }
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXLarge))
-            RadixPrimaryButton(
-                text = stringResource(R.string.accountSettings_specificAssetsDeposits_addAnAssetButton),
-                onClick = {
-                    onAddAsset()
-                },
-                modifier = Modifier.fillMaxWidth(),
-                enabled = asset.addressValid,
-                isLoading = false
-            )
         }
-    }
-}
-
-@Composable
-private fun LabeledRadioButton(
-    modifier: Modifier = Modifier,
-    label: String,
-    selected: Boolean,
-    onSelected: () -> Unit
-) {
-    Row(
-        modifier = modifier.clickable { onSelected() },
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        RadixRadioButton(
-            selected = selected,
-            colors = RadixRadioButtonDefaults.darkColors(),
-            onClick = onSelected,
-        )
-        Text(
-            text = label,
-            style = RadixTheme.typography.body1HighImportance,
-            color = RadixTheme.colors.gray1,
-            textAlign = TextAlign.Center
-        )
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/composables/LabeledRadioButton.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificassets/composables/LabeledRadioButton.kt
@@ -1,10 +1,7 @@
 package com.babylon.wallet.android.presentation.account.settings.specificassets.composables
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.RadioButton
-import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -12,10 +9,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
+import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButtonDefaults
 
 @Composable
 fun LabeledRadioButton(
@@ -24,23 +22,18 @@ fun LabeledRadioButton(
     selected: Boolean,
     onSelected: () -> Unit
 ) {
-    Box(
+    Row(
         modifier = modifier.clickable {
             onSelected()
         },
-        contentAlignment = Alignment.CenterStart
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        RadioButton(
+        RadixRadioButton(
             selected = selected,
-            colors = RadioButtonDefaults.colors(
-                selectedColor = RadixTheme.colors.gray1,
-                unselectedColor = RadixTheme.colors.gray3,
-                disabledSelectedColor = RadixTheme.colors.white
-            ),
+            colors = RadixRadioButtonDefaults.darkColors(),
             onClick = onSelected,
         )
         Text(
-            modifier = Modifier.padding(start = 40.dp),
             text = label,
             style = RadixTheme.typography.body1HighImportance,
             color = RadixTheme.colors.gray1,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/specificdepositor/SpecificDepositorScreen.kt
@@ -55,8 +55,7 @@ import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.model.displayTitleAsNFTCollection
 import com.babylon.wallet.android.presentation.model.displayTitleAsToken
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
-import com.babylon.wallet.android.presentation.ui.composables.BottomDialogHeader
-import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
+import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
@@ -155,27 +154,19 @@ fun SpecificDepositorScreen(
     )
 
     if (state.isAddDepositorSheetVisible) {
-        DefaultModalSheetLayout(
-            sheetState = sheetState,
-            showDragHandle = true,
-            wrapContent = true,
-            onDismissRequest = { hideCallback() },
-            sheetContent = {
-                AddDepositorSheet(
-                    onResourceAddressChanged = sharedViewModel::depositorAddressTyped,
-                    onAddDepositor = {
-                        hideCallback()
-                        sharedViewModel.onAddDepositor()
-                    },
-                    modifier = Modifier
-                        .imePadding()
-                        .fillMaxWidth()
-                        .clip(RadixTheme.shapes.roundedRectTopDefault),
-                    depositor = state.depositorToAdd,
-                    onDismiss = {
-                        hideCallback()
-                    }
-                )
+        AddDepositorSheet(
+            onResourceAddressChanged = sharedViewModel::depositorAddressTyped,
+            onAddDepositor = {
+                hideCallback()
+                sharedViewModel.onAddDepositor()
+            },
+            modifier = Modifier
+                .imePadding()
+                .fillMaxWidth()
+                .clip(RadixTheme.shapes.roundedRectTopDefault),
+            depositor = state.depositorToAdd,
+            onDismiss = {
+                hideCallback()
             }
         )
     }
@@ -194,69 +185,70 @@ fun AddDepositorSheet(
         inputFocusRequester.requestFocus()
     }
 
-    Column(
-        modifier = modifier
-            .verticalScroll(rememberScrollState())
-            .imePadding(),
-        verticalArrangement = Arrangement.Center,
+    BottomSheetDialogWrapper(
+        addScrim = true,
+        showDragHandle = true,
+        onDismiss = onDismiss,
+        showDefaultTopBar = true
     ) {
-        BottomDialogHeader(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = RadixTheme.dimensions.paddingSmall),
-            onDismissRequest = onDismiss
-        )
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(
-                    start = RadixTheme.dimensions.paddingDefault,
-                    end = RadixTheme.dimensions.paddingDefault,
-                    bottom = RadixTheme.dimensions.paddingDefault
-                )
+            modifier = modifier
+                .verticalScroll(rememberScrollState())
+                .imePadding(),
+            verticalArrangement = Arrangement.Center,
         ) {
-            Text(
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = RadixTheme.dimensions.paddingDefault),
-                text = stringResource(id = R.string.accountSettings_thirdPartyDeposits_addDepositorTitle),
-                style = RadixTheme.typography.title,
-                color = RadixTheme.colors.gray1,
-                textAlign = TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = RadixTheme.dimensions.paddingDefault),
-                text = stringResource(id = R.string.accountSettings_thirdPartyDeposits_addDepositorSubtitle),
-                style = RadixTheme.typography.body1Regular,
-                color = RadixTheme.colors.gray1,
-                textAlign = TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-            RadixTextField(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = RadixTheme.dimensions.paddingLarge)
-                    .focusRequester(inputFocusRequester),
-                onValueChanged = onResourceAddressChanged,
-                value = depositor.addressToDisplay,
-                hint = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetInputHint),
-                hintColor = RadixTheme.colors.gray2,
-                singleLine = true,
-                error = null
-            )
-            Spacer(modifier = Modifier.height(60.dp))
-            RadixPrimaryButton(
-                text = stringResource(R.string.accountSettings_thirdPartyDeposits_allowSpecificDepositorsButton),
-                onClick = {
-                    onAddDepositor()
-                },
-                modifier = Modifier.fillMaxWidth(),
-                enabled = depositor.addressValid,
-                isLoading = false
-            )
+                    .fillMaxSize()
+                    .padding(
+                        start = RadixTheme.dimensions.paddingDefault,
+                        end = RadixTheme.dimensions.paddingDefault,
+                        bottom = RadixTheme.dimensions.paddingDefault
+                    )
+            ) {
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+                    text = stringResource(id = R.string.accountSettings_thirdPartyDeposits_addDepositorTitle),
+                    style = RadixTheme.typography.title,
+                    color = RadixTheme.colors.gray1,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+                    text = stringResource(id = R.string.accountSettings_thirdPartyDeposits_addDepositorSubtitle),
+                    style = RadixTheme.typography.body1Regular,
+                    color = RadixTheme.colors.gray1,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                RadixTextField(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingLarge)
+                        .focusRequester(inputFocusRequester),
+                    onValueChanged = onResourceAddressChanged,
+                    value = depositor.addressToDisplay,
+                    hint = stringResource(id = R.string.accountSettings_specificAssetsDeposits_addAnAssetInputHint),
+                    hintColor = RadixTheme.colors.gray2,
+                    singleLine = true,
+                    error = null
+                )
+                Spacer(modifier = Modifier.height(60.dp))
+                RadixPrimaryButton(
+                    text = stringResource(R.string.accountSettings_thirdPartyDeposits_allowSpecificDepositorsButton),
+                    onClick = {
+                        onAddDepositor()
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = depositor.addressValid,
+                    isLoading = false
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
@@ -47,7 +47,7 @@ import com.babylon.wallet.android.designsystem.composable.RadixTextField
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
-import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
+import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
@@ -89,19 +89,11 @@ fun GatewaysScreen(
     )
 
     state.addGatewayInput?.let { input ->
-        DefaultModalSheetLayout(
-            sheetState = bottomSheetState,
-            showDragHandle = true,
-            wrapContent = true,
-            onDismissRequest = { viewModel.setAddGatewaySheetVisible(false) },
-            sheetContent = {
-                AddGatewaySheet(
-                    input = input,
-                    onAddGatewayClick = viewModel::onAddGateway,
-                    onUrlChanged = viewModel::onNewUrlChanged,
-                    onClose = { viewModel.setAddGatewaySheetVisible(false) }
-                )
-            }
+        AddGatewaySheet(
+            input = input,
+            onAddGatewayClick = viewModel::onAddGateway,
+            onUrlChanged = viewModel::onNewUrlChanged,
+            onDismiss = { viewModel.setAddGatewaySheetVisible(false) }
         )
     }
 }
@@ -224,8 +216,7 @@ private fun AddGatewaySheet(
     input: GatewaysViewModel.State.AddGatewayInput,
     onAddGatewayClick: () -> Unit,
     onUrlChanged: (String) -> Unit,
-    onClose: () -> Unit,
-    modifier: Modifier = Modifier
+    onDismiss: () -> Unit
 ) {
     val inputFocusRequester = remember { FocusRequester() }
 
@@ -233,29 +224,15 @@ private fun AddGatewaySheet(
         inputFocusRequester.requestFocus()
     }
 
-    Box(
-        modifier = modifier.imePadding()
+    BottomSheetDialogWrapper(
+        addScrim = true,
+        showDragHandle = true,
+        onDismiss = onDismiss
     ) {
         Column(
-            modifier = Modifier
-                .padding(bottom = 88.dp)
-                .verticalScroll(rememberScrollState()),
+            modifier = Modifier.verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.Center,
         ) {
-            IconButton(
-                modifier = Modifier.padding(
-                    start = RadixTheme.dimensions.paddingXSmall,
-                    top = RadixTheme.dimensions.paddingMedium
-                ),
-                onClick = onClose
-            ) {
-                Icon(
-                    painter = painterResource(id = com.babylon.wallet.android.designsystem.R.drawable.ic_close),
-                    tint = RadixTheme.colors.gray1,
-                    contentDescription = null
-                )
-            }
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.gateways_addNewGateway_title),
@@ -297,7 +274,7 @@ private fun AddGatewaySheet(
         }
 
         RadixBottomBar(
-            modifier = Modifier.align(Alignment.BottomCenter),
+            modifier = Modifier.imePadding(),
             onClick = onAddGatewayClick,
             text = stringResource(R.string.gateways_addNewGateway_addGatewayButtonTitle),
             enabled = input.isUrlValid,
@@ -435,7 +412,7 @@ private fun AddGatewaySheetPreview() {
             input = GatewaysViewModel.State.AddGatewayInput(),
             onAddGatewayClick = {},
             onUrlChanged = {},
-            onClose = {}
+            onDismiss = {}
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DefaultModalSheetLayout.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DefaultModalSheetLayout.kt
@@ -3,6 +3,7 @@ package com.babylon.wallet.android.presentation.ui.composables
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -74,11 +75,12 @@ fun DefaultModalSheetLayout(
 
 @Composable
 fun DefaultModalSheetDragHandle(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    padding: PaddingValues = PaddingValues(top = RadixTheme.dimensions.paddingSmall)
 ) {
     Box(
         modifier = modifier
-            .padding(top = RadixTheme.dimensions.paddingSmall)
+            .padding(padding)
             .size(38.dp, 4.dp)
             .background(color = RadixTheme.colors.gray4, shape = RadixTheme.shapes.circle)
     )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -185,6 +186,7 @@ fun BottomSheetDialogWrapper(
                     .applyIf(
                         dragToDismissEnabled,
                         Modifier
+                            .fillMaxWidth()
                             .anchoredDraggable(
                                 state = draggableState,
                                 orientation = Orientation.Vertical,
@@ -205,17 +207,27 @@ fun BottomSheetDialogWrapper(
                     .clip(RadixTheme.shapes.roundedRectTopMedium),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                if (showDragHandle) {
-                    DefaultModalSheetDragHandle()
-                }
-                if (showDefaultTopBar) {
-                    BottomDialogHeader(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .background(RadixTheme.colors.defaultBackground, shape = RadixTheme.shapes.roundedRectTopDefault),
-                        onDismissRequest = { onDismissRequest() },
-                        title = title
-                    )
+                Box(
+                    contentAlignment = Alignment.TopCenter
+                ) {
+                    if (showDefaultTopBar) {
+                        BottomDialogHeader(
+                            modifier = Modifier
+                                .padding(top = RadixTheme.dimensions.paddingMedium)
+                                .fillMaxWidth()
+                                .background(RadixTheme.colors.defaultBackground, shape = RadixTheme.shapes.roundedRectTopDefault),
+                            onDismissRequest = { onDismissRequest() },
+                            title = title
+                        )
+                    }
+                    if (showDragHandle) {
+                        DefaultModalSheetDragHandle(
+                            padding = PaddingValues(
+                                top = RadixTheme.dimensions.paddingSmall,
+                                bottom = RadixTheme.dimensions.paddingLarge
+                            )
+                        )
+                    }
                 }
                 if (centerContent) {
                     Column(


### PR DESCRIPTION
## Description
Because the `androidx.compose.material3.ModalBottomSheet` is implemented as a pop-up, currently it's not possible for a `TextField` inside it to have a contextual menu displayed on long press. There are a few issues opened but with no resolution ([example](https://issuetracker.google.com/issues/327085717)). 

This is why I decided to switch back to the custom implementation of the bottom sheet, but also to enlarge the draggable area around the handle, this being the reason for switching from it to the `androidx.compose.material3.ModalBottomSheet` in the first place.

Additionally:
- Cleaned up third party deposits labeled radio buttons: removed unused code and replaced `RadioButton` with `RadixRadioButton`
- Fixed the gateways bottom sheet padding
