### PR TITLE
Update sheets insets

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FiltersDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/FiltersDialog.kt
@@ -80,6 +80,7 @@ fun FiltersDialog(
             RadixBottomBar(
                 onClick = onDismiss,
                 text = stringResource(id = R.string.transactionHistory_filters_showResultsButton),
+                insets = WindowInsets(0.dp)
             )
         },
         containerColor = RadixTheme.colors.defaultBackground

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/accounts/ChooseAccountSheet.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -112,10 +111,7 @@ fun ChooseAccountSheet(
                     onClick = onChooseAccountSubmitted,
                     text = stringResource(id = R.string.common_choose),
                     enabled = state.isChooseButtonEnabled,
-                    isLoading = state.isLoadingAssetsForAccount,
-                    // Since the sheet is configured inside BottomSheetDialogWrapper, bottom padding is already added
-                    // This should be fixed
-                    insets = WindowInsets(0.dp)
+                    isLoading = state.isLoadingAssetsForAccount
                 )
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/ChooseAssetsSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/ChooseAssetsSheet.kt
@@ -2,7 +2,6 @@ package com.babylon.wallet.android.presentation.transfer.assets
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -13,7 +12,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
@@ -72,10 +70,7 @@ fun ChooseAssetsSheet(
                     1 -> stringResource(id = R.string.assetTransfer_addAssets_buttonAssetsOne)
                     else -> stringResource(id = R.string.assetTransfer_addAssets_buttonAssets, count)
                 },
-                enabled = state.isSubmitEnabled,
-                // Since the sheet is configured inside BottomSheetDialogWrapper, bottom padding is already added
-                // This should be fixed
-                insets = WindowInsets(0.dp)
+                enabled = state.isSubmitEnabled
             )
         },
         snackbarHost = {


### PR DESCRIPTION
## Description
- asset chooser - transfer
- account chooser - transfer
- filters dialog on history screen
This problem was result of recent padding updates I did, sheets listed above declared specific insets values to adjust for `navigationBarsPadding()` that was used in the sheet themselves.

## How to test

1. Before the fix UI either overlaps with navigation bar or padding is too big (history filters dialog)
