### PR TITLE
[ABW-3709] - Fix restore mnemonic transition animations

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -53,6 +53,7 @@ import com.babylon.wallet.android.presentation.onboarding.restore.backup.restore
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonic.MnemonicType
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonic.addSingleMnemonic
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.RestoreMnemonicsArgs
+import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.RestoreMnemonicsRequestSource
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.restoreMnemonics
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.restoreMnemonicsScreen
 import com.babylon.wallet.android.presentation.onboarding.restore.withoutbackup.restoreWithoutBackupScreen
@@ -156,7 +157,12 @@ fun NavigationHost(
                 navController.popBackStack()
             },
             onRestoreConfirmed = {
-                navController.restoreMnemonics(args = RestoreMnemonicsArgs(backupType = it))
+                navController.restoreMnemonics(
+                    args = RestoreMnemonicsArgs(
+                        backupType = it,
+                        requestSource = RestoreMnemonicsRequestSource.Onboarding
+                    )
+                )
             },
             onOtherRestoreOptionsClick = {
                 navController.restoreWithoutBackupScreen()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsNav.kt
@@ -1,41 +1,51 @@
 package com.babylon.wallet.android.presentation.onboarding.restore.mnemonics
 
+import android.os.Build
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.babylon.wallet.android.presentation.navigation.markAsHighPriority
+import com.babylon.wallet.android.presentation.settings.personas.createpersona.ARG_REQUEST_SOURCE
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import rdx.works.profile.domain.backup.BackupType
 
+private const val ARGS_REQUEST_SOURCE = "arg_request_source"
 private const val ARGS_BACKUP_TYPE = "backup_type"
-private const val ROUTE = "restore_mnemonics?$ARGS_BACKUP_TYPE={$ARGS_BACKUP_TYPE}"
+private const val ROUTE = "restore_mnemonics?$ARGS_BACKUP_TYPE={$ARGS_BACKUP_TYPE}&$ARGS_REQUEST_SOURCE={$ARGS_REQUEST_SOURCE}"
+
+enum class RestoreMnemonicsRequestSource {
+    Onboarding, Settings
+}
 
 fun NavController.restoreMnemonics(
     args: RestoreMnemonicsArgs
 ) {
     val backupType = Json.encodeToString(args.backupType)
-    navigate(route = "restore_mnemonics?$ARGS_BACKUP_TYPE=$backupType")
+    navigate(route = "restore_mnemonics?$ARGS_BACKUP_TYPE=$backupType&$ARGS_REQUEST_SOURCE=${args.requestSource}")
 }
 
 @Serializable
 data class RestoreMnemonicsArgs(
-    val backupType: BackupType? = null
+    val backupType: BackupType? = null,
+    val requestSource: RestoreMnemonicsRequestSource
 ) {
     companion object {
         fun from(savedStateHandle: SavedStateHandle): RestoreMnemonicsArgs {
             val backupType: BackupType? = savedStateHandle.get<String>(ARGS_BACKUP_TYPE)?.let {
                 Json.decodeFromString(it)
             }
-            return RestoreMnemonicsArgs(backupType)
+            val requestSource = checkNotNull(savedStateHandle[ARGS_REQUEST_SOURCE]) as RestoreMnemonicsRequestSource
+            return RestoreMnemonicsArgs(backupType, requestSource)
         }
     }
 }
@@ -53,6 +63,9 @@ fun NavGraphBuilder.restoreMnemonicsScreen(
             ) {
                 nullable = true
                 type = NavType.StringType
+            },
+            navArgument(ARGS_REQUEST_SOURCE) {
+                type = NavType.EnumType(RestoreMnemonicsRequestSource::class.java)
             }
         ),
         enterTransition = {
@@ -65,7 +78,12 @@ fun NavGraphBuilder.restoreMnemonicsScreen(
             EnterTransition.None
         },
         popExitTransition = {
-            slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Right)
+            slideOutOfContainer(
+                when (initialState.getRequestSource()) {
+                    RestoreMnemonicsRequestSource.Onboarding -> AnimatedContentTransitionScope.SlideDirection.Left
+                    RestoreMnemonicsRequestSource.Settings -> AnimatedContentTransitionScope.SlideDirection.Right
+                }
+            )
         }
     ) {
         RestoreMnemonicsScreen(
@@ -73,5 +91,13 @@ fun NavGraphBuilder.restoreMnemonicsScreen(
             onCloseApp = onCloseApp,
             onDismiss = onDismiss
         )
+    }
+}
+
+private fun NavBackStackEntry.getRequestSource(): RestoreMnemonicsRequestSource {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        checkNotNull(arguments?.getSerializable(ARG_REQUEST_SOURCE, RestoreMnemonicsRequestSource::class.java))
+    } else {
+        arguments?.getSerializable(ARG_REQUEST_SOURCE) as RestoreMnemonicsRequestSource
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -235,11 +235,14 @@ private fun RestoreMnemonicsContent(
         containerColor = RadixTheme.colors.defaultBackground
     ) { padding ->
         if (state.screenType !is RestoreMnemonicsViewModel.State.ScreenType.Loading) {
+            val enterTransition = slideInHorizontally(initialOffsetX = { if (state.isMovingForward) it else -it })
+            val exitTransition = slideOutHorizontally(targetOffsetX = { if (state.isMovingForward) -it else it })
+
             AnimatedVisibility(
                 modifier = Modifier.padding(padding),
                 visible = state.screenType is RestoreMnemonicsViewModel.State.ScreenType.Entities,
-                enter = slideInHorizontally(initialOffsetX = { if (state.isMovingForward) it else -it }),
-                exit = slideOutHorizontally(targetOffsetX = { if (state.isMovingForward) it else -it })
+                enter = enterTransition,
+                exit = exitTransition
             ) {
                 EntitiesView(
                     state = state
@@ -256,8 +259,8 @@ private fun RestoreMnemonicsContent(
                     }
                 ),
                 visible = state.screenType is RestoreMnemonicsViewModel.State.ScreenType.SeedPhrase,
-                enter = slideInHorizontally(initialOffsetX = { if (state.isMovingForward) -it else it }),
-                exit = slideOutHorizontally(targetOffsetX = { if (state.isMovingForward) -it else it })
+                enter = enterTransition,
+                exit = exitTransition
             ) {
                 SeedPhraseView(
                     state = state,
@@ -270,8 +273,8 @@ private fun RestoreMnemonicsContent(
             AnimatedVisibility(
                 modifier = Modifier.padding(padding),
                 visible = state.screenType is RestoreMnemonicsViewModel.State.ScreenType.NoMainSeedPhrase,
-                enter = slideInHorizontally(initialOffsetX = { if (state.isMovingForward) -it else it }),
-                exit = slideOutHorizontally(targetOffsetX = { if (state.isMovingForward) -it else it })
+                enter = enterTransition,
+                exit = exitTransition
             ) {
                 NoMainSeedPhraseView()
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -132,7 +132,10 @@ class RestoreMnemonicsViewModel @Inject constructor(
 
     fun onSkipMainSeedPhraseClick() {
         _state.update {
-            it.copy(screenType = State.ScreenType.NoMainSeedPhrase)
+            it.copy(
+                screenType = State.ScreenType.NoMainSeedPhrase,
+                isMovingForward = true
+            )
         }
     }
 
@@ -164,7 +167,12 @@ class RestoreMnemonicsViewModel @Inject constructor(
 
     fun onSubmit() {
         if (state.value.screenType == State.ScreenType.Entities) {
-            _state.update { it.copy(screenType = State.ScreenType.SeedPhrase, isMovingForward = false) }
+            _state.update {
+                it.copy(
+                    screenType = State.ScreenType.SeedPhrase,
+                    isMovingForward = true
+                )
+            }
         } else {
             viewModelScope.launch { restoreMnemonic() }
         }
@@ -205,7 +213,10 @@ class RestoreMnemonicsViewModel @Inject constructor(
                 _state.update { it.copy(isPrimaryButtonLoading = true) }
 
                 args.backupType?.let { backupType ->
-                    if (skipAuth.not() && biometricAuthProvider().not()) return
+                    if (skipAuth.not() && biometricAuthProvider().not()) {
+                        _state.update { it.copy(isPrimaryButtonLoading = false) }
+                        return
+                    }
 
                     restoreProfileFromBackupUseCase(backupType = backupType, mainSeedPhraseSkipped = true)
                         .onSuccess {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/SecurityCenterNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/SecurityCenterNav.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.babylon.wallet.android.presentation.main.MAIN_ROUTE
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.RestoreMnemonicsArgs
+import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.RestoreMnemonicsRequestSource
 import com.babylon.wallet.android.presentation.onboarding.restore.mnemonics.restoreMnemonics
 import com.babylon.wallet.android.presentation.settings.SettingsItem
 import com.babylon.wallet.android.presentation.settings.securitycenter.backup.backupScreen
@@ -58,7 +59,7 @@ fun NavGraphBuilder.securityCenterNavGraph(
                     navController.backupScreen()
                 },
                 onRecoverEntitiesClick = {
-                    navController.restoreMnemonics(args = RestoreMnemonicsArgs())
+                    navController.restoreMnemonics(args = RestoreMnemonicsArgs(requestSource = RestoreMnemonicsRequestSource.Settings))
                 },
                 onBackupEntities = {
                     navController.seedPhrases()
@@ -91,7 +92,7 @@ fun NavGraphBuilder.securityCenterNavGraph(
         seedPhrases(
             onBackClick = { navController.popBackStack() },
             onNavigateToRecoverMnemonic = {
-                navController.restoreMnemonics(args = RestoreMnemonicsArgs())
+                navController.restoreMnemonics(args = RestoreMnemonicsArgs(requestSource = RestoreMnemonicsRequestSource.Settings))
             },
             onNavigateToSeedPhrase = { navController.revealSeedPhrase(it) }
         )


### PR DESCRIPTION
[Jira Ticket](https://radixdlt.atlassian.net/browse/ABW-3709)

## Description
This PR fixes transition animations between the content inside `RestoreMnemonicScreen` as well as the transition between the `RestoreMnemonicScreen` and the next screen. Additionally, fixed the primary button loading after the biometric prompt is canceled by the user. 

> Note: The transition between different Entities content inside `RestoreMnemonicScreen` cannot be seen due to the current implementation limitations: the transition being based on AnimatedVisibility composable

## How to test

Verify transition animations within restore mnemonic screen