### PR TITLE
[ABW-3721] Warning for not involved accounts in transactions

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -339,6 +339,7 @@ private fun TransactionPreviewContent(
                             fees = state.transactionFees,
                             noFeePayerSelected = state.noFeePayerSelected,
                             insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
+                            isSelectedFeePayerInvolvedInTransaction = state.isSelectedFeePayerInvolvedInTransaction,
                             isNetworkFeeLoading = state.isNetworkFeeLoading,
                             onCustomizeClick = onCustomizeClick
                         )
@@ -369,6 +370,7 @@ private fun TransactionPreviewContent(
                     sheetState = state.sheetState,
                     transactionFees = state.transactionFees,
                     insufficientBalanceToPayTheFee = state.isBalanceInsufficientToPayTheFee,
+                    isSelectedFeePayerInvolvedInTransaction = state.isSelectedFeePayerInvolvedInTransaction,
                     onCloseBottomSheetClick = onCloseBottomSheetClick,
                     onGuaranteesApplyClick = onGuaranteesApplyClick,
                     onGuaranteeValueChanged = onGuaranteeValueChanged,
@@ -413,6 +415,7 @@ private fun BottomSheetContent(
     sheetState: State.Sheet,
     transactionFees: TransactionFees,
     insufficientBalanceToPayTheFee: Boolean,
+    isSelectedFeePayerInvolvedInTransaction: Boolean,
     onCloseBottomSheetClick: () -> Unit,
     onGuaranteesApplyClick: () -> Unit,
     onGuaranteeValueChanged: (AccountWithPredictedGuarantee, String) -> Unit,
@@ -444,6 +447,7 @@ private fun BottomSheetContent(
                 state = sheetState,
                 transactionFees = transactionFees,
                 insufficientBalanceToPayTheFee = insufficientBalanceToPayTheFee,
+                isSelectedFeePayerInvolvedInTransaction = isSelectedFeePayerInvolvedInTransaction,
                 onClose = onCloseBottomSheetClick,
                 onChangeFeePayerClick = onChangeFeePayerClick,
                 onSelectFeePayerClick = onSelectFeePayerClick,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -332,6 +332,9 @@ class TransactionReviewViewModel @Inject constructor(
         val noFeePayerSelected: Boolean
             get() = feePayers?.selectedAccountAddress == null
 
+        val isSelectedFeePayerInvolvedInTransaction: Boolean
+            get() = request?.transactionManifestData?.feePayerCandidates()?.contains(feePayers?.selectedAccountAddress) ?: false
+
         val isBalanceInsufficientToPayTheFee: Boolean
             get() {
                 if (feePayers == null) return true

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
@@ -34,7 +34,10 @@ import com.babylon.wallet.android.presentation.transaction.model.AccountWithTran
 import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
 import com.babylon.wallet.android.presentation.ui.composables.BottomDialogHeader
 import com.babylon.wallet.android.presentation.ui.composables.InfoLink
+import com.radixdlt.sargon.Account
+import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.extensions.formatted
+import com.radixdlt.sargon.samples.sampleMainnet
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -42,6 +45,7 @@ fun FeesSheet(
     modifier: Modifier = Modifier,
     state: TransactionReviewViewModel.State.Sheet.CustomizeFees,
     transactionFees: TransactionFees,
+    isSelectedFeePayerInvolvedInTransaction: Boolean,
     insufficientBalanceToPayTheFee: Boolean,
     onClose: () -> Unit,
     onChangeFeePayerClick: () -> Unit,
@@ -208,6 +212,19 @@ fun FeesSheet(
                             iconRes = com.babylon.wallet.android.designsystem.R.drawable.ic_warning_error,
                             textStyle = RadixTheme.typography.body1Header
                         )
+                    } else if (isSelectedFeePayerInvolvedInTransaction.not()) {
+                        InfoLink(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(
+                                    horizontal = RadixTheme.dimensions.paddingLarge,
+                                    vertical = RadixTheme.dimensions.paddingSmall
+                                ),
+                            text = stringResource(id = R.string.transactionReview_feePayerValidation_linksNewAccount),
+                            contentColor = RadixTheme.colors.orange1,
+                            iconRes = com.babylon.wallet.android.designsystem.R.drawable.ic_warning_error,
+                            textStyle = RadixTheme.typography.body1Header
+                        )
                     }
                 }
             }
@@ -248,8 +265,6 @@ fun FeesSheet(
                     }
                 }
             }
-
-            else -> {}
         }
 
         item {
@@ -794,7 +809,7 @@ fun NetworkFeesAdvancedView(
 
 @Composable
 @Preview(showBackground = true)
-private fun FeesSheetPreview() {
+private fun FeesSheetEmptyPreview() {
     RadixWalletPreviewTheme {
         FeesSheet(
             state = TransactionReviewViewModel.State.Sheet.CustomizeFees(
@@ -803,6 +818,59 @@ private fun FeesSheetPreview() {
             ),
             transactionFees = TransactionFees(),
             insufficientBalanceToPayTheFee = false,
+            isSelectedFeePayerInvolvedInTransaction = false,
+            onClose = {},
+            onChangeFeePayerClick = {},
+            onSelectFeePayerClick = {},
+            onFeePaddingAmountChanged = {},
+            onTipPercentageChanged = {},
+            onViewDefaultModeClick = {},
+            onViewAdvancedModeClick = {}
+        )
+    }
+}
+
+@UsesSampleValues
+@Composable
+@Preview(showBackground = true)
+private fun FeesSheetNotEnoughXRDPreview() {
+    RadixWalletPreviewTheme {
+        FeesSheet(
+            state = TransactionReviewViewModel.State.Sheet.CustomizeFees(
+                feePayerMode = TransactionReviewViewModel.State.Sheet.CustomizeFees.FeePayerMode.FeePayerSelected(
+                    feePayerCandidate = Account.sampleMainnet.carol
+                ),
+                feesMode = TransactionReviewViewModel.State.Sheet.CustomizeFees.FeesMode.Default
+            ),
+            transactionFees = TransactionFees(),
+            insufficientBalanceToPayTheFee = true,
+            isSelectedFeePayerInvolvedInTransaction = false,
+            onClose = {},
+            onChangeFeePayerClick = {},
+            onSelectFeePayerClick = {},
+            onFeePaddingAmountChanged = {},
+            onTipPercentageChanged = {},
+            onViewDefaultModeClick = {},
+            onViewAdvancedModeClick = {}
+        )
+    }
+}
+
+@UsesSampleValues
+@Composable
+@Preview(showBackground = true)
+private fun FeesSheetAccountNotInvolvedPreview() {
+    RadixWalletPreviewTheme {
+        FeesSheet(
+            state = TransactionReviewViewModel.State.Sheet.CustomizeFees(
+                feePayerMode = TransactionReviewViewModel.State.Sheet.CustomizeFees.FeePayerMode.FeePayerSelected(
+                    feePayerCandidate = Account.sampleMainnet.carol
+                ),
+                feesMode = TransactionReviewViewModel.State.Sheet.CustomizeFees.FeesMode.Default
+            ),
+            transactionFees = TransactionFees(),
+            insufficientBalanceToPayTheFee = false,
+            isSelectedFeePayerInvolvedInTransaction = false,
             onClose = {},
             onChangeFeePayerClick = {},
             onSelectFeePayerClick = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/NetworkFeeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/NetworkFeeContent.kt
@@ -16,6 +16,7 @@ import com.babylon.wallet.android.designsystem.composable.RadixTextButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.White
 import com.babylon.wallet.android.presentation.transaction.fees.TransactionFees
+import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
 import com.babylon.wallet.android.presentation.ui.composables.InfoLink
 import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.placeholder
@@ -27,6 +28,7 @@ fun NetworkFeeContent(
     fees: TransactionFees,
     noFeePayerSelected: Boolean,
     insufficientBalanceToPayTheFee: Boolean,
+    isSelectedFeePayerInvolvedInTransaction: Boolean,
     isNetworkFeeLoading: Boolean,
     modifier: Modifier = Modifier,
     onCustomizeClick: () -> Unit
@@ -84,7 +86,7 @@ fun NetworkFeeContent(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = RadixTheme.dimensions.paddingSmall),
-                    text = stringResource(id = R.string.customizeNetworkFees_warning_selectFeePayer),
+                    text = stringResource(id = R.string.transactionReview_feePayerValidation_feePayerRequired),
                     contentColor = RadixTheme.colors.orange1,
                     iconRes = com.babylon.wallet.android.designsystem.R.drawable.ic_warning_error
                 )
@@ -95,6 +97,15 @@ fun NetworkFeeContent(
                     .fillMaxWidth()
                     .padding(top = RadixTheme.dimensions.paddingSmall),
                 text = stringResource(id = R.string.customizeNetworkFees_warning_insufficientBalance),
+                contentColor = RadixTheme.colors.red1,
+                iconRes = com.babylon.wallet.android.designsystem.R.drawable.ic_warning_error
+            )
+        } else if (isSelectedFeePayerInvolvedInTransaction.not()) {
+            InfoLink(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = RadixTheme.dimensions.paddingSmall),
+                text = stringResource(id = R.string.transactionReview_feePayerValidation_linksNewAccount),
                 contentColor = RadixTheme.colors.orange1,
                 iconRes = com.babylon.wallet.android.designsystem.R.drawable.ic_warning_error
             )
@@ -111,12 +122,75 @@ fun NetworkFeeContent(
 
 @Preview(showBackground = true)
 @Composable
-fun NetworkFeeContentPreview() {
-    NetworkFeeContent(
-        fees = TransactionFees(),
-        noFeePayerSelected = false,
-        insufficientBalanceToPayTheFee = false,
-        isNetworkFeeLoading = false,
-        onCustomizeClick = {}
-    )
+fun NetworkFeeContentLoadingPreview() {
+    RadixWalletPreviewTheme {
+        NetworkFeeContent(
+            fees = TransactionFees(),
+            noFeePayerSelected = false,
+            insufficientBalanceToPayTheFee = false,
+            isSelectedFeePayerInvolvedInTransaction = true,
+            isNetworkFeeLoading = true,
+            onCustomizeClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NetworkFeeContentWithoutInvolvedAccountPreview() {
+    RadixWalletPreviewTheme {
+        NetworkFeeContent(
+            fees = TransactionFees(),
+            noFeePayerSelected = false,
+            insufficientBalanceToPayTheFee = false,
+            isSelectedFeePayerInvolvedInTransaction = false,
+            isNetworkFeeLoading = false,
+            onCustomizeClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NetworkFeeContentNoFeePayerPreview() {
+    RadixWalletPreviewTheme {
+        NetworkFeeContent(
+            fees = TransactionFees(),
+            noFeePayerSelected = true,
+            insufficientBalanceToPayTheFee = false,
+            isSelectedFeePayerInvolvedInTransaction = false,
+            isNetworkFeeLoading = false,
+            onCustomizeClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NetworkFeeContentInsufficientBalancePreview() {
+    RadixWalletPreviewTheme {
+        NetworkFeeContent(
+            fees = TransactionFees(),
+            noFeePayerSelected = false,
+            insufficientBalanceToPayTheFee = true,
+            isSelectedFeePayerInvolvedInTransaction = true,
+            isNetworkFeeLoading = false,
+            onCustomizeClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NetworkFeeContentInsufficientBalanceWithoutInvolvedAccountPreview() {
+    RadixWalletPreviewTheme {
+        NetworkFeeContent(
+            fees = TransactionFees(),
+            noFeePayerSelected = false,
+            insufficientBalanceToPayTheFee = true,
+            isSelectedFeePayerInvolvedInTransaction = false,
+            isNetworkFeeLoading = false,
+            onCustomizeClick = {}
+        )
+    }
 }


### PR DESCRIPTION
## Description
This PR adds functionality to warn users about paying fees with an account not involved in transaction


## How to test

1. Execute a transfer or another transaction 
2. Add as fee payer an account that is not involved in the transaction
3. You must see a warning (see video)


## Video

https://github.com/user-attachments/assets/5cc32efb-0440-4af8-9229-007d3b28aa44




## PR submission checklist
- [x] I have tested transactions with not involved accounts
