### PR TITLE
[ABW-3268] Rename link connector

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -120,7 +121,9 @@ fun AccountSettingsScreen(
                 viewModel.setBottomSheetContent(AccountPreferenceUiState.BottomSheetContent.HideAccount)
                 bottomSheetState.show()
             }
-        }
+        },
+        isAccountNameUpdated = state.isAccountNameUpdated,
+        onSnackbarMessageShown = viewModel::onSnackbarMessageShown
     )
 
     if (state.isBottomSheetVisible) {
@@ -173,14 +176,29 @@ private fun AccountSettingsContent(
     onGetFreeXrdClick: () -> Unit,
     faucetState: FaucetState,
     isXrdLoading: Boolean,
-    onHideAccount: () -> Unit
+    onHideAccount: () -> Unit,
+    isAccountNameUpdated: Boolean,
+    onSnackbarMessageShown: () -> Unit,
 ) {
-    val snackBarHostState = remember { SnackbarHostState() }
+    val snackbarHostState = remember { SnackbarHostState() }
     SnackbarUIMessage(
         message = error,
-        snackbarHostState = snackBarHostState,
+        snackbarHostState = snackbarHostState,
         onMessageShown = onMessageShown
     )
+
+    val accountUpdatedText = stringResource(R.string.accountSettings_updatedAccountHUDMessage)
+    LaunchedEffect(isAccountNameUpdated) {
+        if (isAccountNameUpdated) {
+            snackbarHostState.showSnackbar(
+                message = accountUpdatedText,
+                duration = SnackbarDuration.Short,
+                withDismissAction = true
+            )
+            onSnackbarMessageShown()
+        }
+    }
+
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -193,7 +211,7 @@ private fun AccountSettingsContent(
         snackbarHost = {
             RadixSnackbarHost(
                 modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
-                hostState = snackBarHostState
+                hostState = snackbarHostState
             )
         },
         containerColor = RadixTheme.colors.gray5
@@ -430,7 +448,9 @@ fun AccountSettingsPreview() {
             onGetFreeXrdClick = {},
             faucetState = FaucetState.Available(isEnabled = true),
             isXrdLoading = false,
-            onHideAccount = {}
+            onHideAccount = {},
+            isAccountNameUpdated = false,
+            onSnackbarMessageShown = {}
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
@@ -129,6 +129,7 @@ class AccountSettingsViewModel @Inject constructor(
                     accountToRename = it,
                     newDisplayName = DisplayName(newAccountName)
                 )
+                _state.update { state -> state.copy(isAccountNameUpdated = true) }
             } ?: Timber.d("Couldn't find account to rename the display name!")
         }
     }
@@ -169,6 +170,10 @@ class AccountSettingsViewModel @Inject constructor(
             sendEvent(Event.AccountHidden)
         }
     }
+
+    fun onSnackbarMessageShown() {
+        _state.update { state -> state.copy(isAccountNameUpdated = false) }
+    }
 }
 
 sealed interface Event : OneOffEvent {
@@ -184,6 +189,7 @@ data class AccountPreferenceUiState(
     val bottomSheetContent: BottomSheetContent = BottomSheetContent.None,
     val error: UiMessage? = null,
     val faucetState: FaucetState = FaucetState.Unavailable,
+    val isAccountNameUpdated: Boolean = false,
     val isFreeXRDLoading: Boolean = false
 ) : UiState {
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -35,6 +36,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -354,6 +356,7 @@ private fun RenameActiveLinkedConnectorSheet(
                     .padding(horizontal = RadixTheme.dimensions.paddingXXLarge)
                     .focusRequester(focusRequester = inputFocusRequester),
                 onValueChanged = onNewNameChange,
+                keyboardOptions = KeyboardOptions.Default.copy(capitalization = KeyboardCapitalization.Words),
                 value = input.name,
                 singleLine = true,
                 hintColor = RadixTheme.colors.gray2

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -148,7 +148,7 @@ private fun LinkedConnectorsContent(
             HorizontalDivider(color = RadixTheme.colors.gray4)
 
             Box(modifier = Modifier.fillMaxSize().background(color = RadixTheme.colors.gray5)) {
-                ActiveLinkedConnectorDetails(
+                ActiveLinkedConnectorsListContent(
                     modifier = Modifier.fillMaxWidth(),
                     activeLinkedConnectorsList = activeLinkedConnectorsList,
                     onLinkNewConnectorClick = onLinkNewConnectorClick,
@@ -189,32 +189,6 @@ private fun LinkedConnectorsContent(
 }
 
 @Composable
-private fun ActiveLinkedConnectorDetails(
-    activeLinkedConnectorsList: ImmutableList<ConnectorUiItem>,
-    onLinkNewConnectorClick: () -> Unit,
-    onRenameConnectorClick: (connectorUiItem: ConnectorUiItem) -> Unit,
-    onDeleteConnectorClick: (id: PublicKeyHash) -> Unit,
-    isAddingNewLinkConnectorInProgress: Boolean,
-    modifier: Modifier = Modifier
-) {
-    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(
-            modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
-            text = stringResource(R.string.linkedConnectors_subtitle),
-            style = RadixTheme.typography.body1Header,
-            color = RadixTheme.colors.gray2
-        )
-        ActiveLinkedConnectorsListContent(
-            activeLinkedConnectorsList = activeLinkedConnectorsList,
-            onRenameConnectorClick = onRenameConnectorClick,
-            onDeleteConnectorClick = onDeleteConnectorClick,
-            isAddingNewLinkConnectorInProgress = isAddingNewLinkConnectorInProgress,
-            onLinkNewConnectorClick = onLinkNewConnectorClick
-        )
-    }
-}
-
-@Composable
 private fun ActiveLinkedConnectorsListContent(
     modifier: Modifier = Modifier,
     activeLinkedConnectorsList: ImmutableList<ConnectorUiItem>,
@@ -224,6 +198,14 @@ private fun ActiveLinkedConnectorsListContent(
     onLinkNewConnectorClick: () -> Unit
 ) {
     LazyColumn(modifier) {
+        item {
+            Text(
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
+                text = stringResource(R.string.linkedConnectors_subtitle),
+                style = RadixTheme.typography.body1Header,
+                color = RadixTheme.colors.gray2
+            )
+        }
         itemsIndexed(activeLinkedConnectorsList) { index, activeLinkedConnector ->
             ActiveLinkedConnectorContent(
                 activeLinkedConnector = activeLinkedConnector,
@@ -251,7 +233,8 @@ private fun ActiveLinkedConnectorsListContent(
                 RadixSecondaryButton(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = RadixTheme.dimensions.paddingMedium),
+                        .padding(horizontal = RadixTheme.dimensions.paddingMedium)
+                        .padding(bottom = RadixTheme.dimensions.paddingDefault),
                     text = stringResource(id = R.string.linkedConnectors_linkNewConnector),
                     onClick = onLinkNewConnectorClick,
                     leadingContent = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -199,9 +199,9 @@ private fun ActiveLinkedConnectorDetails(
 ) {
     Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
-            modifier = Modifier.padding(RadixTheme.dimensions.paddingMedium),
+            modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
             text = stringResource(R.string.linkedConnectors_subtitle),
-            style = RadixTheme.typography.body2Regular,
+            style = RadixTheme.typography.body1Header,
             color = RadixTheme.colors.gray2
         )
         ActiveLinkedConnectorsListContent(
@@ -285,8 +285,8 @@ private fun ActiveLinkedConnectorContent(
             Text(
                 modifier = Modifier.weight(1f),
                 text = activeLinkedConnector.name,
-                style = RadixTheme.typography.body2Regular,
-                color = RadixTheme.colors.gray2,
+                style = RadixTheme.typography.body1Header,
+                color = RadixTheme.colors.gray1,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -54,6 +56,7 @@ import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogW
 import com.babylon.wallet.android.presentation.ui.composables.DSR
 import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
+import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
 import com.radixdlt.sargon.PublicKeyHash
 import com.radixdlt.sargon.annotation.UsesSampleValues
@@ -105,6 +108,8 @@ fun LinkedConnectorsScreen(
             modifier = modifier,
             isAddingNewLinkConnectorInProgress = addLinkConnectorState.isAddingNewLinkConnectorInProgress,
             activeLinkedConnectorsList = state.activeConnectors,
+            isLinkConnectorNameUpdated = state.isLinkConnectorNameUpdated,
+            onSnackbarMessageShown = viewModel::onSnackbarMessageShown,
             onLinkNewConnectorClick = viewModel::onLinkNewConnectorClick,
             onRenameConnectorClick = { viewModel.setRenameConnectorSheetVisible(true, it) },
             onDeleteConnectorClick = viewModel::onDeleteConnectorClick,
@@ -127,11 +132,25 @@ private fun LinkedConnectorsContent(
     modifier: Modifier = Modifier,
     isAddingNewLinkConnectorInProgress: Boolean,
     activeLinkedConnectorsList: ImmutableList<ConnectorUiItem>,
+    isLinkConnectorNameUpdated: Boolean,
+    onSnackbarMessageShown: () -> Unit,
     onLinkNewConnectorClick: () -> Unit,
     onRenameConnectorClick: (connectorUiItem: ConnectorUiItem) -> Unit,
     onDeleteConnectorClick: (id: PublicKeyHash) -> Unit,
     onBackClick: () -> Unit
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val message = stringResource(R.string.linkedConnectors_renameConnector_successHud)
+    LaunchedEffect(isLinkConnectorNameUpdated) {
+        if (isLinkConnectorNameUpdated) {
+            snackbarHostState.showSnackbar(
+                message = message,
+                duration = SnackbarDuration.Short,
+                withDismissAction = true
+            )
+            onSnackbarMessageShown()
+        }
+    }
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -139,6 +158,12 @@ private fun LinkedConnectorsContent(
                 title = stringResource(R.string.linkedConnectors_title),
                 onBackClick = onBackClick,
                 windowInsets = WindowInsets.statusBarsAndBanner
+            )
+        },
+        snackbarHost = {
+            RadixSnackbarHost(
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
+                hostState = snackbarHostState
             )
         }
     ) { padding ->
@@ -378,8 +403,10 @@ fun LinkedConnectorsContentWithActiveLinkedConnectorsPreview() {
                     name = "firefox connection"
                 )
             ).toPersistentList(),
-            onLinkNewConnectorClick = {},
             isAddingNewLinkConnectorInProgress = false,
+            isLinkConnectorNameUpdated = false,
+            onSnackbarMessageShown = {},
+            onLinkNewConnectorClick = {},
             onBackClick = {},
             onRenameConnectorClick = {},
             onDeleteConnectorClick = {}
@@ -429,8 +456,10 @@ fun LinkedConnectorsContentWithoutActiveLinkedConnectorsPreview() {
     RadixWalletTheme {
         LinkedConnectorsContent(
             activeLinkedConnectorsList = persistentListOf(),
-            onLinkNewConnectorClick = {},
             isAddingNewLinkConnectorInProgress = false,
+            isLinkConnectorNameUpdated = false,
+            onLinkNewConnectorClick = {},
+            onSnackbarMessageShown = {},
             onBackClick = {},
             onRenameConnectorClick = {},
             onDeleteConnectorClick = {}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -359,6 +359,11 @@ private fun RenameActiveLinkedConnectorSheet(
                 keyboardOptions = KeyboardOptions.Default.copy(capitalization = KeyboardCapitalization.Words),
                 value = input.name,
                 singleLine = true,
+                error = if (input.isNameEmpty) {
+                    stringResource(R.string.linkedConnectors_renameConnector_errorEmpty)
+                } else {
+                    null
+                },
                 hintColor = RadixTheme.colors.gray2
             )
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXLarge))
@@ -368,7 +373,7 @@ private fun RenameActiveLinkedConnectorSheet(
             onClick = onUpdateNameClick,
             text = stringResource(R.string.accountSettings_renameAccount_button),
             insets = WindowInsets.navigationBars.union(WindowInsets.ime),
-            enabled = input.isNameValid
+            enabled = input.isNameEmpty.not()
         )
     }
 }
@@ -395,6 +400,42 @@ fun LinkedConnectorsContentWithActiveLinkedConnectorsPreview() {
             onBackClick = {},
             onRenameConnectorClick = {},
             onDeleteConnectorClick = {}
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview(showBackground = true)
+@Composable
+fun RenameActiveLinkedConnectorSheetPreview() {
+    RadixWalletTheme {
+        RenameActiveLinkedConnectorSheet(
+            input = LinkedConnectorsUiState.RenameConnectorInput(
+                id = PublicKeyHash.sample(),
+                name = "name",
+                isNameEmpty = false
+            ),
+            onNewNameChange = {},
+            onUpdateNameClick = {},
+            onDismiss = {}
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview(showBackground = true)
+@Composable
+fun RenameActiveLinkedConnectorSheetEmptyPreview() {
+    RadixWalletTheme {
+        RenameActiveLinkedConnectorSheet(
+            input = LinkedConnectorsUiState.RenameConnectorInput(
+                id = PublicKeyHash.sample(),
+                name = "",
+                isNameEmpty = true
+            ),
+            onNewNameChange = {},
+            onUpdateNameClick = {},
+            onDismiss = {}
         )
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsScreen.kt
@@ -151,6 +151,7 @@ private fun LinkedConnectorsContent(
             onSnackbarMessageShown()
         }
     }
+
     Scaffold(
         modifier = modifier,
         topBar = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsViewModel.kt
@@ -98,9 +98,9 @@ class LinkedConnectorsViewModel @Inject constructor(
                     p2pLinkToRename.displayName = newConnectorName
                 }
                 p2pLinksRepository.addOrUpdateP2PLink(p2pLinkToRename)
+                _state.update { state -> state.copy(isLinkConnectorNameUpdated = true) }
             }
             setRenameConnectorSheetVisible(isVisible = false, connectorUiItem = null)
-            _state.update { state -> state.copy(isLinkConnectorNameUpdated = true) }
         }
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsViewModel.kt
@@ -81,7 +81,7 @@ class LinkedConnectorsViewModel @Inject constructor(
             state.copy(
                 renameLinkConnectorItem = state.renameLinkConnectorItem?.copy(
                     name = newName,
-                    isNameValid = newName.isNotEmpty()
+                    isNameEmpty = newName.isEmpty()
                 )
             )
         }
@@ -133,6 +133,6 @@ data class LinkedConnectorsUiState(
     data class RenameConnectorInput(
         val id: PublicKeyHash? = null,
         val name: String = "",
-        val isNameValid: Boolean = false
+        val isNameEmpty: Boolean = false
     )
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/linkedconnectors/LinkedConnectorsViewModel.kt
@@ -100,7 +100,12 @@ class LinkedConnectorsViewModel @Inject constructor(
                 p2pLinksRepository.addOrUpdateP2PLink(p2pLinkToRename)
             }
             setRenameConnectorSheetVisible(isVisible = false, connectorUiItem = null)
+            _state.update { state -> state.copy(isLinkConnectorNameUpdated = true) }
         }
+    }
+
+    fun onSnackbarMessageShown() {
+        _state.update { state -> state.copy(isLinkConnectorNameUpdated = false) }
     }
 }
 
@@ -112,6 +117,7 @@ data class LinkedConnectorsUiState(
     val activeConnectors: ImmutableList<ConnectorUiItem> = persistentListOf(),
     val showAddLinkConnectorScreen: Boolean = false,
     val triggerCameraPermissionPrompt: Boolean = false,
+    val isLinkConnectorNameUpdated: Boolean = false,
     val renameLinkConnectorItem: RenameConnectorInput? = null
 ) : UiState {
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/gateways/GatewaysScreen.kt
@@ -151,14 +151,14 @@ private fun GatewaysContent(
                     InfoButton(
                         modifier = Modifier.padding(
                             horizontal = RadixTheme.dimensions.paddingDefault,
-                            vertical = RadixTheme.dimensions.paddingMedium
+                            vertical = RadixTheme.dimensions.paddingDefault
                         ),
                         text = stringResource(id = R.string.infoLink_title_gateways),
                         onClick = {
                             onInfoClick(GlossaryItem.gateways)
                         }
                     )
-                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXLarge))
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
                 }
                 itemsIndexed(state.gatewayList) { index, gateway ->
                     Column(

--- a/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/RadixTextField.kt
+++ b/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/RadixTextField.kt
@@ -85,7 +85,8 @@ fun RadixTextField(
                         RadixTheme.colors.gray1,
                         LocalTextSelectionColors.current.backgroundColor
                     ),
-                    unfocusedContainerColor = RadixTheme.colors.gray5
+                    unfocusedContainerColor = RadixTheme.colors.gray5,
+                    errorContainerColor = RadixTheme.colors.gray5
                 ),
                 placeholder = {
                     hint?.let {


### PR DESCRIPTION
## Description
This PR adds functionality to rename link connectors.
Also minor update in Gateways screen based on zeplin screens.


## How to test

1. Navigate to Linked Connectors screen
2. Edit a link connector by clicking on the pen icon

➡️  Ensure that link connection has not been affected (e.g. terminated or restarted)


## Video

https://github.com/user-attachments/assets/47f61a86-a700-41c6-84b3-94b775c0d197




## PR submission checklist
- [X] I have tested renaming linked connectors
