### PR TITLE
[ABW-3749] - Fix mnemonic confirmation crash

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/confirm/ConfirmMnemonicNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/confirm/ConfirmMnemonicNav.kt
@@ -59,7 +59,7 @@ fun NavGraphBuilder.confirmSeedPhrase(
             }
         ),
         enterTransition = {
-            slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Up)
+            slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Left)
         },
         exitTransition = {
             ExitTransition.None
@@ -68,7 +68,7 @@ fun NavGraphBuilder.confirmSeedPhrase(
             EnterTransition.None
         },
         popExitTransition = {
-            slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Down)
+            slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Right)
         }
     ) {
         ConfirmMnemonicScreen(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/confirm/ConfirmMnemonicScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/confirm/ConfirmMnemonicScreen.kt
@@ -162,8 +162,7 @@ private fun SeedPhraseView(
                 .fillMaxWidth()
                 .padding(horizontal = RadixTheme.dimensions.paddingDefault),
             seedPhraseWords = state.seedPhraseState.seedPhraseWords,
-            onWordChanged = onWordChanged,
-            onFocusedWordIndexChanged = {}
+            onWordChanged = onWordChanged
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/reveal/RevealSeedPhraseScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/reveal/RevealSeedPhraseScreen.kt
@@ -77,6 +77,7 @@ fun RevealSeedPhraseScreen(
                 } else {
                     onBackClick()
                 }
+                viewModel.dismissConfirmSeedPhraseDialog()
             },
             titleText = stringResource(id = R.string.revealSeedPhrase_warningDialog_title),
             messageText = stringResource(id = R.string.revealSeedPhrase_warningDialog_subtitle),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/reveal/RevealSeedPhraseViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/reveal/RevealSeedPhraseViewModel.kt
@@ -79,6 +79,14 @@ class RevealSeedPhraseViewModel @Inject constructor(
         }
     }
 
+    fun dismissConfirmSeedPhraseDialog() {
+        _state.update { state ->
+            state.copy(
+                showConfirmSeedPhraseDialogState = ConfirmSeedPhraseDialogState.None
+            )
+        }
+    }
+
     data class State(
         val mnemonicSize: Int = 0,
         val mnemonicWordsChunked: PersistentList<PersistentList<String>> = persistentListOf(),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/SeedPhraseInputVerificationForm.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/SeedPhraseInputVerificationForm.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
@@ -14,11 +13,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.focus.FocusManager
-import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -37,10 +32,8 @@ import kotlinx.collections.immutable.ImmutableList
 fun SeedPhraseInputVerificationForm(
     modifier: Modifier = Modifier,
     seedPhraseWords: ImmutableList<SeedPhraseWord>,
-    onWordChanged: (Int, String) -> Unit,
-    onFocusedWordIndexChanged: (Int) -> Unit
+    onWordChanged: (Int, String) -> Unit
 ) {
-    val focusManager = LocalFocusManager.current
     val firstFocusedIndex by remember(seedPhraseWords) {
         mutableIntStateOf(seedPhraseWords.indexOfFirst { it.state == SeedPhraseWord.State.Empty })
     }
@@ -49,7 +42,7 @@ fun SeedPhraseInputVerificationForm(
     ) {
         seedPhraseWords.chunked(3).forEachIndexed { index, wordsChunk ->
             Row(
-                Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingMedium)
             ) {
@@ -58,15 +51,7 @@ fun SeedPhraseInputVerificationForm(
                     SeedPhraseWordInput(
                         onWordChanged = onWordChanged,
                         word = word,
-                        focusManager = focusManager,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .weight(1f),
-                        onFocusChanged = {
-                            if (it.hasFocus) {
-                                onFocusedWordIndexChanged(word.index)
-                            }
-                        },
+                        modifier = Modifier.weight(1f),
                         enabled = word.inputDisabled.not(),
                         initiallyFocused = firstFocusedIndex == wordIndex
                     )
@@ -80,9 +65,7 @@ fun SeedPhraseInputVerificationForm(
 private fun SeedPhraseWordInput(
     onWordChanged: (Int, String) -> Unit,
     word: SeedPhraseWord,
-    focusManager: FocusManager,
     modifier: Modifier = Modifier,
-    onFocusChanged: ((FocusState) -> Unit)?,
     enabled: Boolean,
     initiallyFocused: Boolean
 ) {
@@ -114,7 +97,6 @@ private fun SeedPhraseWordInput(
                 null
             }
         },
-        keyboardActions = KeyboardActions(onNext = { focusManager.moveFocus(FocusDirection.Next) }),
         keyboardOptions = KeyboardOptions(
             imeAction = when {
                 word.lastWord -> {
@@ -125,7 +107,6 @@ private fun SeedPhraseWordInput(
                 }
             }
         ),
-        onFocusChanged = onFocusChanged,
         errorFixedSize = true,
         singleLine = true,
         enabled = enabled,
@@ -143,7 +124,6 @@ fun SeedPhraseInputVerificationFormPreview() {
         SeedPhraseInputVerificationForm(
             seedPhraseWords = MockUiProvider.seedPhraseWords,
             onWordChanged = { _, _ -> },
-            onFocusedWordIndexChanged = { },
             modifier = Modifier
         )
     }

--- a/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/MnemonicWordTextField.kt
+++ b/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/MnemonicWordTextField.kt
@@ -109,7 +109,7 @@ fun MnemonicWordTextField(
                     .focusRequester(focusRequester),
                 value = TextFieldValue(
                     text = value,
-                    selection = TextRange(value.length)
+                    selection = if (enabled) TextRange(value.length) else TextRange.Zero
                 ),
                 onValueChange = { onValueChanged(it.text) },
                 textStyle = textStyle.copy(color = textColor),


### PR DESCRIPTION
[Ticket](https://radixdlt.atlassian.net/browse/ABW-3749)

## Description
This PR fixes the crash when tapping "I have written down this seed phrase" from Reveal seed phrase screen.
Additionally cleaned up the unused code and fixed a screen transition animation.

## How to test

1. Open Security Factors -> Seed Phrases -> Reveal Seed Phrase
2. Tap back and choose "I have written down this seed phrase"
3. Verify the app doesn't crash
