### PR TITLE
Configure navigation bar style to be always light

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
+++ b/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
@@ -13,13 +13,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.graphics.toArgb
 import androidx.core.animation.doOnEnd
 import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.FragmentActivity
 import com.babylon.wallet.android.LinkConnectionStatusObserver.LinkConnectionsStatus
-import com.babylon.wallet.android.designsystem.theme.NavigationBarDefaultScrim
+import com.babylon.wallet.android.designsystem.theme.DefaultDarkScrim
+import com.babylon.wallet.android.designsystem.theme.DefaultLightScrim
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.presentation.BalanceVisibilityObserver
 import com.babylon.wallet.android.presentation.main.AppState
@@ -58,14 +58,6 @@ class MainActivity : FragmentActivity() {
             viewModel.state.value.initialAppState == AppState.Loading
         }
         setSplashExitAnimation(splashScreen)
-        // TODO use auto style when we implement dark mode
-        enableEdgeToEdge(
-            navigationBarStyle = SystemBarStyle.auto(
-                lightScrim = NavigationBarDefaultScrim.toArgb(),
-                darkScrim = NavigationBarDefaultScrim.toArgb()
-            )
-        )
-
         super.onCreate(savedInstanceState)
         cloudBackupSyncExecutor.startPeriodicChecks(lifecycleOwner = this)
 
@@ -136,6 +128,13 @@ class MainActivity : FragmentActivity() {
             fadeIn.duration = splashExitAnimDurationMs
             fadeIn.doOnEnd {
                 splashScreenView.remove()
+                // TODO use auto style when we implement dark mode
+                enableEdgeToEdge(
+                    navigationBarStyle = SystemBarStyle.light(
+                        scrim = DefaultLightScrim,
+                        darkScrim = DefaultDarkScrim
+                    )
+                )
             }
             fadeIn.start()
         }

--- a/designsystem/src/main/java/com/babylon/wallet/android/designsystem/theme/RadixColors.kt
+++ b/designsystem/src/main/java/com/babylon/wallet/android/designsystem/theme/RadixColors.kt
@@ -40,7 +40,8 @@ val DarkMode1 = Color(0xFF28292A)
 val DarkMode2 = Color(0xFF404243)
 val DarkMode3 = Color(0xFF373839)
 
-val NavigationBarDefaultScrim = Color(android.graphics.Color.argb(0xe6, 0xFF, 0xFF, 0xFF))
+val DefaultLightScrim = android.graphics.Color.argb(0xe6, 0xFF, 0xFF, 0xFF)
+val DefaultDarkScrim = android.graphics.Color.argb(0x80, 0x1b, 0x1b, 0x1b)
 
 val RadixBackground = Color(226, 226, 226)
 val RadixCardBackground = Color(190, 189, 189)


### PR DESCRIPTION
## Description
- we still have a glitch when switching theme while app is in the foreground with this update, but otherwise it works consistently using same colors in light/dark theme for navigation bar