### PR TITLE
[ABW-3679] - Hide own accounts text when there are no other accounts

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
@@ -276,14 +276,16 @@ private fun ChooseAccountContent(
             )
         }
 
-        item {
-            Text(
-                modifier = Modifier
-                    .padding(RadixTheme.dimensions.paddingDefault),
-                text = stringResource(id = R.string.assetTransfer_chooseReceivingAccount_chooseOwnAccount),
-                style = RadixTheme.typography.body1Regular,
-                color = RadixTheme.colors.gray1
-            )
+        if (state.ownedAccounts.isNotEmpty()) {
+            item {
+                Text(
+                    modifier = Modifier
+                        .padding(RadixTheme.dimensions.paddingDefault),
+                    text = stringResource(id = R.string.assetTransfer_chooseReceivingAccount_chooseOwnAccount),
+                    style = RadixTheme.typography.body1Regular,
+                    color = RadixTheme.colors.gray1
+                )
+            }
         }
 
         items(state.ownedAccounts.size) { index ->


### PR DESCRIPTION
[Jira Ticket](https://radixdlt.atlassian.net/browse/ABW-3679)

## Description
This PR hides "Or: Choose one of your own Accounts” text when there are no accounts to choose from in transfer flow.


## How to test

1. Account -> Transfer
2. Add a transfer for each suggested account (if there are others)
3. Verify that "Or: Choose one of your own Accounts” text is not shown when there are no accounts to choose from