### PR TITLE
[ABW-3764] Add Provider in manifest for WorkManagerInitializer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,18 @@
             android:launchMode="singleTask"
             android:screenOrientation="portrait" />
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
         <meta-data
             android:name="firebase_crashlytics_collection_enabled"
             android:value="false" />


### PR DESCRIPTION
## Description
I mistakenly assumed that the [Initializationprovider is not needed in the manifest](https://github.com/radixdlt/babylon-wallet-android/pull/1063#discussion_r1721686300) and consequently we get a `NoSuchMethodException` for the `WorkManager`. 

I assume that happens because [we (manually) inject the `HiltWorkerFactory`](https://bbluecoder.medium.com/how-to-use-workmanager-with-hilt-in-android-b60046ff7f02). 
Thanks @micbakos-rdx for the hint!


## How to test

1. Launch the app and check if the cloud backup works. (search with the tag `CloudBackup` in the logs).


## PR submission checklist
- [X] I have tested cloud backup in the wallet with **DEBUG** and **ALPHA** builds
