### PR TITLE
Improve error handling for transaction manifest errors

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -89,7 +89,7 @@ class TransactionAnalysisDelegate @Inject constructor(
         }.onSuccess { feePayers ->
             _state.update { it.copy(isNetworkFeeLoading = false, feePayers = feePayers) }
         }.onFailure { error ->
-            reportFailure(error)
+            reportFailure(RadixWalletException.DappRequestException.PreviewError(error))
         }
     }
 
@@ -135,7 +135,9 @@ class TransactionAnalysisDelegate @Inject constructor(
                     Result.success(preview)
                 }
             },
-            onFailure = { Result.failure(it) }
+            onFailure = {
+                Result.failure(RadixWalletException.DappRequestException.PreviewError(it))
+            }
         )
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -197,7 +197,7 @@ class WalletViewModel @Inject constructor(
     private fun observeWalletAssets() {
         combine(
             accountsFlow,
-            refreshFlow.onEach { accountLockersDelegate.onRefresh() }
+            refreshFlow
         ) { accounts, refreshType ->
             _state.update { it.loadingAssets(accounts = accounts, refreshType = refreshType) }
 
@@ -280,6 +280,7 @@ class WalletViewModel @Inject constructor(
 
     fun onRefresh() {
         loadAssets(refreshType = RefreshType.Manual(overrideCache = true, showRefreshIndicator = true))
+        accountLockersDelegate.onRefresh()
     }
 
     fun onShowHideBalanceToggle(isVisible: Boolean) {


### PR DESCRIPTION
Double-checked the app behavior when receiving invalid manifest requests while investigating tickets:
[ABW-3794](https://radixdlt.atlassian.net/browse/ABW-3794)
[ABW-3792](https://radixdlt.atlassian.net/browse/ABW-3792)
[ABW-3795](https://radixdlt.atlassian.net/browse/ABW-3795)

The crash reported in the tickets was previously fixed during the Account Lockers feature implementation.

## Description
This PR improves error handling for transaction manifest errors by displaying the generic error pop-up which also dismisses the transaction review screen when acknowledged by the user.

Also, fixed unnecessary calls for the account lockers status check when resuming `WalletScreen`, it's required only when the user explicitly pulls to refresh.


[ABW-3794]: https://radixdlt.atlassian.net/browse/ABW-3794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-3792]: https://radixdlt.atlassian.net/browse/ABW-3792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ABW-3795]: https://radixdlt.atlassian.net/browse/ABW-3795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ