### PR TITLE
[ABW-2698] Add space between buttons in account card

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/address/AddressDetailsDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/address/AddressDetailsDialog.kt
@@ -346,6 +346,7 @@ private fun VerifyAddressOnLedger(
     RadixSecondaryButton(
         modifier = modifier
             .fillMaxWidth()
+            .padding(top = RadixTheme.dimensions.paddingDefault)
             .padding(horizontal = RadixTheme.dimensions.paddingDefault),
         text = stringResource(id = R.string.addressDetails_verifyOnLedger),
         onClick = onClick,


### PR DESCRIPTION
## Description
left image: device account 
right  image: ledger account (dialog is scrolled all the way to the bottom)

<img width="300" alt="Screenshot 2024-08-08 at 16 22 22" src="https://github.com/user-attachments/assets/9448d092-a7a6-4091-b4aa-52e7e7143f5a"> <img width="300" alt="Screenshot 2024-08-08 at 16 22 50" src="https://github.com/user-attachments/assets/4d2781f2-0446-43fb-b6b4-f713e4d8a871">

## How to test

1. Open a ledger account and verify there space between the two buttons at the bottom of the dialog