### PR TITLE
Fix small UI issues

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/derivepublickey/DerivePublicKeyDialog.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/accessfactorsources/derivepublickey/DerivePublicKeyDialog.kt
@@ -73,12 +73,14 @@ fun DerivePublicKeyDialog(
         }
     }
 
-    DerivePublicKeyBottomSheetContent(
-        modifier = modifier,
-        contentType = state.contentType,
-        onDismiss = viewModel::onUserDismiss,
-        onRetryClick = viewModel::onRetryClick
-    )
+    state.contentType?.let { contentType ->
+        DerivePublicKeyBottomSheetContent(
+            modifier = modifier,
+            contentType = contentType,
+            onDismiss = viewModel::onUserDismiss,
+            onRetryClick = viewModel::onRetryClick
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountScreen.kt
@@ -23,7 +23,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextAlign
@@ -135,6 +139,7 @@ fun CreateAccountContent(
         snackbarHostState = snackBarHostState,
         onMessageShown = onUiMessageShown
     )
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     Scaffold(
         modifier = modifier,
@@ -148,7 +153,10 @@ fun CreateAccountContent(
         },
         bottomBar = {
             RadixBottomBar(
-                onClick = { onAccountCreateClick(isWithLedger) },
+                onClick = {
+                    keyboardController?.hide()
+                    onAccountCreateClick(isWithLedger)
+                },
                 text = stringResource(id = R.string.createAccount_nameNewAccount_continue),
                 enabled = buttonEnabled,
                 insets = if (isKeyboardVisible()) WindowInsets.ime else WindowInsets.navigationBars

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountScreen.kt
@@ -23,11 +23,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextAlign

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/settings/AccountSettingsViewModel.kt
@@ -166,6 +166,7 @@ class AccountSettingsViewModel @Inject constructor(
         viewModelScope.launch {
             val account = state.value.account ?: return@launch
             changeEntityVisibilityUseCase.changeAccountVisibility(entityAddress = account.address, hide = true)
+            setBottomSheetContent(AccountPreferenceUiState.BottomSheetContent.None)
             sendEvent(Event.AccountHidden)
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -83,6 +84,8 @@ fun RestoreMnemonicsScreen(
     LaunchedEffect(Unit) {
         viewModel.biometricAuthProvider = { context.biometricAuthenticateSuspend() }
     }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     RestoreMnemonicsContent(
         state = state,
         onBackClick = viewModel::onBackClick,
@@ -97,6 +100,7 @@ fun RestoreMnemonicsScreen(
                 }
 
                 else -> {
+                    keyboardController?.hide()
                     viewModel.onSubmit()
                 }
             }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/entityhiding/HiddenEntitiesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/entityhiding/HiddenEntitiesScreen.kt
@@ -128,7 +128,11 @@ private fun HiddenEntitiesContent(
                 .fillMaxSize()
                 .background(RadixTheme.colors.gray5)
                 .padding(padding),
-            contentPadding = PaddingValues(horizontal = RadixTheme.dimensions.paddingDefault)
+            contentPadding = PaddingValues(
+                start = RadixTheme.dimensions.paddingDefault,
+                end = RadixTheme.dimensions.paddingDefault,
+                bottom = RadixTheme.dimensions.paddingDefault
+            )
         ) {
             item {
                 HorizontalDivider(color = RadixTheme.colors.gray5)

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/reset/FactoryResetViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/reset/FactoryResetViewModel.kt
@@ -11,6 +11,7 @@ import com.babylon.wallet.android.presentation.common.StateViewModel
 import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -21,10 +22,12 @@ class FactoryResetViewModel @Inject constructor(
     private val getSecurityProblemsUseCase: GetSecurityProblemsUseCase
 ) : StateViewModel<FactoryResetViewModel.State>(), OneOffEventHandler<FactoryResetViewModel.Event> by OneOffEventHandlerImpl() {
 
+    private var securityProblemsJob: Job? = null
+
     override fun initialState(): State = State()
 
     init {
-        viewModelScope.launch {
+        securityProblemsJob = viewModelScope.launch {
             getSecurityProblemsUseCase().collect { problems ->
                 _state.update { state ->
                     state.copy(
@@ -43,6 +46,7 @@ class FactoryResetViewModel @Inject constructor(
         _state.update { it.copy(deleteWalletDialogVisible = false) }
 
         viewModelScope.launch {
+            securityProblemsJob?.cancel()
             deleteWalletUseCase()
             sendEvent(Event.ProfileDeleted)
         }


### PR DESCRIPTION
## Description
This PR fixes a few small UI issues:
- [ABW-3788](https://radixdlt.atlassian.net/browse/ABW-3788) Animation flicker when hiding an account
- The keyboard was unnecessarily showing after tapping Continue when creating the first account
- The `DerivePublicKey` was briefly shown after providing biometrics when creating the first account
- The keyboard was unnecessarily showing after tapping Continue on Seed Phrase entering screen during onboarding
- When resetting the wallet, the Security Center status on Factory Reset screen unnecessarily turned yellow (warning state)
- The bottom of the list on Hidden Personas & Accounts was too close to the bottom of the screen

[ABW-3788]: https://radixdlt.atlassian.net/browse/ABW-3788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ