### PR TITLE
[ABW-3708] Update persona detail sheet on dapp detail screen

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
@@ -671,19 +671,19 @@ private fun PersonaDetailList(
                     Spacer(modifier = Modifier.height(dimensions.paddingDefault))
                 }
             }
-        }
-        item {
-            GrayBackgroundWrapper(Modifier.fillMaxWidth()) {
-                RadixSecondaryButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = dimensions.paddingLarge),
-                    text = stringResource(
-                        R.string.authorizedDapps_personaDetails_editAccountSharing
-                    ),
-                    onClick = onEditAccountSharing
-                )
-                Spacer(modifier = Modifier.height(dimensions.paddingDefault))
+            item {
+                GrayBackgroundWrapper(Modifier.fillMaxWidth()) {
+                    RadixSecondaryButton(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = dimensions.paddingLarge),
+                        text = stringResource(
+                            R.string.authorizedDapps_personaDetails_editAccountSharing
+                        ),
+                        onClick = onEditAccountSharing
+                    )
+                    Spacer(modifier = Modifier.height(dimensions.paddingDefault))
+                }
             }
         }
         item {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
@@ -671,31 +671,31 @@ private fun PersonaDetailList(
                     Spacer(modifier = Modifier.height(dimensions.paddingDefault))
                 }
             }
-            item {
-                GrayBackgroundWrapper(Modifier.fillMaxWidth()) {
-                    RadixSecondaryButton(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = dimensions.paddingLarge),
-                        text = stringResource(
-                            R.string.authorizedDapps_personaDetails_editAccountSharing
-                        ),
-                        onClick = onEditAccountSharing
-                    )
-                    Spacer(modifier = Modifier.height(dimensions.paddingDefault))
-                }
-            }
-            item {
-                HorizontalDivider(color = RadixTheme.colors.gray5)
-                Spacer(modifier = Modifier.height(dimensions.paddingDefault))
-                WarningButton(
-                    modifier = Modifier.padding(horizontal = dimensions.paddingDefault),
-                    text = stringResource(id = R.string.authorizedDapps_personaDetails_removeAuthorization),
-                    onClick = {
-                        onDisconnectPersona(persona.persona)
-                    }
+        }
+        item {
+            GrayBackgroundWrapper(Modifier.fillMaxWidth()) {
+                RadixSecondaryButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = dimensions.paddingLarge),
+                    text = stringResource(
+                        R.string.authorizedDapps_personaDetails_editAccountSharing
+                    ),
+                    onClick = onEditAccountSharing
                 )
+                Spacer(modifier = Modifier.height(dimensions.paddingDefault))
             }
+        }
+        item {
+            HorizontalDivider(color = RadixTheme.colors.gray5)
+            Spacer(modifier = Modifier.height(dimensions.paddingDefault))
+            WarningButton(
+                modifier = Modifier.padding(horizontal = dimensions.paddingDefault),
+                text = stringResource(id = R.string.authorizedDapps_personaDetails_removeAuthorization),
+                onClick = {
+                    onDisconnectPersona(persona.persona)
+                }
+            )
         }
     }
 }


### PR DESCRIPTION
## Description
- visibility of disconnect button was tied to accounts shared with that persona. If they were empty - button was not shown, which is clearly wrong.


## How to test

1. Share some persona data with a dApp, then go to dapp details -> persona sheet - observe "Disconnect" button is not shown before this fix.