### PR TITLE
Replace info strings

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/EmptyResourcesContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/EmptyResourcesContent.kt
@@ -70,8 +70,8 @@ private fun AssetsTab.toEmptyTitleRes() = when (this) {
 @Suppress("UnusedPrivateMember") // it will be used soon
 @StringRes
 private fun AssetsTab.toEmptyInfoRes() = when (this) {
-    AssetsTab.Tokens -> R.string.assetDetails_tokenDetails_whatAreTokens
-    AssetsTab.Nfts -> R.string.assetDetails_NFTDetails_whatAreNfts
-    AssetsTab.Staking -> R.string.assetDetails_stakingDetails_whatIsStaking
-    AssetsTab.PoolUnits -> R.string.assetDetails_poolUnitDetails_whatArePoolUnits
+    AssetsTab.Tokens -> R.string.infoLink_title_tokens
+    AssetsTab.Nfts -> R.string.infoLink_title_nfts
+    AssetsTab.Staking -> R.string.infoLink_title_networkstaking
+    AssetsTab.PoolUnits -> R.string.infoLink_title_poolunits
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/AssetDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/AssetDialog.kt
@@ -361,7 +361,7 @@ fun BehavioursSection(
                         top = RadixTheme.dimensions.paddingDefault,
                         bottom = RadixTheme.dimensions.paddingSmall
                     ),
-                text = stringResource(id = R.string.assetDetails_behaviors_whatAreBehaviors),
+                text = stringResource(id = R.string.infoLink_title_behaviors),
                 onClick = {
                     onInfoClick(GlossaryItem.behaviors)
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/ApprovedDappsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/ApprovedDappsScreen.kt
@@ -109,7 +109,7 @@ private fun ApprovedDAppsContent(
                         horizontal = RadixTheme.dimensions.paddingDefault,
                         vertical = RadixTheme.dimensions.paddingMedium
                     ),
-                    text = stringResource(id = R.string.authorizedDapps_whatIsDapp),
+                    text = stringResource(id = R.string.infoLink_title_dapps),
                     onClick = {
                         onInfoClick(GlossaryItem.dapps)
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/PersonasScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/PersonasScreen.kt
@@ -115,7 +115,7 @@ fun PersonasContent(
                     horizontal = RadixTheme.dimensions.paddingDefault,
                     vertical = RadixTheme.dimensions.paddingMedium
                 ),
-                text = stringResource(id = R.string.personas_whatIsPersona),
+                text = stringResource(id = R.string.infoLink_title_personas),
                 onClick = {
                     onInfoClick(GlossaryItem.personas)
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaInfoScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaInfoScreen.kt
@@ -105,7 +105,7 @@ private fun CreatePersonaInfoContent(
                     horizontal = dimensions.paddingDefault,
                     vertical = dimensions.paddingDefault
                 ),
-                text = stringResource(id = R.string.createPersona_introduction_learnAboutPersonas),
+                text = stringResource(id = R.string.infoLink_title_personasLearnAbout),
                 onClick = {
                     onInfoClick(GlossaryItem.personas)
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/createpersona/CreatePersonaScreen.kt
@@ -252,7 +252,7 @@ private fun CreatePersonaContentList(
                     horizontal = dimensions.paddingDefault,
                     vertical = dimensions.paddingDefault
                 ),
-                text = stringResource(id = R.string.createPersona_introduction_learnAboutPersonas),
+                text = stringResource(id = R.string.infoLink_title_personasLearnAbout),
                 onClick = {
                     onInfoClick(GlossaryItem.personas)
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/depositguarantees/DepositGuaranteesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/depositguarantees/DepositGuaranteesScreen.kt
@@ -96,7 +96,7 @@ fun DepositGuaranteesContent(
                         horizontal = RadixTheme.dimensions.paddingDefault,
                         vertical = RadixTheme.dimensions.paddingLarge
                     ),
-                    text = stringResource(id = R.string.transactionReview_guarantees_howDoGuaranteesWork),
+                    text = stringResource(id = R.string.infoLink_title_guarantees),
                     onClick = {
                         onInfoClick(GlossaryItem.guarantees)
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
@@ -153,7 +153,7 @@ private fun GatewaysContent(
                             horizontal = RadixTheme.dimensions.paddingDefault,
                             vertical = RadixTheme.dimensions.paddingMedium
                         ),
-                        text = stringResource(id = R.string.gateways_whatIsAGateway),
+                        text = stringResource(id = R.string.infoLink_title_gateways),
                         onClick = {
                             onInfoClick(GlossaryItem.gateways)
                         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewScreen.kt
@@ -445,7 +445,8 @@ private fun BottomSheetContent(
                 onApplyClick = onGuaranteesApplyClick,
                 onGuaranteeValueChanged = onGuaranteeValueChanged,
                 onGuaranteeValueIncreased = onGuaranteeValueIncreased,
-                onGuaranteeValueDecreased = onGuaranteeValueDecreased
+                onGuaranteeValueDecreased = onGuaranteeValueDecreased,
+                onInfoClick = onInfoClick
             )
         }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
@@ -120,7 +120,7 @@ fun FeesSheet(
                 contentAlignment = Alignment.Center,
             ) {
                 InfoButton(
-                    text = stringResource(id = R.string.customizeNetworkFees_howDoFeesWork),
+                    text = stringResource(id = R.string.infoLink_title_transactionfee),
                     onClick = {
                         onInfoClick(GlossaryItem.transactionfee)
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/GuaranteesSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/GuaranteesSheet.kt
@@ -15,12 +15,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixPrimaryButton
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.domain.model.TransferableAsset
+import com.babylon.wallet.android.presentation.dialogs.info.GlossaryItem
 import com.babylon.wallet.android.presentation.transaction.TransactionReviewViewModel.State
 import com.babylon.wallet.android.presentation.transaction.model.AccountWithPredictedGuarantee
+import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
 import com.babylon.wallet.android.presentation.ui.composables.BottomDialogHeader
 import com.babylon.wallet.android.presentation.ui.composables.GrayBackgroundWrapper
+import com.babylon.wallet.android.presentation.ui.composables.InfoButton
+import com.radixdlt.sargon.Account
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.extensions.toDecimal192
+import com.radixdlt.sargon.samples.sampleMainnet
+import rdx.works.core.domain.resources.Resource
+import rdx.works.core.domain.resources.sampleMainnet
 
 @Composable
 fun GuaranteesSheet(
@@ -31,6 +43,7 @@ fun GuaranteesSheet(
     onGuaranteeValueChanged: (AccountWithPredictedGuarantee, String) -> Unit,
     onGuaranteeValueIncreased: (AccountWithPredictedGuarantee) -> Unit,
     onGuaranteeValueDecreased: (AccountWithPredictedGuarantee) -> Unit,
+    onInfoClick: (GlossaryItem) -> Unit
 ) {
     Column(
         modifier = modifier
@@ -56,14 +69,17 @@ fun GuaranteesSheet(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.fillMaxSize()
         ) {
-//            item {
-//                InfoLink(
-//                    stringResource(com.babylon.wallet.android.R.string.transactionReview_guarantees_howDoGuaranteesWork),
-//                    modifier = Modifier
-//                        .padding(horizontal = RadixTheme.dimensions.paddingDefault)
-//                )
-//                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-//            }
+            item {
+                InfoButton(
+                    modifier = Modifier
+                        .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+                        .padding(bottom = RadixTheme.dimensions.paddingDefault),
+                    text = stringResource(id = R.string.infoLink_title_guarantees),
+                    onClick = {
+                        onInfoClick(GlossaryItem.guarantees)
+                    }
+                )
+            }
             item {
                 Text(
                     modifier = Modifier
@@ -75,11 +91,15 @@ fun GuaranteesSheet(
                     color = RadixTheme.colors.gray1,
                     textAlign = TextAlign.Center
                 )
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSemiLarge))
             }
             items(state.accountsWithPredictedGuarantees) { accountWithCustomizableGuarantee ->
                 GrayBackgroundWrapper {
                     TransactionAccountWithGuaranteesCard(
+                        modifier = Modifier
+                            .padding(top = RadixTheme.dimensions.paddingLarge)
+                            .padding(bottom = RadixTheme.dimensions.paddingSmall)
+                            .padding(horizontal = RadixTheme.dimensions.paddingSmall),
                         accountWithGuarantee = accountWithCustomizableGuarantee,
                         onGuaranteePercentChanged = {
                             onGuaranteeValueChanged(accountWithCustomizableGuarantee, it)
@@ -107,5 +127,35 @@ fun GuaranteesSheet(
                 )
             }
         }
+    }
+}
+
+@UsesSampleValues
+@Preview(showBackground = true)
+@Composable
+private fun GuaranteesSheetPreview() {
+    RadixWalletPreviewTheme {
+        GuaranteesSheet(
+            state = State.Sheet.CustomizeGuarantees(
+                listOf(
+                    AccountWithPredictedGuarantee.Owned(
+                        account = Account.sampleMainnet(),
+                        transferable = TransferableAsset.Fungible.Token(
+                            amount = 10.toDecimal192(),
+                            resource = Resource.FungibleResource.sampleMainnet(),
+                            isNewlyCreated = false
+                        ),
+                        instructionIndex = 1L,
+                        guaranteeAmountString = "100"
+                    )
+                )
+            ),
+            onClose = {},
+            onApplyClick = {},
+            onGuaranteeValueChanged = { _, _ -> },
+            onGuaranteeValueDecreased = {},
+            onGuaranteeValueIncreased = {},
+            onInfoClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLinkConnectorScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/AddLinkConnectorScreen.kt
@@ -236,7 +236,7 @@ private fun ScanQrCode(
         InfoButton(
             modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingXXLarge,),
             textStyle = RadixTheme.typography.body2Link,
-            text = stringResource(id = R.string.scanQR_connectorExtension_radixConnectLearMore),
+            text = stringResource(id = R.string.infoLink_title_radixconnect),
             onClick = {
                 onInfoClick(GlossaryItem.radixconnect)
             }


### PR DESCRIPTION
## Description
This PR replaces the info strings with new ones and adds a missing info button for Customize Guarantees bottom sheet. It also updates its UI based on Zeplin screens.

