### PR TITLE
[ABW-3767] Pause/resume advanced lock when using google sign in

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/AppLockStateProvider.kt
+++ b/app/src/main/java/com/babylon/wallet/android/AppLockStateProvider.kt
@@ -22,6 +22,7 @@ class AppLockStateProvider @Inject constructor(
 ) {
 
     private val _state: MutableStateFlow<State> = MutableStateFlow(State())
+
     val lockState = combine(
         getProfileUseCase.state,
         _state,
@@ -36,6 +37,10 @@ class AppLockStateProvider @Inject constructor(
 
             else -> LockState.Unlocked
         }
+    }.shareIn(scope = coroutineScope, started = SharingStarted.WhileSubscribed())
+
+    val shouldShowPrivacyOverlay = combine(_state, preferencesManager.isAppLockEnabled) { state, isEnabled ->
+        isEnabled && !state.isLockingPaused
     }.shareIn(scope = coroutineScope, started = SharingStarted.WhileSubscribed())
 
     suspend fun lockApp() {

--- a/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
+++ b/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
@@ -158,7 +158,7 @@ class MainActivity : FragmentActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 viewModel.state.collect { state ->
-                    if (state.isAppLockEnabled) {
+                    if (state.shouldShowPrivacyOverlay) {
                         window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
                     }
                     if (state.isAppLocked) {
@@ -223,7 +223,7 @@ class MainActivity : FragmentActivity() {
     }
 
     override fun onUserLeaveHint() {
-        if (viewModel.state.value.isAppLockEnabled) {
+        if (viewModel.state.value.shouldShowPrivacyOverlay) {
             val params = WindowManager.LayoutParams().apply {
                 type = WindowManager.LayoutParams.TYPE_APPLICATION_PANEL
                 token = privacyOverlay.applicationWindowToken

--- a/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
+++ b/app/src/main/java/com/babylon/wallet/android/MainActivity.kt
@@ -45,7 +45,9 @@ import com.babylon.wallet.android.presentation.ui.composables.LockScreenBackgrou
 import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.ActionableAddressViewEntryPoint
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import rdx.works.core.logNonFatalException
 import rdx.works.profile.cloudbackup.CloudBackupSyncExecutor
+import timber.log.Timber
 import javax.inject.Inject
 
 // Extending from FragmentActivity because of Biometric
@@ -171,7 +173,9 @@ class MainActivity : FragmentActivity() {
                     }
                     try {
                         windowManager.removeView(privacyOverlay)
-                    } catch (_: Exception) {
+                    } catch (exception: Exception) {
+                        Timber.e("Failed to remove privacy overlay with exception: ${exception.message}")
+                        logNonFatalException(exception)
                     }
                 }
             }
@@ -222,6 +226,7 @@ class MainActivity : FragmentActivity() {
         viewModel.onAppToForeground()
     }
 
+    // Called as part of the activity lifecycle when an activity is about to go into the background as the result of user choice.
     override fun onUserLeaveHint() {
         if (viewModel.state.value.shouldShowPrivacyOverlay) {
             val params = WindowManager.LayoutParams().apply {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
@@ -139,9 +139,9 @@ class MainViewModel @Inject constructor(
             combine(
                 getProfileUseCase.state,
                 preferencesManager.isDeviceRootedDialogShown,
-                preferencesManager.isAppLockEnabled,
+                appLockStateProvider.shouldShowPrivacyOverlay,
                 cloudBackupErrorStream.errors
-            ) { profileState, isDeviceRootedDialogShown, isAppLockEnabled, backupError ->
+            ) { profileState, isDeviceRootedDialogShown, shouldShowPrivacyOverlay, backupError ->
                 _state.update {
                     MainUiState(
                         initialAppState = AppState.from(
@@ -149,7 +149,7 @@ class MainViewModel @Inject constructor(
                         ),
                         showDeviceRootedWarning = deviceCapabilityHelper.isDeviceRooted() && !isDeviceRootedDialogShown,
                         claimedByAnotherDeviceError = backupError as? ClaimedByAnotherDevice,
-                        isAppLockEnabled = isAppLockEnabled,
+                        shouldShowPrivacyOverlay = shouldShowPrivacyOverlay,
                         isDeviceSecure = deviceCapabilityHelper.isDeviceSecure
                     )
                 }
@@ -412,11 +412,11 @@ data class MainUiState(
     val claimedByAnotherDeviceError: ClaimedByAnotherDevice? = null,
     val showMobileConnectWarning: Boolean = false,
     val isAppLocked: Boolean = false,
-    val isAppLockEnabled: Boolean = false,
+    val shouldShowPrivacyOverlay: Boolean = false,
     val isDeviceSecure: Boolean
 ) : UiState {
     val showDeviceNotSecureDialog: Boolean
-        get() = !isDeviceSecure && !isAppLockEnabled
+        get() = !isDeviceSecure && !shouldShowPrivacyOverlay
 }
 
 data class OlympiaErrorState(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/cloudbackup/ConnectCloudBackupViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/cloudbackup/ConnectCloudBackupViewModel.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.presentation.onboarding.cloudbackup
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.babylon.wallet.android.AppLockStateProvider
 import com.babylon.wallet.android.di.coroutines.ApplicationScope
 import com.babylon.wallet.android.domain.RadixWalletException.CloudBackupException
 import com.babylon.wallet.android.presentation.common.OneOffEvent
@@ -29,6 +30,7 @@ class ConnectCloudBackupViewModel @Inject constructor(
     private val googleSignInManager: GoogleSignInManager,
     private val checkMigrationToNewBackupSystemUseCase: CheckMigrationToNewBackupSystemUseCase,
     private val changeBackupSettingUseCase: ChangeBackupSettingUseCase,
+    private val appLockStateProvider: AppLockStateProvider,
     @ApplicationScope private val appScope: CoroutineScope
 ) : StateViewModel<ConnectCloudBackupViewModel.State>(),
     CanSignInToGoogle,
@@ -63,6 +65,7 @@ class ConnectCloudBackupViewModel @Inject constructor(
                     Timber.tag("CloudBackup").w(exception)
                 }
             }
+            appLockStateProvider.resumeLocking()
         }
     }
 
@@ -74,7 +77,7 @@ class ConnectCloudBackupViewModel @Inject constructor(
         }
 
         checkIfExistingWalletAndRevokeAccessToDeprecatedCloud()
-
+        appLockStateProvider.pauseLocking()
         sendEvent(Event.SignInToGoogle)
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupViewModel.kt
@@ -2,6 +2,7 @@ package com.babylon.wallet.android.presentation.settings.securitycenter.backup
 
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
+import com.babylon.wallet.android.AppLockStateProvider
 import com.babylon.wallet.android.presentation.common.OneOffEvent
 import com.babylon.wallet.android.presentation.common.OneOffEventHandler
 import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
@@ -34,6 +35,7 @@ class BackupViewModel @Inject constructor(
     private val googleSignInManager: GoogleSignInManager,
     private val checkCloudBackupFileAvailabilityUseCase: CheckCloudBackupFileAvailabilityUseCase,
     private val getProfileUseCase: GetProfileUseCase,
+    private val appLockStateProvider: AppLockStateProvider,
     getBackupStateUseCase: GetBackupStateUseCase
 ) : StateViewModel<BackupViewModel.State>(),
     CanSignInToGoogle,
@@ -52,6 +54,7 @@ class BackupViewModel @Inject constructor(
     override fun signInManager(): GoogleSignInManager = googleSignInManager
 
     override fun onSignInResult(result: Result<GoogleAccount>) {
+        appLockStateProvider.resumeLocking()
         viewModelScope.launch {
             result
                 .onSuccess {
@@ -80,6 +83,7 @@ class BackupViewModel @Inject constructor(
         if (isChecked) {
             Timber.tag("CloudBackup").d("Cloud backup authorization is in progress...")
             _state.update { it.copy(isCloudAuthorizationInProgress = true) }
+            appLockStateProvider.pauseLocking()
             sendEvent(Event.SignInToGoogle)
         } else {
             _state.update { it.copy(isCloudAuthorizationInProgress = true) }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/LockScreenBackground.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/LockScreenBackground.kt
@@ -16,10 +16,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
 
 @Composable
 fun LockScreenBackground(modifier: Modifier = Modifier, onTapToUnlock: (() -> Unit)? = null) {
@@ -60,12 +63,20 @@ fun LockScreenBackground(modifier: Modifier = Modifier, onTapToUnlock: (() -> Un
                 Text(
                     modifier = Modifier
                         .clickable { onTapToUnlock() },
-                    text = "Tap to unlock",
+                    text = stringResource(R.string.splash_tapAnywhereToUnlock),
                     style = RadixTheme.typography.body2Regular,
                     color = RadixTheme.colors.white,
                     textAlign = TextAlign.Center
                 )
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun LockScreenBackgroundPreview() {
+    RadixWalletPreviewTheme {
+        LockScreenBackground()
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/utils/ContextExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/utils/ContextExtensions.kt
@@ -46,11 +46,9 @@ fun Context.biometricAuthenticate(
             activity = activity,
             entryPoint = BiometricAuthenticationEntryPoint::class.java
         ).provideAppLockStateProvider()
-        // It appear that below Android 11 BiometricPrompt uses new activity
-        // for biometric authentication when there is no fingerprint registered
-        // so we pause app locking to avoid double biometric prompt when we have advanced lock feature on
-        // and we ask for biometrics from a Wallet, eg. when user wants to create account/sign transaction, app is moved to background
-        // and advanced lock is applied
+        // It appear that below Android 11 Lock Screen uses new activity when there is no fingerprint registered (e.g. PIN).
+        // So we pause app locking to avoid double biometric prompt when advanced lock on and we ask for biometrics from a Wallet,
+        // eg. when user wants to create account/sign transaction, app is moved to background and advanced lock is applied
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             appLockStateProvider.pauseLocking()
         }
@@ -67,8 +65,7 @@ fun Context.biometricAuthenticate(
     }
 }
 
-suspend fun Context.biometricAuthenticateSuspend(allowIfDeviceIsNotSecure: Boolean = false): Boolean {
-    if (allowIfDeviceIsNotSecure) return true
+suspend fun Context.biometricAuthenticateSuspend(): Boolean {
     val fragmentActivity = findFragmentActivity() ?: return false
     val appLockStateProvider = EntryPointAccessors.fromActivity(
         activity = fragmentActivity,

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,13 +23,11 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField "boolean", "CRASH_REPORTING_ENABLED", "true"
-            buildConfigField "boolean", "APP_LOCK_ENABLED", "true"
         }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             buildConfigField "boolean", "CRASH_REPORTING_ENABLED", "false"
-            buildConfigField "boolean", "APP_LOCK_ENABLED", "true"
         }
     }
     compileOptions {


### PR DESCRIPTION
## Description
Launching google sign in moves wallet to the background. To avoid locking user wallet in that procedure, I've added "flow specific" pause/resume of advanced locking.


## How to test

1. Verify that with advanced lock on, when signing on with google at any entry point - backup restoration/onboarding/security center - lock screen is not shown when user signs in with google

## PR submission checklist
- [x] I have tested above scenarios and verified that app is not being locked when launching google sign in intent
