### PR TITLE
[ABW-3707] Verify 2 way link for dapp resources/dapps in tx review

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetDAppWithResourcesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/GetDAppWithResourcesUseCase.kt
@@ -16,8 +16,7 @@ class GetDAppWithResourcesUseCase @Inject constructor(
 
     suspend operator fun invoke(
         definitionAddress: AccountAddress,
-        needMostRecentData: Boolean,
-        verifyResources: Boolean = true
+        needMostRecentData: Boolean
     ): Result<DAppWithResources> = stateRepository.getDAppsDetails(
         definitionAddresses = listOf(definitionAddress),
         isRefreshing = needMostRecentData
@@ -32,16 +31,14 @@ class GetDAppWithResourcesUseCase @Inject constructor(
             withDetails = false,
             withAllMetadata = false
         ).getOrNull().orEmpty()
-        val dAppResources = if (verifyResources) {
-            resources.filter { it.metadata.dAppDefinitions().contains(definitionAddress.string) }
-        } else {
-            resources
+        val verifiedResources = resources.filter {
+            it.metadata.dAppDefinitions().contains(definitionAddress.string)
         }
 
         DAppWithResources(
             dApp = dApp,
-            fungibleResources = dAppResources.filterIsInstance<Resource.FungibleResource>(),
-            nonFungibleResources = dAppResources.filterIsInstance<Resource.NonFungibleResource>()
+            fungibleResources = verifiedResources.filterIsInstance<Resource.FungibleResource>(),
+            nonFungibleResources = verifiedResources.filterIsInstance<Resource.NonFungibleResource>()
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/ResolveComponentAddressesUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/ResolveComponentAddressesUseCase.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.domain.usecases
 
 import com.babylon.wallet.android.data.repository.state.StateRepository
 import com.radixdlt.sargon.ComponentAddress
+import com.radixdlt.sargon.extensions.string
 import rdx.works.core.domain.DApp
 import rdx.works.core.then
 import javax.inject.Inject
@@ -29,7 +30,7 @@ class ResolveComponentAddressesUseCase @Inject constructor(
                 isRefreshing = true
             ).mapCatching { dApps ->
                 val dApp = dApps.first()
-                componentAddress to dApp
+                componentAddress to dApp.takeIf { it.claimedEntities.contains(componentAddress.string) }
             }
         } else {
             Result.success(componentAddress to null)

--- a/core/src/main/java/rdx/works/core/domain/resources/metadata/StandardMetadata.kt
+++ b/core/src/main/java/rdx/works/core/domain/resources/metadata/StandardMetadata.kt
@@ -102,6 +102,11 @@ fun List<Metadata>.dAppDefinition(): String? {
     )?.value
 }
 
+fun List<Metadata>.dAppDefinitions(): List<String> = findCollection(
+    key = ExplicitMetadataKey.DAPP_DEFINITIONS,
+    type = MetadataType.String
+)?.map { it.value }.orEmpty()
+
 fun List<Metadata>.claimedWebsites(): List<String>? = findCollection(
     key = ExplicitMetadataKey.CLAIMED_WEBSITES,
     type = MetadataType.Url


### PR DESCRIPTION
## Description
- for dApps resolution in tx review - check if dapp links back to the component
- for dApp resources - validate if resource lists dApp address in `dapp_definitions` and filter out those that do not

Additional context can be found in the ticket [here](https://radixdlt.atlassian.net/browse/ABW-3707?atlOrigin=eyJpIjoiNTYwYzUwMDE5YWJiNDEzYThjMGY1ZGY3NzlkMWYwODIiLCJwIjoiaiJ9)

## How to test

1. For first case I can't give specific transaction to test this - I was tampering with the data in debug mode to reproduce situation when component is unknown
2. For second case - connect with Radquest, and see there are 14 resources listed before the fix, after the fix there are only 12 of them, as 2 of them do not link back to Radquest dApp
