### PR TITLE
Improve seed phrase entry UI

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicScreen.kt
@@ -30,10 +30,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
@@ -57,7 +55,7 @@ import com.babylon.wallet.android.presentation.ui.composables.WarningText
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
 import com.babylon.wallet.android.presentation.ui.composables.utils.HideKeyboardOnFullScroll
 import com.babylon.wallet.android.presentation.ui.composables.utils.isKeyboardVisible
-import com.babylon.wallet.android.presentation.ui.modifier.dynamicImePadding
+import com.babylon.wallet.android.presentation.ui.modifier.keyboardVisiblePadding
 import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.radixdlt.sargon.Bip39WordCount
@@ -91,11 +89,9 @@ fun AddSingleMnemonicScreen(
         onSeedPhraseLengthChanged = viewModel::onSeedPhraseLengthChanged
     )
 
-    val focusManager = LocalFocusManager.current
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.collect {
             when (it) {
-                AddSingleMnemonicViewModel.Event.MoveToNextWord -> focusManager.moveFocus(FocusDirection.Next)
                 AddSingleMnemonicViewModel.Event.FactorSourceAdded -> onBackClick()
                 AddSingleMnemonicViewModel.Event.MainSeedPhraseCompleted -> onStartRecovery()
             }
@@ -150,7 +146,6 @@ private fun AddSingleMnemonicsContent(
                     onCandidateClick = { candidate ->
                         focusedWordIndex?.let {
                             onWordSelected(it, candidate)
-                            focusedWordIndex = null
                         }
                     }
                 )
@@ -180,9 +175,9 @@ private fun AddSingleMnemonicsContent(
         val isOlympia = state.mnemonicType == MnemonicType.Olympia
         Box(
             modifier = Modifier
-                .dynamicImePadding(
+                .keyboardVisiblePadding(
                     padding = padding,
-                    keyboardVisibleBottomPadding = if (isSuggestionsVisible(state)) {
+                    bottom = if (isSuggestionsVisible(state)) {
                         RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight
                     } else {
                         RadixTheme.dimensions.paddingDefault
@@ -307,13 +302,15 @@ private fun SeedPhraseView(
         SeedPhraseInputForm(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+                .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+                .padding(bottom = RadixTheme.dimensions.paddingXLarge),
             seedPhraseWords = seedPhraseState.seedPhraseWords,
             bip39Passphrase = seedPhraseState.bip39Passphrase,
             onWordChanged = onWordChanged,
             onPassphraseChanged = onPassphraseChanged,
             onFocusedWordIndexChanged = onFocusedWordIndexChanged,
-            showAdvancedMode = isOlympia
+            showAdvancedMode = isOlympia,
+            initiallyFocusedIndex = 0
         )
 
         val shouldDisplayInvalidSeedPhraseWarning = remember(seedPhraseState) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonic/AddSingleMnemonicViewModel.kt
@@ -61,9 +61,6 @@ class AddSingleMnemonicViewModel @Inject constructor(
 
     fun onWordSelected(index: Int, value: String) {
         seedPhraseInputDelegate.onWordSelected(index, value)
-        viewModelScope.launch {
-            sendEvent(Event.MoveToNextWord)
-        }
     }
 
     fun onPassphraseChanged(value: String) {
@@ -122,7 +119,6 @@ class AddSingleMnemonicViewModel @Inject constructor(
     ) : UiState
 
     sealed interface Event : OneOffEvent {
-        data object MoveToNextWord : Event
         data object FactorSourceAdded : Event
         data object MainSeedPhraseCompleted : Event
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -33,9 +33,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -64,7 +62,7 @@ import com.babylon.wallet.android.presentation.ui.composables.WarningText
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
 import com.babylon.wallet.android.presentation.ui.composables.utils.HideKeyboardOnFullScroll
 import com.babylon.wallet.android.presentation.ui.composables.utils.isKeyboardVisible
-import com.babylon.wallet.android.presentation.ui.modifier.dynamicImePadding
+import com.babylon.wallet.android.presentation.ui.modifier.keyboardVisiblePadding
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.formattedSpans
 import com.radixdlt.sargon.Account
@@ -110,12 +108,10 @@ fun RestoreMnemonicsScreen(
         onMessageShown = viewModel::onMessageShown
     )
 
-    val focusManager = LocalFocusManager.current
     LaunchedEffect(Unit) {
         viewModel.oneOffEvent.collect {
             when (it) {
                 is RestoreMnemonicsViewModel.Event.FinishRestoration -> onDismiss(it.isMovingToMain)
-                is RestoreMnemonicsViewModel.Event.MoveToNextWord -> focusManager.moveFocus(FocusDirection.Next)
                 is RestoreMnemonicsViewModel.Event.CloseApp -> onCloseApp()
             }
         }
@@ -171,7 +167,6 @@ private fun RestoreMnemonicsContent(
                     onCandidateClick = { candidate ->
                         focusedWordIndex?.let {
                             onWordSelected(it, candidate)
-                            focusedWordIndex = null
                         }
                     }
                 )
@@ -250,9 +245,9 @@ private fun RestoreMnemonicsContent(
             }
 
             AnimatedVisibility(
-                modifier = Modifier.dynamicImePadding(
+                modifier = Modifier.keyboardVisiblePadding(
                     padding = padding,
-                    keyboardVisibleBottomPadding = if (isSuggestionsVisible(state)) {
+                    bottom = if (isSuggestionsVisible(state)) {
                         RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight
                     } else {
                         RadixTheme.dimensions.paddingDefault
@@ -436,7 +431,8 @@ private fun SeedPhraseView(
             bip39Passphrase = state.seedPhraseState.bip39Passphrase,
             onWordChanged = onWordChanged,
             onPassphraseChanged = onPassphraseChanged,
-            onFocusedWordIndexChanged = onFocusedWordIndexChanged
+            onFocusedWordIndexChanged = onFocusedWordIndexChanged,
+            initiallyFocusedIndex = 0
         )
         val shouldDisplaySeedPhraseWarning = remember(state.seedPhraseState) {
             state.seedPhraseState.shouldDisplayInvalidSeedPhraseWarning()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -156,9 +156,6 @@ class RestoreMnemonicsViewModel @Inject constructor(
 
     fun onWordSelected(index: Int, value: String) {
         seedPhraseInputDelegate.onWordSelected(index, value)
-        viewModelScope.launch {
-            sendEvent(Event.MoveToNextWord)
-        }
     }
 
     fun onPassphraseChanged(value: String) {
@@ -308,7 +305,6 @@ class RestoreMnemonicsViewModel @Inject constructor(
     sealed interface Event : OneOffEvent {
         data class FinishRestoration(val isMovingToMain: Boolean) : Event
         data object CloseApp : Event
-        data object MoveToNextWord : Event
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletScreen.kt
@@ -45,9 +45,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
@@ -93,7 +91,7 @@ import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanne
 import com.babylon.wallet.android.presentation.ui.composables.utils.HideKeyboardOnFullScroll
 import com.babylon.wallet.android.presentation.ui.composables.utils.isKeyboardVisible
 import com.babylon.wallet.android.presentation.ui.modifier.applyIf
-import com.babylon.wallet.android.presentation.ui.modifier.dynamicImePadding
+import com.babylon.wallet.android.presentation.ui.modifier.keyboardVisiblePadding
 import com.babylon.wallet.android.utils.BiometricAuthenticationResult
 import com.babylon.wallet.android.utils.biometricAuthenticate
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
@@ -232,7 +230,6 @@ private fun ImportLegacyWalletContent(
     onInvalidConnectionPasswordShown: () -> Unit,
     seedPhraseInputState: SeedPhraseInputDelegate.State
 ) {
-    val focusManager = LocalFocusManager.current
     val cameraPermissionState = rememberPermissionState(permission = Manifest.permission.CAMERA)
     val pagerState = rememberPagerState(0) { pages.size }
     val scope = rememberCoroutineScope()
@@ -287,10 +284,6 @@ private fun ImportLegacyWalletContent(
                         }
                     }
                 }
-
-                OlympiaImportEvent.MoveFocusToNextWord -> {
-                    focusManager.moveFocus(FocusDirection.Next)
-                }
             }
         }
     }
@@ -328,7 +321,6 @@ private fun ImportLegacyWalletContent(
                         onCandidateClick = { candidate ->
                             focusedWordIndex?.let {
                                 onWordSelected(it, candidate)
-                                focusedWordIndex = null
                             }
                         }
                     )
@@ -368,13 +360,10 @@ private fun ImportLegacyWalletContent(
                         VerifyWithYourSeedPhrasePage(
                             modifier = Modifier
                                 .fillMaxSize()
-                                .dynamicImePadding(
+                                .keyboardVisiblePadding(
                                     padding = padding,
-                                    keyboardVisibleBottomPadding = if (seedPhraseSuggestionsVisible(
-                                            seedPhraseInputState.wordAutocompleteCandidates
-                                        )
-                                    ) {
-                                        RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight + RadixTheme.dimensions.paddingDefault
+                                    bottom = if (seedPhraseSuggestionsVisible(seedPhraseInputState.wordAutocompleteCandidates)) {
+                                        RadixTheme.dimensions.seedPhraseWordsSuggestionsHeight
                                     } else {
                                         RadixTheme.dimensions.paddingDefault
                                     }
@@ -837,7 +826,8 @@ private fun VerifyWithYourSeedPhrasePage(
                 onPassphraseChanged = onPassphraseChanged,
                 bip39Passphrase = bip39Passphrase,
                 modifier = Modifier.fillMaxWidth(),
-                onFocusedWordIndexChanged = onFocusedWordIndexChanged
+                onFocusedWordIndexChanged = onFocusedWordIndexChanged,
+                initiallyFocusedIndex = 0
             )
 
             val shouldDisplayInvalidSeedPhraseWarning = remember(seedPhraseInputState) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/importlegacywallet/ImportLegacyWalletViewModel.kt
@@ -277,9 +277,6 @@ class ImportLegacyWalletViewModel @Inject constructor(
 
     fun onWordSelected(index: Int, value: String) {
         seedPhraseInputDelegate.onWordSelected(index, value)
-        viewModelScope.launch {
-            sendEvent(OlympiaImportEvent.MoveFocusToNextWord)
-        }
     }
 
     fun onPassphraseChanged(value: String) {
@@ -529,7 +526,6 @@ class ImportLegacyWalletViewModel @Inject constructor(
 }
 
 sealed interface OlympiaImportEvent : OneOffEvent {
-    data object MoveFocusToNextWord : OlympiaImportEvent
     data class NextPage(val page: ImportLegacyWalletUiState.Page) : OlympiaImportEvent
     data class PreviousPage(val page: ImportLegacyWalletUiState.Page?) : OlympiaImportEvent
     data object BiometricPromptBeforeFinalImport : OlympiaImportEvent

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SeedPhraseInputForm.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/SeedPhraseInputForm.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -21,11 +20,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -53,9 +49,9 @@ fun SeedPhraseInputForm(
     onPassphraseChanged: (String) -> Unit,
     bip39Passphrase: String,
     onFocusedWordIndexChanged: (Int) -> Unit,
-    showAdvancedMode: Boolean = true
+    showAdvancedMode: Boolean = true,
+    initiallyFocusedIndex: Int? = null
 ) {
-    val focusManager = LocalFocusManager.current
     Column(
         modifier = modifier
     ) {
@@ -72,7 +68,6 @@ fun SeedPhraseInputForm(
                     SeedPhraseWordInput(
                         onWordChanged = onWordChanged,
                         word = word,
-                        focusManager = focusManager,
                         modifier = Modifier
                             .fillMaxWidth()
                             .weight(1f),
@@ -81,7 +76,8 @@ fun SeedPhraseInputForm(
                                 onFocusedWordIndexChanged(word.index)
                             }
                         },
-                        enabled = word.inputDisabled.not()
+                        enabled = word.inputDisabled.not(),
+                        hasInitialFocus = initiallyFocusedIndex == word.index
                     )
                 }
             }
@@ -142,10 +138,10 @@ fun SeedPhraseSuggestions(
 private fun SeedPhraseWordInput(
     onWordChanged: (Int, String) -> Unit,
     word: SeedPhraseWord,
-    focusManager: FocusManager,
     modifier: Modifier = Modifier,
     onFocusChanged: ((FocusState) -> Unit)?,
-    enabled: Boolean
+    enabled: Boolean,
+    hasInitialFocus: Boolean
 ) {
     MnemonicWordTextField(
         modifier = modifier,
@@ -190,7 +186,6 @@ private fun SeedPhraseWordInput(
                 null
             }
         },
-        keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Next) }),
         keyboardOptions = KeyboardOptions(
             imeAction = when {
                 word.lastWord -> {
@@ -207,7 +202,8 @@ private fun SeedPhraseWordInput(
         errorFixedSize = true,
         singleLine = true,
         enabled = enabled,
-        highlightField = false
+        highlightField = false,
+        hasInitialFocus = hasInitialFocus
     )
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/modifier/KeyboardVisiblePadding.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/modifier/KeyboardVisiblePadding.kt
@@ -5,18 +5,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.unit.Dp
-import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.ui.composables.utils.isKeyboardVisible
 
-fun Modifier.dynamicImePadding(
+fun Modifier.keyboardVisiblePadding(
     padding: PaddingValues,
-    keyboardVisibleBottomPadding: Dp? = null
+    bottom: Dp
 ): Modifier {
     return this.composed {
         padding(
             top = padding.calculateTopPadding(),
             bottom = if (isKeyboardVisible()) {
-                keyboardVisibleBottomPadding ?: RadixTheme.dimensions.paddingSmall
+                bottom
             } else {
                 padding.calculateBottomPadding()
             }

--- a/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/MnemonicWordTextField.kt
+++ b/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/MnemonicWordTextField.kt
@@ -34,9 +34,11 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -105,8 +107,11 @@ fun MnemonicWordTextField(
                         onFocusChanged?.invoke(it)
                     }
                     .focusRequester(focusRequester),
-                value = value,
-                onValueChange = onValueChanged,
+                value = TextFieldValue(
+                    text = value,
+                    selection = TextRange(value.length)
+                ),
+                onValueChange = { onValueChanged(it.text) },
                 textStyle = textStyle.copy(color = textColor),
                 keyboardActions = keyboardActions,
                 keyboardOptions = keyboardOptions,


### PR DESCRIPTION
## Description
- Removed automatically switching to the next word after selecting a suggested word (this was a requirement for the autocompletion removal task)
- Updated the selection indicator on a mnemonic word text field to be always at the end of the word: this fixes the issue of the indicator remaining in the middle of the word when a suggested word is selected
- Fixed the issue when tapping on a suggested word has no effect after it was already selected once, for example when the word is edited and a suggestion is selected again
- Partially fixed [ticket](https://radixdlt.atlassian.net/browse/ABW-3717) by showing the keyboard when the screen is opened. Unfortunately, the issue still occurs if hiding the keyboard, fully scrolling to the bottom and tapping a word on the last row.
