### PR TITLE
[ABW-3678] Reuse same view for dApp details screen and dApp details dialog

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/dapp/DAppDetailsDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/dapp/DAppDetailsDialog.kt
@@ -94,7 +94,7 @@ private fun DAppDetailsDialogContent(
                 dAppWithResources = state.dAppWithResources,
                 isValidatingWebsite = state.isWebsiteValidating,
                 validatedWebsite = state.validatedWebsite,
-                personaList = state.personas,
+                personaList = state.authorizedPersonas,
                 onFungibleTokenClick = onFungibleClick,
                 onNonFungibleClick = onNonFungibleClick,
                 onDeleteDapp = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/dapp/DAppDetailsDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/dapp/DAppDetailsDialog.kt
@@ -1,40 +1,25 @@
 package com.babylon.wallet.android.presentation.dialogs.dapp
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
-import com.babylon.wallet.android.presentation.settings.approveddapps.dappdetail.DAppWebsiteAddressRow
-import com.babylon.wallet.android.presentation.settings.approveddapps.dappdetail.DappDefinitionAddressRow
+import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
-import com.babylon.wallet.android.presentation.ui.composables.GrayBackgroundWrapper
+import com.babylon.wallet.android.presentation.ui.composables.DappDetails
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUiMessageHandler
-import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
-import com.babylon.wallet.android.presentation.ui.composables.card.FungibleCard
-import com.babylon.wallet.android.presentation.ui.composables.card.NonFungibleCard
 import com.babylon.wallet.android.presentation.ui.composables.displayName
-import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
 import rdx.works.core.domain.resources.Resource
 
 @Composable
@@ -45,12 +30,20 @@ fun DAppDetailsDialog(
     onDismiss: () -> Unit
 ) {
     val state by viewModel.state.collectAsState()
+    LaunchedEffect(Unit) {
+        viewModel.oneOffEvent.collect { event ->
+            when (event) {
+                DAppDetailsDialogViewModel.Event.DAppDeleted -> onDismiss()
+            }
+        }
+    }
     DAppDetailsDialogContent(
         state = state,
         onMessageShown = viewModel::onMessageShown,
         onFungibleClick = onFungibleClick,
         onNonFungibleClick = onNonFungibleClick,
-        onDismiss = onDismiss
+        onDismiss = onDismiss,
+        onDeleteDapp = viewModel::onDeleteDapp
     )
 }
 
@@ -61,125 +54,54 @@ private fun DAppDetailsDialogContent(
     onFungibleClick: (Resource.FungibleResource) -> Unit,
     onNonFungibleClick: (Resource.NonFungibleResource) -> Unit,
     onMessageShown: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onDeleteDapp: () -> Unit
 ) {
+    var showDeleteDappPrompt by remember { mutableStateOf(false) }
+    if (showDeleteDappPrompt) {
+        BasicPromptAlertDialog(
+            finish = {
+                if (it) {
+                    onDeleteDapp()
+                }
+                showDeleteDappPrompt = false
+            },
+            title = {
+                Text(
+                    text = stringResource(id = R.string.authorizedDapps_forgetDappAlert_title),
+                    style = RadixTheme.typography.body2Header,
+                    color = RadixTheme.colors.gray1
+                )
+            },
+            message = {
+                Text(
+                    text = stringResource(id = R.string.authorizedDapps_forgetDappAlert_message),
+                    style = RadixTheme.typography.body2Regular,
+                    color = RadixTheme.colors.gray1
+                )
+            },
+            confirmText = stringResource(id = R.string.authorizedDapps_forgetDappAlert_forget)
+        )
+    }
     BottomSheetDialogWrapper(
         modifier = modifier,
         title = state.dAppWithResources?.dApp.displayName(),
         onDismiss = onDismiss
     ) {
         Box(modifier = Modifier.fillMaxHeight(fraction = 0.9f)) {
-            Column(
-                modifier = Modifier
-                    .background(RadixTheme.colors.defaultBackground)
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(
-                        vertical = RadixTheme.dimensions.paddingSemiLarge
-                    ),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                if (state.dAppWithResources != null) {
-                    Thumbnail.DApp(
-                        modifier = Modifier.size(104.dp),
-                        dapp = state.dAppWithResources.dApp
-                    )
-                } else {
-                    Box(
-                        modifier = Modifier
-                            .size(104.dp)
-                            .radixPlaceholder(
-                                visible = true,
-                                shape = CircleShape
-                            )
-                    )
-                }
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                HorizontalDivider(color = RadixTheme.colors.gray5)
-
-                state.dAppWithResources?.dApp?.description?.let { description ->
-
-                    Text(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(RadixTheme.dimensions.paddingDefault),
-                        text = description,
-                        style = RadixTheme.typography.body1Regular,
-                        color = RadixTheme.colors.gray1,
-                        textAlign = TextAlign.Start
-                    )
-                    HorizontalDivider(color = RadixTheme.colors.gray5)
-                }
-
-                state.dAppWithResources?.dApp?.dAppAddress?.let { dAppAddress ->
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                    DappDefinitionAddressRow(
-                        dappDefinitionAddress = dAppAddress,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = RadixTheme.dimensions.paddingDefault)
-                    )
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                }
-
-                if (state.isWebsiteValidating || state.validatedWebsite != null) {
-                    DAppWebsiteAddressRow(
-                        website = state.validatedWebsite,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = RadixTheme.dimensions.paddingDefault)
-                    )
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                }
-
-                if (state.dAppWithResources?.fungibleResources?.isNotEmpty() == true) {
-                    GrayBackgroundWrapper {
-                        Text(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(RadixTheme.dimensions.paddingDefault),
-                            text = stringResource(id = R.string.authorizedDapps_dAppDetails_tokens),
-                            style = RadixTheme.typography.body1Regular,
-                            color = RadixTheme.colors.gray2,
-                            textAlign = TextAlign.Start
-                        )
-                    }
-                }
-                state.dAppWithResources?.fungibleResources?.forEach { resource ->
-                    GrayBackgroundWrapper {
-                        FungibleCard(
-                            fungible = resource,
-                            showChevron = false,
-                            onClick = { onFungibleClick(resource) }
-                        )
-                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                    }
-                }
-
-                if (state.dAppWithResources?.nonFungibleResources?.isNotEmpty() == true) {
-                    GrayBackgroundWrapper {
-                        Text(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(RadixTheme.dimensions.paddingDefault),
-                            text = stringResource(id = R.string.authorizedDapps_dAppDetails_nfts),
-                            style = RadixTheme.typography.body1Regular,
-                            color = RadixTheme.colors.gray2,
-                            textAlign = TextAlign.Start
-                        )
-                    }
-                }
-                state.dAppWithResources?.nonFungibleResources?.forEach { resource ->
-                    GrayBackgroundWrapper {
-                        NonFungibleCard(
-                            nonFungible = resource,
-                            showChevron = false,
-                            onClick = { onNonFungibleClick(resource) }
-                        )
-                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-                    }
-                }
-            }
+            DappDetails(
+                modifier = Modifier.fillMaxSize(),
+                dAppWithResources = state.dAppWithResources,
+                isValidatingWebsite = state.isWebsiteValidating,
+                validatedWebsite = state.validatedWebsite,
+                personaList = state.personas,
+                onFungibleTokenClick = onFungibleClick,
+                onNonFungibleClick = onNonFungibleClick,
+                onDeleteDapp = {
+                    showDeleteDappPrompt = true
+                },
+                onPersonaClick = null
+            )
 
             SnackbarUiMessageHandler(
                 message = state.uiMessage,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/dapp/DAppDetailsDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/dapp/DAppDetailsDialogViewModel.kt
@@ -5,24 +5,39 @@ import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.domain.model.DAppWithResources
 import com.babylon.wallet.android.domain.usecases.GetDAppWithResourcesUseCase
 import com.babylon.wallet.android.domain.usecases.GetValidatedDAppWebsiteUseCase
+import com.babylon.wallet.android.presentation.common.OneOffEvent
+import com.babylon.wallet.android.presentation.common.OneOffEventHandler
+import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
 import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.UiState
+import com.babylon.wallet.android.presentation.dapp.authorized.login.Event
 import com.radixdlt.sargon.AccountAddress
+import com.radixdlt.sargon.AuthorizedDapp
+import com.radixdlt.sargon.Persona
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import rdx.works.core.sargon.activePersonaOnCurrentNetwork
+import rdx.works.profile.data.repository.DAppConnectionRepository
+import rdx.works.profile.domain.GetProfileUseCase
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class DAppDetailsDialogViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val dAppConnectionRepository: DAppConnectionRepository,
+    private val getProfileUseCase: GetProfileUseCase,
     getDAppWithResourcesUseCase: GetDAppWithResourcesUseCase,
     getValidatedDAppWebsiteUseCase: GetValidatedDAppWebsiteUseCase
-) : StateViewModel<DAppDetailsDialogViewModel.State>() {
+) : StateViewModel<DAppDetailsDialogViewModel.State>(), OneOffEventHandler<DAppDetailsDialogViewModel.Event> by OneOffEventHandlerImpl() {
 
     private val args = DAppDetailsDialogArgs(savedStateHandle)
+    private lateinit var authorizedDapp: AuthorizedDapp
     override fun initialState(): State = State(
         dAppDefinitionAddress = args.dAppDefinitionAddress
     )
@@ -46,6 +61,34 @@ class DAppDetailsDialogViewModel @Inject constructor(
                 }
             }
         }
+        observeDapp()
+    }
+
+    fun onDeleteDapp() {
+        viewModelScope.launch {
+            dAppConnectionRepository.deleteAuthorizedDApp(args.dAppDefinitionAddress)
+            sendEvent(Event.DAppDeleted)
+        }
+    }
+
+    private fun observeDapp() {
+        viewModelScope.launch {
+            dAppConnectionRepository.getAuthorizedDAppFlow(args.dAppDefinitionAddress).collect {
+                if (it == null) {
+                    return@collect
+                } else {
+                    authorizedDapp = checkNotNull(dAppConnectionRepository.getAuthorizedDApp(args.dAppDefinitionAddress))
+                }
+                val personas = authorizedDapp.referencesToAuthorizedPersonas.mapNotNull { personaSimple ->
+                    getProfileUseCase().activePersonaOnCurrentNetwork(personaSimple.identityAddress)
+                }
+                _state.update { state ->
+                    state.copy(
+                        personas = personas.toPersistentList(),
+                    )
+                }
+            }
+        }
     }
 
     fun onMessageShown() {
@@ -57,6 +100,11 @@ class DAppDetailsDialogViewModel @Inject constructor(
         val dAppWithResources: DAppWithResources? = null,
         val validatedWebsite: String? = null,
         val isWebsiteValidating: Boolean = false,
+        val personas: ImmutableList<Persona> = persistentListOf(),
         val uiMessage: UiMessage? = null
     ) : UiState
+
+    sealed interface Event : OneOffEvent {
+        data object DAppDeleted : Event
+    }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
@@ -35,7 +34,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -55,6 +53,7 @@ import com.babylon.wallet.android.presentation.dapp.authorized.selectpersona.Per
 import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
 import com.babylon.wallet.android.presentation.ui.composables.BackIconType
 import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDialog
+import com.babylon.wallet.android.presentation.ui.composables.DappDetails
 import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
 import com.babylon.wallet.android.presentation.ui.composables.GrayBackgroundWrapper
 import com.babylon.wallet.android.presentation.ui.composables.LinkText
@@ -65,12 +64,8 @@ import com.babylon.wallet.android.presentation.ui.composables.SimpleAccountCard
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.composables.WarningButton
 import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.ActionableAddressView
-import com.babylon.wallet.android.presentation.ui.composables.card.FungibleCard
-import com.babylon.wallet.android.presentation.ui.composables.card.NonFungibleCard
-import com.babylon.wallet.android.presentation.ui.composables.card.PersonaCard
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
 import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
-import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.Address
 import com.radixdlt.sargon.AppearanceId
@@ -278,175 +273,6 @@ private fun DappDetailContent(
                 }
             }
         )
-    }
-}
-
-@Composable
-private fun DappDetails(
-    modifier: Modifier,
-    dAppWithResources: DAppWithResources?,
-    isValidatingWebsite: Boolean,
-    validatedWebsite: String?,
-    personaList: ImmutableList<Persona>,
-    onPersonaClick: (Persona) -> Unit,
-    onFungibleTokenClick: (Resource.FungibleResource) -> Unit,
-    onNonFungibleClick: (Resource.NonFungibleResource) -> Unit,
-    onDeleteDapp: () -> Unit
-) {
-    Column(modifier = modifier) {
-        LazyColumn(
-            contentPadding = PaddingValues(vertical = dimensions.paddingLarge),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .fillMaxSize()
-        ) {
-            dAppWithResources?.let { dAppWithResources ->
-                item {
-                    Thumbnail.DApp(
-                        modifier = Modifier
-                            .size(104.dp),
-                        dapp = dAppWithResources.dApp
-                    )
-                    Spacer(modifier = Modifier.height(dimensions.paddingLarge))
-                    HorizontalDivider(color = RadixTheme.colors.gray4, modifier = Modifier.padding(horizontal = dimensions.paddingXLarge))
-                }
-                dAppWithResources.dApp.description?.let { description ->
-                    item {
-                        Text(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = dimensions.paddingXLarge, vertical = dimensions.paddingLarge),
-                            text = description,
-                            style = RadixTheme.typography.body1Regular,
-                            color = RadixTheme.colors.gray1,
-                            textAlign = TextAlign.Start
-                        )
-                        HorizontalDivider(
-                            color = RadixTheme.colors.gray4,
-                            modifier = Modifier.padding(horizontal = dimensions.paddingXLarge)
-                        )
-                    }
-                }
-                item {
-                    Spacer(modifier = Modifier.height(dimensions.paddingLarge))
-                    DappDefinitionAddressRow(
-                        dappDefinitionAddress = dAppWithResources.dApp.dAppAddress,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dimensions.paddingXLarge)
-                    )
-                    Spacer(modifier = Modifier.height(dimensions.paddingDefault))
-                }
-                if (isValidatingWebsite || validatedWebsite != null) {
-                    item {
-                        DAppWebsiteAddressRow(
-                            website = validatedWebsite,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = dimensions.paddingXLarge)
-                        )
-                        Spacer(modifier = Modifier.height(dimensions.paddingLarge))
-                    }
-                }
-                if (dAppWithResources.fungibleResources.isNotEmpty()) {
-                    item {
-                        Text(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = dimensions.paddingXLarge),
-                            text = stringResource(id = R.string.authorizedDapps_dAppDetails_tokens),
-                            style = RadixTheme.typography.body1Regular,
-                            color = RadixTheme.colors.gray2,
-                            textAlign = TextAlign.Start
-                        )
-                        Spacer(modifier = Modifier.height(dimensions.paddingDefault))
-                    }
-                    itemsIndexed(dAppWithResources.fungibleResources) { index, fungibleToken ->
-                        val spacerHeight = if (dAppWithResources.fungibleResources.lastIndex == index) {
-                            dimensions.paddingLarge
-                        } else {
-                            dimensions.paddingDefault
-                        }
-                        FungibleCard(
-                            modifier = Modifier.padding(horizontal = dimensions.paddingDefault),
-                            fungible = fungibleToken,
-                            showChevron = false,
-                            onClick = {
-                                onFungibleTokenClick(fungibleToken)
-                            }
-                        )
-                        Spacer(modifier = Modifier.height(spacerHeight))
-                    }
-                }
-                if (dAppWithResources.nonFungibleResources.isNotEmpty()) {
-                    item {
-                        Text(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = dimensions.paddingXLarge),
-                            text = stringResource(id = R.string.authorizedDapps_dAppDetails_nfts),
-                            style = RadixTheme.typography.body1Regular,
-                            color = RadixTheme.colors.gray2,
-                            textAlign = TextAlign.Start
-                        )
-                        Spacer(modifier = Modifier.height(dimensions.paddingDefault))
-                    }
-                    itemsIndexed(dAppWithResources.nonFungibleResources) { index, nonFungibleResource ->
-                        val spacerHeight = if (dAppWithResources.nonFungibleResources.lastIndex == index) {
-                            dimensions.paddingLarge
-                        } else {
-                            dimensions.paddingDefault
-                        }
-                        NonFungibleCard(
-                            modifier = Modifier.padding(horizontal = dimensions.paddingDefault),
-                            nonFungible = nonFungibleResource,
-                            showChevron = false,
-                            onClick = {
-                                onNonFungibleClick(nonFungibleResource)
-                            }
-                        )
-                        Spacer(modifier = Modifier.height(spacerHeight))
-                    }
-                }
-                item {
-                    GrayBackgroundWrapper(contentPadding = PaddingValues(horizontal = dimensions.paddingLarge)) {
-                        Spacer(modifier = Modifier.height(dimensions.paddingLarge))
-                        Text(
-                            modifier = Modifier.fillMaxWidth(),
-                            text = stringResource(R.string.authorizedDapps_dAppDetails_personasHeading),
-                            style = RadixTheme.typography.body1HighImportance,
-                            color = RadixTheme.colors.gray2
-                        )
-                        Spacer(modifier = Modifier.height(dimensions.paddingLarge))
-                    }
-                }
-                itemsIndexed(personaList) { index, persona ->
-                    val spacerHeight = if (personaList.lastIndex == index) {
-                        dimensions.paddingXXXLarge
-                    } else {
-                        dimensions.paddingDefault
-                    }
-                    GrayBackgroundWrapper {
-                        PersonaCard(
-                            modifier = Modifier.throttleClickable {
-                                onPersonaClick(persona)
-                            },
-                            persona = persona
-                        )
-                        Spacer(modifier = Modifier.height(spacerHeight))
-                    }
-                }
-                item {
-                    Spacer(modifier = Modifier.height(dimensions.paddingDefault))
-                    WarningButton(
-                        modifier = Modifier
-                            .padding(horizontal = dimensions.paddingDefault),
-                        text = stringResource(R.string.authorizedDapps_dAppDetails_forgetDapp),
-                        onClick = onDeleteDapp
-                    )
-                }
-            }
-        }
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
@@ -209,7 +209,7 @@ private fun DappDetailContent(
                 dAppWithResources = state.dAppWithResources,
                 isValidatingWebsite = state.isValidatingWebsite,
                 validatedWebsite = state.validatedWebsite,
-                personaList = state.personas,
+                personaList = state.authorizedPersonas,
                 onPersonaClick = { persona ->
                     onPersonaClick(persona)
                     scope.launch {
@@ -568,7 +568,7 @@ private fun DappDetailContentPreview(
             onBackClick = {},
             state = DappDetailUiState(
                 loading = false,
-                personas = persistentListOf(Persona.sampleMainnet(), Persona.sampleMainnet.ripley),
+                authorizedPersonas = persistentListOf(Persona.sampleMainnet(), Persona.sampleMainnet.ripley),
                 dAppWithResources = previewValues.first,
                 sharedPersonaAccounts = persistentListOf(
                     AccountItemUiModel(AccountAddress.sampleMainnet.random(), "Account1", AppearanceId(0u))

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/PersonasScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/PersonasScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -119,9 +120,11 @@ fun PersonasContent(
 //                }
                 itemsIndexed(items = state.personas) { _, personaItem ->
                     PersonaCard(
-                        modifier = Modifier.throttleClickable {
-                            onPersonaClick(personaItem.address)
-                        },
+                        modifier = Modifier
+                            .clip(RadixTheme.shapes.roundedRectMedium)
+                            .throttleClickable {
+                                onPersonaClick(personaItem.address)
+                            },
                         persona = personaItem,
                         securityPrompts = state.securityPrompt(personaItem)?.toPersistentList(),
                         onNavigateToSecurityCenter = onNavigateToSecurityCenter

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DappDetails.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DappDetails.kt
@@ -186,6 +186,7 @@ fun DappDetails(
                                     onPersonaClick?.invoke(persona)
                                 }
                             ),
+                            showChevron = onPersonaClick != null,
                             persona = persona
                         )
                         Spacer(modifier = Modifier.height(spacerHeight))

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DappDetails.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/DappDetails.kt
@@ -1,0 +1,206 @@
+package com.babylon.wallet.android.presentation.ui.composables
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.babylon.wallet.android.R
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.designsystem.theme.RadixTheme.dimensions
+import com.babylon.wallet.android.domain.model.DAppWithResources
+import com.babylon.wallet.android.presentation.settings.approveddapps.dappdetail.DAppWebsiteAddressRow
+import com.babylon.wallet.android.presentation.settings.approveddapps.dappdetail.DappDefinitionAddressRow
+import com.babylon.wallet.android.presentation.ui.composables.card.FungibleCard
+import com.babylon.wallet.android.presentation.ui.composables.card.NonFungibleCard
+import com.babylon.wallet.android.presentation.ui.composables.card.PersonaCard
+import com.babylon.wallet.android.presentation.ui.modifier.applyIf
+import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
+import com.radixdlt.sargon.Persona
+import kotlinx.collections.immutable.ImmutableList
+import rdx.works.core.domain.resources.Resource
+
+@Composable
+fun DappDetails(
+    modifier: Modifier,
+    dAppWithResources: DAppWithResources?,
+    isValidatingWebsite: Boolean,
+    validatedWebsite: String?,
+    personaList: ImmutableList<Persona>,
+    onPersonaClick: ((Persona) -> Unit)?,
+    onFungibleTokenClick: (Resource.FungibleResource) -> Unit,
+    onNonFungibleClick: (Resource.NonFungibleResource) -> Unit,
+    onDeleteDapp: () -> Unit
+) {
+    Column(modifier = modifier) {
+        LazyColumn(
+            contentPadding = PaddingValues(vertical = dimensions.paddingLarge),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxSize()
+        ) {
+            dAppWithResources?.let { dAppWithResources ->
+                item {
+                    Thumbnail.DApp(
+                        modifier = Modifier
+                            .size(104.dp),
+                        dapp = dAppWithResources.dApp
+                    )
+                    Spacer(modifier = Modifier.height(dimensions.paddingLarge))
+                    HorizontalDivider(color = RadixTheme.colors.gray4, modifier = Modifier.padding(horizontal = dimensions.paddingXLarge))
+                }
+                dAppWithResources.dApp.description?.let { description ->
+                    item {
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = dimensions.paddingXLarge, vertical = dimensions.paddingLarge),
+                            text = description,
+                            style = RadixTheme.typography.body1Regular,
+                            color = RadixTheme.colors.gray1,
+                            textAlign = TextAlign.Start
+                        )
+                        HorizontalDivider(
+                            color = RadixTheme.colors.gray4,
+                            modifier = Modifier.padding(horizontal = dimensions.paddingXLarge)
+                        )
+                    }
+                }
+                item {
+                    Spacer(modifier = Modifier.height(dimensions.paddingLarge))
+                    DappDefinitionAddressRow(
+                        dappDefinitionAddress = dAppWithResources.dApp.dAppAddress,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = dimensions.paddingXLarge)
+                    )
+                    Spacer(modifier = Modifier.height(dimensions.paddingDefault))
+                }
+                if (isValidatingWebsite || validatedWebsite != null) {
+                    item {
+                        DAppWebsiteAddressRow(
+                            website = validatedWebsite,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = dimensions.paddingXLarge)
+                        )
+                        Spacer(modifier = Modifier.height(dimensions.paddingLarge))
+                    }
+                }
+                if (dAppWithResources.fungibleResources.isNotEmpty()) {
+                    item {
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = dimensions.paddingXLarge),
+                            text = stringResource(id = R.string.authorizedDapps_dAppDetails_tokens),
+                            style = RadixTheme.typography.body1Regular,
+                            color = RadixTheme.colors.gray2,
+                            textAlign = TextAlign.Start
+                        )
+                        Spacer(modifier = Modifier.height(dimensions.paddingDefault))
+                    }
+                    itemsIndexed(dAppWithResources.fungibleResources) { index, fungibleToken ->
+                        val spacerHeight = if (dAppWithResources.fungibleResources.lastIndex == index) {
+                            dimensions.paddingLarge
+                        } else {
+                            dimensions.paddingDefault
+                        }
+                        FungibleCard(
+                            modifier = Modifier.padding(horizontal = dimensions.paddingDefault),
+                            fungible = fungibleToken,
+                            showChevron = false,
+                            onClick = {
+                                onFungibleTokenClick(fungibleToken)
+                            }
+                        )
+                        Spacer(modifier = Modifier.height(spacerHeight))
+                    }
+                }
+                if (dAppWithResources.nonFungibleResources.isNotEmpty()) {
+                    item {
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = dimensions.paddingXLarge),
+                            text = stringResource(id = R.string.authorizedDapps_dAppDetails_nfts),
+                            style = RadixTheme.typography.body1Regular,
+                            color = RadixTheme.colors.gray2,
+                            textAlign = TextAlign.Start
+                        )
+                        Spacer(modifier = Modifier.height(dimensions.paddingDefault))
+                    }
+                    itemsIndexed(dAppWithResources.nonFungibleResources) { index, nonFungibleResource ->
+                        val spacerHeight = if (dAppWithResources.nonFungibleResources.lastIndex == index) {
+                            dimensions.paddingLarge
+                        } else {
+                            dimensions.paddingDefault
+                        }
+                        NonFungibleCard(
+                            modifier = Modifier.padding(horizontal = dimensions.paddingDefault),
+                            nonFungible = nonFungibleResource,
+                            showChevron = false,
+                            onClick = {
+                                onNonFungibleClick(nonFungibleResource)
+                            }
+                        )
+                        Spacer(modifier = Modifier.height(spacerHeight))
+                    }
+                }
+                item {
+                    GrayBackgroundWrapper(contentPadding = PaddingValues(horizontal = dimensions.paddingLarge)) {
+                        Spacer(modifier = Modifier.height(dimensions.paddingLarge))
+                        Text(
+                            modifier = Modifier.fillMaxWidth(),
+                            text = stringResource(R.string.authorizedDapps_dAppDetails_personasHeading),
+                            style = RadixTheme.typography.body1HighImportance,
+                            color = RadixTheme.colors.gray2
+                        )
+                        Spacer(modifier = Modifier.height(dimensions.paddingLarge))
+                    }
+                }
+                itemsIndexed(personaList) { index, persona ->
+                    val spacerHeight = if (personaList.lastIndex == index) {
+                        dimensions.paddingXXXLarge
+                    } else {
+                        dimensions.paddingDefault
+                    }
+                    GrayBackgroundWrapper {
+                        PersonaCard(
+                            modifier = Modifier.applyIf(
+                                onPersonaClick != null,
+                                Modifier.throttleClickable {
+                                    onPersonaClick?.invoke(persona)
+                                }
+                            ),
+                            persona = persona
+                        )
+                        Spacer(modifier = Modifier.height(spacerHeight))
+                    }
+                }
+                item {
+                    Spacer(modifier = Modifier.height(dimensions.paddingDefault))
+                    WarningButton(
+                        modifier = Modifier
+                            .padding(horizontal = dimensions.paddingDefault),
+                        text = stringResource(R.string.authorizedDapps_dAppDetails_forgetDapp),
+                        onClick = onDeleteDapp
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/PersonaCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/PersonaCard.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -52,7 +51,6 @@ fun PersonaCard(
     Column(
         modifier = modifier
             .defaultCardShadow(elevation = elevation)
-            .clip(RadixTheme.shapes.roundedRectMedium)
             .fillMaxWidth()
             .background(RadixTheme.colors.white, shape = RadixTheme.shapes.roundedRectMedium)
             .padding(

--- a/app/src/test/java/com/babylon/wallet/android/presentation/settings/authorizeddapps/ApprovedDappsViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/settings/authorizeddapps/ApprovedDappsViewModelTest.kt
@@ -116,7 +116,7 @@ internal class ApprovedDappsViewModelTest : StateViewModelTest<DappDetailViewMod
             val item = expectMostRecentItem()
             assert(item.dAppWithResources != null)
             assert(item.dapp != null)
-            assert(item.personas.size == 1)
+            assert(item.authorizedPersonas.size == 1)
         }
     }
 

--- a/app/src/test/java/com/babylon/wallet/android/presentation/settings/dappdetail/DappDetailViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/settings/dappdetail/DappDetailViewModelTest.kt
@@ -117,7 +117,7 @@ internal class DappDetailViewModelTest : StateViewModelTest<DappDetailViewModel>
             val item = expectMostRecentItem()
             assertNotNull(item.dAppWithResources)
             assertNotNull(item.dapp)
-            assertEquals(1, item.personas.size)
+            assertEquals(1, item.authorizedPersonas.size)
         }
     }
 


### PR DESCRIPTION
## Description
- reuse same UI for dapp details screen and dapp details dialog accessible from persona details.

Since this is `dialog` destination, it's not respecting edge to edge - I think we have similar issue with other dialogs that use `dialog`. This can't be fix easily without changing dialog to be part of the screen, unless I'm missing something here

## How to test

1. Verify that details opened by " personas -> persona detail -> dApp click " are the same as the one opened in from "Approved Dapps" screen. Verify that forget this dapp removes dApp from the persona and dismisses dialog.
