### PR TITLE
Fix crash when formatting assets fiat value

### DIFF
--- a/core/src/main/java/rdx/works/core/domain/Decimal192.kt
+++ b/core/src/main/java/rdx/works/core/domain/Decimal192.kt
@@ -20,7 +20,7 @@ fun Decimal192.roundedWith(divisibility: Divisibility?) = if (divisibility != nu
 }
 
 // This will later be migrated to Sargon
-fun Decimal192.toDouble() = formatted(useGroupingSeparator = false).toDouble()
+fun Decimal192.toDouble() = string.toDouble()
 
 val Decimal192.Companion.Serializer: KSerializer<Decimal192>
     get() = object : KSerializer<Decimal192> {

--- a/core/src/main/java/rdx/works/core/domain/Decimal192.kt
+++ b/core/src/main/java/rdx/works/core/domain/Decimal192.kt
@@ -1,7 +1,6 @@
 package rdx.works.core.domain
 
 import com.radixdlt.sargon.Decimal192
-import com.radixdlt.sargon.extensions.formatted
 import com.radixdlt.sargon.extensions.rounded
 import com.radixdlt.sargon.extensions.string
 import com.radixdlt.sargon.extensions.toDecimal192


### PR DESCRIPTION
## Description
This PR fixes the crash caused by formatting some asset prices:
`java.lang.NumberFormatException: For input string: "13.859522 M"`
