### PR TITLE
[ABW-3710] - Fix seed phrase entry screen issue

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
@@ -143,8 +143,8 @@ private fun AddSingleMnemonicsContent(
                 SeedPhraseSuggestions(
                     wordAutocompleteCandidates = state.seedPhraseState.wordAutocompleteCandidates,
                     modifier = Modifier
-                        .fillMaxWidth()
                         .imePadding()
+                        .fillMaxWidth()
                         .height(RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight)
                         .padding(RadixTheme.dimensions.paddingSmall),
                     onCandidateClick = { candidate ->
@@ -178,25 +178,27 @@ private fun AddSingleMnemonicsContent(
             MnemonicType.Olympia -> stringResource(id = R.string.enterSeedPhrase_titleOlympia)
         }
         val isOlympia = state.mnemonicType == MnemonicType.Olympia
-        SeedPhraseView(
+        Box(
             modifier = Modifier
-                .fillMaxSize()
                 .dynamicImePadding(
                     padding = padding,
                     keyboardVisibleBottomPadding = if (isSuggestionsVisible(state)) {
-                        RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight + RadixTheme.dimensions.paddingDefault
+                        RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight
                     } else {
                         RadixTheme.dimensions.paddingDefault
                     }
-                ),
-            title = title,
-            onWordChanged = onWordTyped,
-            onPassphraseChanged = onPassphraseChanged,
-            onFocusedWordIndexChanged = { focusedWordIndex = it },
-            seedPhraseState = state.seedPhraseState,
-            onSeedPhraseLengthChanged = onSeedPhraseLengthChanged,
-            isOlympia = isOlympia
-        )
+                )
+        ) {
+            SeedPhraseView(
+                title = title,
+                onWordChanged = onWordTyped,
+                onPassphraseChanged = onPassphraseChanged,
+                onFocusedWordIndexChanged = { focusedWordIndex = it },
+                seedPhraseState = state.seedPhraseState,
+                onSeedPhraseLengthChanged = onSeedPhraseLengthChanged,
+                isOlympia = isOlympia
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -164,8 +164,8 @@ private fun RestoreMnemonicsContent(
                 SeedPhraseSuggestions(
                     wordAutocompleteCandidates = state.seedPhraseState.wordAutocompleteCandidates,
                     modifier = Modifier
-                        .fillMaxWidth()
                         .imePadding()
+                        .fillMaxWidth()
                         .height(RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight)
                         .padding(RadixTheme.dimensions.paddingSmall),
                     onCandidateClick = { candidate ->
@@ -250,7 +250,7 @@ private fun RestoreMnemonicsContent(
                 modifier = Modifier.dynamicImePadding(
                     padding = padding,
                     keyboardVisibleBottomPadding = if (isSuggestionsVisible(state)) {
-                        RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight + RadixTheme.dimensions.paddingDefault
+                        RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight
                     } else {
                         RadixTheme.dimensions.paddingDefault
                     }


### PR DESCRIPTION
[Jira Ticket](https://radixdlt.atlassian.net/browse/ABW-3710)

## Description
This PR attempts to fix the issue when the seed phrase entry screen is cut out at the bottom (most likely because of unnecessary ime padding). The fix relies on using exactly the same code as in `RestoreMnemonicScreen` where the issue doesn't occur.


## How to test

1. Go to Wallet Settings -> Troubleshooting -> Account recovery scan -> seed phrase entry
2. Go back and forth and check that the seed phrase entry screen is not cut out
