### PR TITLE
[ABW-2699] Add divisibility for fungible resources

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/fungible/FungibleDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/fungible/FungibleDialogContent.kt
@@ -150,6 +150,26 @@ fun FungibleDialogContent(
                 )
             }
 
+            token?.resource?.divisibility?.let {
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                MetadataView(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingSmall),
+                    key = stringResource(id = R.string.assetDetails_divisibility)
+                ) {
+                    Text(
+                        modifier = Modifier
+                            .padding(start = RadixTheme.dimensions.paddingDefault)
+                            .widthIn(min = RadixTheme.dimensions.paddingXXXXLarge * 2),
+                        text = it.value.toString(),
+                        style = RadixTheme.typography.body1HighImportance,
+                        color = RadixTheme.colors.gray1,
+                        textAlign = TextAlign.End
+                    )
+                }
+            }
+
             BehavioursSection(
                 modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSmall),
                 isXRD = token?.resource?.isXrd ?: false,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/lsu/LSUDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/lsu/LSUDialogContent.kt
@@ -201,6 +201,26 @@ fun LSUDialogContent(
             )
         }
 
+        lsu?.fungibleResource?.divisibility?.let {
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+            MetadataView(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = RadixTheme.dimensions.paddingSmall),
+                key = stringResource(id = R.string.assetDetails_divisibility)
+            ) {
+                Text(
+                    modifier = Modifier
+                        .padding(start = RadixTheme.dimensions.paddingDefault)
+                        .widthIn(min = RadixTheme.dimensions.paddingXXXXLarge * 2),
+                    text = it.value.toString(),
+                    style = RadixTheme.typography.body1HighImportance,
+                    color = RadixTheme.colors.gray1,
+                    textAlign = TextAlign.End
+                )
+            }
+        }
+
         BehavioursSection(
             modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSmall),
             behaviours = lsu?.fungibleResource?.behaviours

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/pool/PoolUnitDialogContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/pool/PoolUnitDialogContent.kt
@@ -202,6 +202,26 @@ fun PoolUnitDialogContent(
             )
         }
 
+        poolUnit?.resource?.divisibility?.let {
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+            MetadataView(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = RadixTheme.dimensions.paddingSmall),
+                key = stringResource(id = R.string.assetDetails_divisibility)
+            ) {
+                Text(
+                    modifier = Modifier
+                        .padding(start = RadixTheme.dimensions.paddingDefault)
+                        .widthIn(min = RadixTheme.dimensions.paddingXXXXLarge * 2),
+                    text = it.value.toString(),
+                    style = RadixTheme.typography.body1HighImportance,
+                    color = RadixTheme.colors.gray1,
+                    textAlign = TextAlign.End
+                )
+            }
+        }
+
         BehavioursSection(
             modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSmall),
             behaviours = poolUnit?.resource?.behaviours


### PR DESCRIPTION
## Description
This PR adds `divisibility` for fungible resources in fungible detail view.
if the `divisibility` we do not show the row.

## How to test

1. open fungible detail view
2. verify the divisibility is there

## Screenshot

<img width="300" alt="Screenshot 2024-08-09 at 12 43 53" src="https://github.com/user-attachments/assets/c09a158c-f206-446f-b8ac-322d1f231813">
<img src="image_url" width="300">


## PR submission checklist
- [x] I have tested divisibility with several tokens.
