### PR TITLE
Pick the right factor instance based on sign purpose

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/transaction/ROLAClient.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/transaction/ROLAClient.kt
@@ -1,7 +1,7 @@
 package com.babylon.wallet.android.data.transaction
 
+import com.babylon.wallet.android.domain.model.signing.SignPurpose
 import com.babylon.wallet.android.domain.model.signing.SignRequest
-import com.babylon.wallet.android.domain.model.signing.SignType
 import com.babylon.wallet.android.domain.usecases.assets.GetEntitiesOwnerKeysUseCase
 import com.babylon.wallet.android.domain.usecases.transaction.GenerateAuthSigningFactorInstanceUseCase
 import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesInput
@@ -62,7 +62,7 @@ class ROLAClient @Inject constructor(
     ): Result<Map<ProfileEntity, SignatureWithPublicKey>> {
         return accessFactorSourcesProxy.getSignatures(
             accessFactorSourcesInput = AccessFactorSourcesInput.ToGetSignatures(
-                signType = SignType.ProvingOwnership,
+                signPurpose = SignPurpose.SignAuth,
                 signRequest = signRequest,
                 signers = entities
             )

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/signing/SignPurpose.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/signing/SignPurpose.kt
@@ -1,0 +1,5 @@
+package com.babylon.wallet.android.domain.model.signing
+
+enum class SignPurpose {
+    SignTransaction, SignAuth
+}

--- a/app/src/main/java/com/babylon/wallet/android/domain/model/signing/SignType.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/model/signing/SignType.kt
@@ -1,5 +1,0 @@
-package com.babylon.wallet.android.domain.model.signing
-
-enum class SignType {
-    SigningTransaction, ProvingOwnership
-}

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
@@ -4,8 +4,8 @@ import com.babylon.wallet.android.data.transaction.ROLAClient
 import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.model.IncomingMessage
 import com.babylon.wallet.android.domain.model.IncomingMessage.IncomingRequest.AuthorizedRequest
+import com.babylon.wallet.android.domain.model.signing.SignPurpose
 import com.babylon.wallet.android.domain.model.signing.SignRequest
-import com.babylon.wallet.android.domain.model.signing.SignType
 import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesInput
 import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesProxy
 import com.babylon.wallet.android.presentation.model.toWalletToDappInteractionPersonaDataRequestResponseItem
@@ -59,7 +59,7 @@ open class BuildDappResponseUseCase(private val accessFactorSourcesProxy: Access
 
             accessFactorSourcesProxy.getSignatures(
                 accessFactorSourcesInput = AccessFactorSourcesInput.ToGetSignatures(
-                    signType = SignType.ProvingOwnership,
+                    signPurpose = SignPurpose.SignAuth,
                     signers = accounts.map { it.asProfileEntity() },
                     signRequest = signRequest
                 )
@@ -298,7 +298,7 @@ class BuildUnauthorizedDappResponseUseCase @Inject constructor(
 
             accessFactorSourcesProxy.getSignatures(
                 accessFactorSourcesInput = AccessFactorSourcesInput.ToGetSignatures(
-                    signType = SignType.ProvingOwnership,
+                    signPurpose = SignPurpose.SignAuth,
                     signers = oneTimeAccounts.map { it.asProfileEntity() },
                     signRequest = signRequest
                 )

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/signing/SignTransactionUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/signing/SignTransactionUseCase.kt
@@ -4,8 +4,8 @@ import com.babylon.wallet.android.data.repository.transaction.TransactionReposit
 import com.babylon.wallet.android.data.transaction.NotaryAndSigners
 import com.babylon.wallet.android.data.transaction.TransactionConfig.EPOCH_WINDOW
 import com.babylon.wallet.android.domain.RadixWalletException
+import com.babylon.wallet.android.domain.model.signing.SignPurpose
 import com.babylon.wallet.android.domain.model.signing.SignRequest
-import com.babylon.wallet.android.domain.model.signing.SignType
 import com.babylon.wallet.android.domain.usecases.NotariseTransactionUseCase
 import com.babylon.wallet.android.domain.usecases.ResolveNotaryAndSignersUseCase
 import com.babylon.wallet.android.presentation.accessfactorsources.AccessFactorSourcesInput
@@ -105,7 +105,7 @@ class SignTransactionUseCase @Inject constructor(
             } else {
                 accessFactorSourcesProxy.getSignatures(
                     accessFactorSourcesInput = AccessFactorSourcesInput.ToGetSignatures(
-                        signType = SignType.SigningTransaction,
+                        signPurpose = SignPurpose.SignTransaction,
                         signers = notaryAndSigners.signers,
                         signRequest = signRequest
                     )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/AccessFactorSourceProxyContract.kt
@@ -1,7 +1,7 @@
 package com.babylon.wallet.android.presentation.accessfactorsources
 
+import com.babylon.wallet.android.domain.model.signing.SignPurpose
 import com.babylon.wallet.android.domain.model.signing.SignRequest
-import com.babylon.wallet.android.domain.model.signing.SignType
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.EntityKind
 import com.radixdlt.sargon.FactorSource
@@ -30,7 +30,7 @@ interface AccessFactorSourcesProxy {
     ): Result<AccessFactorSourcesOutput.DerivedAccountsWithNextDerivationPath>
 
     /**
-     * This method is used for signing, and based on [SignType] it can be
+     * This method is used for signing, and based on [SignPurpose] it can be
      * - either for signing a transaction
      * - or proving ownership.
      *
@@ -115,7 +115,7 @@ sealed interface AccessFactorSourcesInput {
     }
 
     data class ToGetSignatures(
-        val signType: SignType,
+        val signPurpose: SignPurpose,
         val signers: List<ProfileEntity>,
         val signRequest: SignRequest
     ) : AccessFactorSourcesInput

--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
@@ -28,7 +28,7 @@ import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixTextButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
-import com.babylon.wallet.android.domain.model.signing.SignType
+import com.babylon.wallet.android.domain.model.signing.SignPurpose
 import com.babylon.wallet.android.presentation.accessfactorsources.composables.RoundLedgerItem
 import com.babylon.wallet.android.presentation.accessfactorsources.signatures.GetSignaturesViewModel.State
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
@@ -73,7 +73,7 @@ fun GetSignaturesDialog(
 
     GetSignaturesBottomSheetContent(
         modifier = modifier,
-        signType = state.signType,
+        signPurpose = state.signPurpose,
         showContentForFactorSource = state.showContentForFactorSource,
         isRetryButtonEnabled = state.isRetryButtonEnabled,
         onDismiss = viewModel::onUserDismiss,
@@ -84,7 +84,7 @@ fun GetSignaturesDialog(
 @Composable
 private fun GetSignaturesBottomSheetContent(
     modifier: Modifier = Modifier,
-    signType: SignType,
+    signPurpose: SignPurpose,
     showContentForFactorSource: State.ShowContentForFactorSource,
     isRetryButtonEnabled: Boolean,
     onDismiss: () -> Unit,
@@ -114,9 +114,9 @@ private fun GetSignaturesBottomSheetContent(
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
             Text(
                 style = RadixTheme.typography.title,
-                text = when (signType) {
-                    SignType.SigningTransaction -> stringResource(id = R.string.factorSourceActions_signature_title)
-                    SignType.ProvingOwnership -> stringResource(id = R.string.factorSourceActions_proveOwnership_title)
+                text = when (signPurpose) {
+                    SignPurpose.SignTransaction -> stringResource(id = R.string.factorSourceActions_signature_title)
+                    SignPurpose.SignAuth -> stringResource(id = R.string.factorSourceActions_proveOwnership_title)
                 }
             )
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
@@ -124,17 +124,17 @@ private fun GetSignaturesBottomSheetContent(
                 is State.ShowContentForFactorSource.Device -> {
                     Text(
                         style = RadixTheme.typography.body1Regular,
-                        text = when (signType) {
-                            SignType.SigningTransaction -> stringResource(id = R.string.factorSourceActions_device_messageSignature)
-                            SignType.ProvingOwnership -> stringResource(id = R.string.factorSourceActions_device_message)
+                        text = when (signPurpose) {
+                            SignPurpose.SignTransaction -> stringResource(id = R.string.factorSourceActions_device_messageSignature)
+                            SignPurpose.SignAuth -> stringResource(id = R.string.factorSourceActions_device_message)
                         }
                     )
                 }
 
                 is State.ShowContentForFactorSource.Ledger -> {
-                    val stringRes = when (signType) {
-                        SignType.SigningTransaction -> stringResource(id = R.string.factorSourceActions_ledger_messageSignature)
-                        SignType.ProvingOwnership -> stringResource(id = R.string.factorSourceActions_ledger_message)
+                    val stringRes = when (signPurpose) {
+                        SignPurpose.SignTransaction -> stringResource(id = R.string.factorSourceActions_ledger_messageSignature)
+                        SignPurpose.SignAuth -> stringResource(id = R.string.factorSourceActions_ledger_message)
                     }
                     Text(
                         text = stringRes.formattedSpans(SpanStyle(fontWeight = FontWeight.Bold)),
@@ -165,7 +165,7 @@ private fun GetSignaturesBottomSheetContent(
 fun GetSignaturesForSigningTransactionWithDevicePreview() {
     RadixWalletTheme {
         GetSignaturesBottomSheetContent(
-            signType = SignType.SigningTransaction,
+            signPurpose = SignPurpose.SignTransaction,
             showContentForFactorSource = State.ShowContentForFactorSource.Device,
             isRetryButtonEnabled = true,
             onDismiss = {},
@@ -180,7 +180,7 @@ fun GetSignaturesForSigningTransactionWithDevicePreview() {
 fun GetSignaturesForSigningTransactionWithLedgerPreview() {
     RadixWalletTheme {
         GetSignaturesBottomSheetContent(
-            signType = SignType.SigningTransaction,
+            signPurpose = SignPurpose.SignTransaction,
             showContentForFactorSource = State.ShowContentForFactorSource.Ledger(
                 ledgerFactorSource = FactorSource.Ledger.sample()
             ),
@@ -197,7 +197,7 @@ fun GetSignaturesForSigningTransactionWithLedgerPreview() {
 fun GetSignaturesForProvingOwnershipWithDevicePreview() {
     RadixWalletTheme {
         GetSignaturesBottomSheetContent(
-            signType = SignType.ProvingOwnership,
+            signPurpose = SignPurpose.SignAuth,
             showContentForFactorSource = State.ShowContentForFactorSource.Device,
             isRetryButtonEnabled = true,
             onDismiss = {},

--- a/app/src/test/java/com/babylon/wallet/android/presentation/GetSignaturesViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/GetSignaturesViewModelTest.kt
@@ -5,7 +5,7 @@ import com.babylon.wallet.android.data.dapp.model.LedgerErrorCode
 import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.model.signing.EntityWithSignature
 import com.babylon.wallet.android.domain.model.signing.SignRequest
-import com.babylon.wallet.android.domain.model.signing.SignType
+import com.babylon.wallet.android.domain.model.signing.SignPurpose
 import com.babylon.wallet.android.domain.usecases.signing.SignWithDeviceFactorSourceUseCase
 import com.babylon.wallet.android.domain.usecases.signing.SignWithLedgerFactorSourceUseCase
 import com.babylon.wallet.android.fakes.FakeProfileRepository
@@ -138,7 +138,7 @@ class GetSignaturesViewModelTest : StateViewModelTest<GetSignaturesViewModel>() 
         backgroundScope.launch(Dispatchers.Default)   { // TransactionReviewScreen needs to access factor sources to get signatures
             val result = accessFactorSourcesProxyFake.getSignatures(
                 accessFactorSourcesInput = AccessFactorSourcesInput.ToGetSignatures(
-                    signType = SignType.SigningTransaction,
+                    signPurpose = SignPurpose.SignTransaction,
                     signers = listOf(signerWithLedgerFactorSource, signerWithDeviceFactorSource),
                     signRequest = signRequest
                 )
@@ -176,7 +176,7 @@ class GetSignaturesViewModelTest : StateViewModelTest<GetSignaturesViewModel>() 
         backgroundScope.launch(Dispatchers.Default)  { // TransactionReviewScreen needs to access factor sources to get signatures
             val result = accessFactorSourcesProxyFake.getSignatures(
                 accessFactorSourcesInput = AccessFactorSourcesInput.ToGetSignatures(
-                    signType = SignType.SigningTransaction,
+                    signPurpose = SignPurpose.SignTransaction,
                     signers = signers,
                     signRequest = signRequest
                 )
@@ -235,7 +235,7 @@ class AccessFactorSourcesProxyFake : AccessFactorSourcesProxy, AccessFactorSourc
 
     override fun getInput(): AccessFactorSourcesInput {
         return AccessFactorSourcesInput.ToGetSignatures(
-            signType = SignType.SigningTransaction,
+            signPurpose = SignPurpose.SignTransaction,
             signers = signers,
             signRequest = signRequest
         )


### PR DESCRIPTION
## Description
So far wallet has been signing transaction and auth requests with `transactionSigning` instance.
This PR fixes this issue.
