### PR TITLE
Align text in get signatures dialog

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/signatures/GetSignaturesDialog.kt
@@ -124,6 +124,7 @@ private fun GetSignaturesBottomSheetContent(
                 is State.ShowContentForFactorSource.Device -> {
                     Text(
                         style = RadixTheme.typography.body1Regular,
+                        textAlign = TextAlign.Center,
                         text = when (signPurpose) {
                             SignPurpose.SignTransaction -> stringResource(id = R.string.factorSourceActions_device_messageSignature)
                             SignPurpose.SignAuth -> stringResource(id = R.string.factorSourceActions_device_message)


### PR DESCRIPTION
## Description
This:
<img width="305" alt="Screenshot 2024-08-09 at 15 10 53" src="https://github.com/user-attachments/assets/37fdebdf-69c3-4329-9700-ea6e644cf32a">


