### PR TITLE
Properly handle not secure dialog when advanced lock is turned on

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
+++ b/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -60,7 +59,6 @@ fun WalletApp(
     val context = LocalContext.current
     val state by mainViewModel.state.collectAsStateWithLifecycle()
     val navController = rememberNavController()
-    var showNotSecuredDialog by remember { mutableStateOf(false) }
     var showSecureFolderWarning by rememberSaveable { mutableStateOf(false) }
     if (state.isAppLocked) {
         FullScreen {
@@ -115,11 +113,6 @@ fun WalletApp(
         }
 
         LaunchedEffect(Unit) {
-            mainViewModel.appNotSecureEvent.collect {
-                showNotSecuredDialog = true
-            }
-        }
-        LaunchedEffect(Unit) {
             mainViewModel.secureFolderWarning.collect {
                 showSecureFolderWarning = true
             }
@@ -142,13 +135,12 @@ fun WalletApp(
             onHighPriorityScreen = mainViewModel::onHighPriorityScreen
         )
         mainViewModel.observeP2PLinks.collectAsStateWithLifecycle(null)
-        if (showNotSecuredDialog) {
+        if (state.showDeviceNotSecureDialog) {
             NotSecureAlertDialog(finish = {
                 if (it) {
                     val intent = Intent(Settings.ACTION_SECURITY_SETTINGS)
                     ContextCompat.startActivity(context, intent, null)
                 }
-                showNotSecuredDialog = false
                 onCloseApp()
             })
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/lock/AppLockScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/lock/AppLockScreen.kt
@@ -1,14 +1,39 @@
 package com.babylon.wallet.android.presentation.dialogs.lock
 
+import android.content.Intent
+import android.provider.Settings
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.AppLockContent
+import com.babylon.wallet.android.presentation.ui.composables.NotSecureAlertDialog
+import com.babylon.wallet.android.utils.findFragmentActivity
 
 @Composable
 fun AppLockScreen(
     viewModel: AppLockViewModel = hiltViewModel(),
     onUnlock: () -> Unit
 ) {
+    val context = LocalContext.current
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    if (state.isDeviceSecure.not()) {
+        NotSecureAlertDialog(finish = {
+            if (it) {
+                val intent = Intent(Settings.ACTION_SECURITY_SETTINGS)
+                ContextCompat.startActivity(context, intent, null)
+            } else {
+                context.findFragmentActivity()?.moveTaskToBack(true)
+            }
+        })
+    }
+    LifecycleEventEffect(event = Lifecycle.Event.ON_RESUME) {
+        viewModel.onResumed()
+    }
     AppLockContent(onUnlock = {
         viewModel.onUnlock()
         onUnlock()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/lock/AppLockViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/lock/AppLockViewModel.kt
@@ -1,16 +1,38 @@
 package com.babylon.wallet.android.presentation.dialogs.lock
 
-import androidx.lifecycle.ViewModel
 import com.babylon.wallet.android.AppLockStateProvider
+import com.babylon.wallet.android.presentation.common.StateViewModel
+import com.babylon.wallet.android.presentation.common.UiState
+import com.babylon.wallet.android.utils.DeviceCapabilityHelper
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 @HiltViewModel
 class AppLockViewModel @Inject constructor(
-    private val appLockStateProvider: AppLockStateProvider
-) : ViewModel() {
+    private val appLockStateProvider: AppLockStateProvider,
+    private val deviceCapabilityHelper: DeviceCapabilityHelper,
+) : StateViewModel<AppLockViewModel.State>() {
 
     fun onUnlock() {
         appLockStateProvider.unlockApp()
+    }
+
+    data class State(
+        val isDeviceSecure: Boolean
+    ) : UiState
+
+    fun onResumed() {
+        _state.update {
+            it.copy(
+                isDeviceSecure = deviceCapabilityHelper.isDeviceSecure
+            )
+        }
+    }
+
+    override fun initialState(): State {
+        return State(
+            isDeviceSecure = deviceCapabilityHelper.isDeviceSecure
+        )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/utils/AppEventBusImpl.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/AppEventBusImpl.kt
@@ -28,8 +28,6 @@ class AppEventBusImpl @Inject constructor() : AppEventBus {
 
 sealed interface AppEvent {
 
-    data object AppNotSecure : AppEvent
-
     data object RefreshAssetsNeeded : AppEvent
 
     data object RestoredMnemonic : AppEvent

--- a/app/src/main/java/com/babylon/wallet/android/utils/DeviceCapabilityHelper.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/DeviceCapabilityHelper.kt
@@ -2,7 +2,6 @@ package com.babylon.wallet.android.utils
 
 import android.app.KeyguardManager
 import android.content.Context
-import android.content.pm.PackageManager
 import android.os.Build
 import com.babylon.wallet.android.BuildConfig
 import com.scottyab.rootbeer.RootBeer
@@ -13,6 +12,9 @@ class DeviceCapabilityHelper @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
     private val keyguardManager = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+
+    val isDeviceSecure: Boolean
+        get() = keyguardManager.isDeviceSecure
 
     private val makeAndModel: String
         get() = "${Build.MANUFACTURER} ${Build.MODEL}"
@@ -27,19 +29,6 @@ class DeviceCapabilityHelper @Inject constructor(
             append("Device: ${makeAndModel}\n")
             append("System version: ${systemVersion}\n")
         }
-
-    fun isDeviceSecure(): Boolean = keyguardManager.isDeviceSecure
-
-    fun canOpenSystemBackupSettings(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.packageManager.queryIntentActivities(
-                backupSettingsScreenIntent,
-                PackageManager.ResolveInfoFlags.of(PackageManager.MATCH_ALL.toLong())
-            )
-        } else {
-            context.packageManager.queryIntentActivities(backupSettingsScreenIntent, PackageManager.MATCH_ALL)
-        }.size > 0
-    }
 
     fun isDeviceRooted(): Boolean = RootBeer(context).isRooted
 }

--- a/app/src/test/java/com/babylon/wallet/android/presentation/CreatePersonaViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/CreatePersonaViewModelTest.kt
@@ -47,7 +47,7 @@ class CreatePersonaViewModelTest : StateViewModelTest<CreatePersonaViewModel>() 
     @Before
     override fun setUp() = runTest {
         coEvery {
-            deviceCapabilityHelper.isDeviceSecure()
+            deviceCapabilityHelper.isDeviceSecure
         } returns true
         coEvery { preferencesManager.firstPersonaCreated } returns flow {
             emit(true)

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModelTest.kt
@@ -19,9 +19,9 @@ import com.babylon.wallet.android.domain.usecases.ResolveComponentAddressesUseCa
 import com.babylon.wallet.android.domain.usecases.ResolveNotaryAndSignersUseCase
 import com.babylon.wallet.android.domain.usecases.RespondToIncomingRequestUseCase
 import com.babylon.wallet.android.domain.usecases.SearchFeePayersUseCase
-import com.babylon.wallet.android.domain.usecases.signing.SignTransactionUseCase
 import com.babylon.wallet.android.domain.usecases.assets.CacheNewlyCreatedEntitiesUseCase
 import com.babylon.wallet.android.domain.usecases.assets.ResolveAssetsFromAddressUseCase
+import com.babylon.wallet.android.domain.usecases.signing.SignTransactionUseCase
 import com.babylon.wallet.android.domain.usecases.transaction.SubmitTransactionUseCase
 import com.babylon.wallet.android.presentation.StateViewModelTest
 import com.babylon.wallet.android.presentation.transaction.analysis.TransactionAnalysisDelegate
@@ -219,10 +219,10 @@ internal class TransactionReviewViewModelTest : StateViewModelTest<TransactionRe
             getDAppsUseCase(dApp.dAppAddress, false)
         } returns Result.success(dApp)
         every { exceptionMessageProvider.throwableMessage(any()) } returns ""
-        every { deviceCapabilityHelper.isDeviceSecure() } returns true
+        every { deviceCapabilityHelper.isDeviceSecure } returns true
         mockkStatic("rdx.works.core.CrashlyticsExtensionsKt")
         every { logNonFatalException(any()) } just Runs
-        every { savedStateHandle.get<String>(ARG_TRANSACTION_REQUEST_ID) } returns sampleRequestId.toString()
+        every { savedStateHandle.get<String>(ARG_TRANSACTION_REQUEST_ID) } returns sampleRequestId
         coEvery { getCurrentGatewayUseCase() } returns Gateway.forNetwork(NetworkId.MAINNET)
         coEvery { submitTransactionUseCase(any()) } returns Result.success(notarizationResult)
         coEvery { signTransactionUseCase(any()) } returns Result.success(notarizationResult)


### PR DESCRIPTION
## Description
See [this](https://rdxworks.slack.com/archives/C03Q8QK1GLW/p1724672451342089) message for buggy behavior. Expected behavior:
- when user has advanced lock on and remove lock screen on the device, opening wallet results in a lock screen with not secure dialog shown. After going to settings and coming back to wallet, user can tap padlock icon and unlock the wallet. No Secure Dialog warning on wallet home screen
- when advanced lock is off, app should behave as it was before. So if user disable device lock screen and open Wallet, dialog is there. After going to settings and re-enabling lock, opening the wallet from recent - dialog is gone.

## How to test

1. See above

## PR submission checklist
- [ ] I have tested scenarios listed in the description section
