### PR TITLE
[ABW-3774] [ABW-3521] UI fixes

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixPrimaryButton
+import com.babylon.wallet.android.designsystem.composable.RadixSecondaryButton
 import com.babylon.wallet.android.designsystem.composable.RadixTextButton
 import com.babylon.wallet.android.designsystem.composable.RadixTextField
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
@@ -260,7 +261,8 @@ private fun RestoreFromBackupContent(
                     RadixTextButton(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(RadixTheme.dimensions.paddingDefault),
+                            .padding(RadixTheme.dimensions.paddingDefault)
+                            .padding(bottom = RadixTheme.dimensions.paddingMedium),
                         text = stringResource(id = R.string.recoverProfileBackup_importFileButton_title),
                         onClick = onRestoreFromFileClick
                     )
@@ -446,10 +448,11 @@ private fun OtherRestoreOptionsSection(onOtherRestoreOptionsClick: () -> Unit, m
             style = RadixTheme.typography.body1Header,
             color = RadixTheme.colors.gray1
         )
-        RadixTextButton(
+        RadixSecondaryButton(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+                .padding(horizontal = RadixTheme.dimensions.paddingXXXLarge)
+                .padding(top = RadixTheme.dimensions.paddingDefault),
             text = stringResource(id = R.string.recoverProfileBackup_otherRestoreOptionsButton),
             onClick = onOtherRestoreOptionsClick
         )
@@ -558,17 +561,10 @@ private fun Timestamp.displayable() = remember(this) {
 @UsesSampleValues
 @Preview
 @Composable
-fun RestoreFromBackupWithMultipleCloudBackupsPreview() {
+fun RestoreFromBackupNotLoggedInPreview() {
     RadixWalletTheme {
         RestoreFromBackupContent(
-            state = RestoreFromBackupViewModel.State(
-                backupEmail = "email",
-                restoringProfiles = CloudBackupFileEntity.sample.all.map {
-                    Selectable<RestoreFromBackupViewModel.State.RestoringProfile>(
-                        data = RestoreFromBackupViewModel.State.RestoringProfile.GoogleDrive(it, false)
-                    )
-                }.toPersistentList()
-            ),
+            state = RestoreFromBackupViewModel.State(),
             onBackClick = {},
             onLoginToGoogleClick = {},
             onRestoreFromFileClick = {},
@@ -586,10 +582,17 @@ fun RestoreFromBackupWithMultipleCloudBackupsPreview() {
 @UsesSampleValues
 @Preview
 @Composable
-fun RestoreFromBackupNotLoggedInPreview() {
+fun RestoreFromBackupWithMultipleCloudBackupsPreview() {
     RadixWalletTheme {
         RestoreFromBackupContent(
-            state = RestoreFromBackupViewModel.State(),
+            state = RestoreFromBackupViewModel.State(
+                backupEmail = "email",
+                restoringProfiles = CloudBackupFileEntity.sample.all.map {
+                    Selectable<RestoreFromBackupViewModel.State.RestoringProfile>(
+                        data = RestoreFromBackupViewModel.State.RestoringProfile.GoogleDrive(it, false)
+                    )
+                }.toPersistentList()
+            ),
             onBackClick = {},
             onLoginToGoogleClick = {},
             onRestoreFromFileClick = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/ApprovedDappsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/ApprovedDappsScreen.kt
@@ -2,7 +2,6 @@ package com.babylon.wallet.android.presentation.settings.approveddapps
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -96,39 +95,35 @@ private fun ApprovedDAppsContent(
         Box(modifier = Modifier.padding(padding)) {
             Column {
                 HorizontalDivider(color = RadixTheme.colors.gray4)
-                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
-                Text(
-                    modifier = Modifier.padding(
-                        horizontal = RadixTheme.dimensions.paddingDefault,
-                        vertical = RadixTheme.dimensions.paddingMedium
-                    ),
-                    text = stringResource(R.string.authorizedDapps_subtitle),
-                    style = RadixTheme.typography.body1HighImportance,
-                    color = RadixTheme.colors.gray2
-                )
-                InfoButton(
-                    modifier = Modifier.padding(
-                        horizontal = RadixTheme.dimensions.paddingDefault,
-                        vertical = RadixTheme.dimensions.paddingMedium
-                    ),
-                    text = stringResource(id = R.string.infoLink_title_dapps),
-                    onClick = {
-                        onInfoClick(GlossaryItem.dapps)
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    item {
+                        Text(
+                            modifier = Modifier.padding(
+                                horizontal = RadixTheme.dimensions.paddingDefault,
+                                vertical = RadixTheme.dimensions.paddingDefault
+                            ),
+                            text = stringResource(R.string.authorizedDapps_subtitle),
+                            style = RadixTheme.typography.body1HighImportance,
+                            color = RadixTheme.colors.gray2
+                        )
+                        InfoButton(
+                            modifier = Modifier.padding(
+                                horizontal = RadixTheme.dimensions.paddingDefault
+                            ),
+                            text = stringResource(id = R.string.infoLink_title_dapps),
+                            onClick = {
+                                onInfoClick(GlossaryItem.dapps)
+                            }
+                        )
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXLarge))
                     }
-                )
-                LazyColumn(
-                    contentPadding = PaddingValues(
-                        horizontal = RadixTheme.dimensions.paddingDefault,
-                        vertical = RadixTheme.dimensions.paddingLarge
-                    ),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier.fillMaxSize()
-                ) {
                     items(state.dApps) { item ->
                         DappCard(
-                            modifier = Modifier.throttleClickable {
-                                onDAppClick(item.dApp.dAppAddress)
-                            },
+                            modifier = Modifier
+                                .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+                                .throttleClickable {
+                                    onDAppClick(item.dApp.dAppAddress)
+                                },
                             dApp = item.dApp,
                             bottomContent = if (item.hasDeposits) {
                                 {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/approveddapps/dappdetail/DappDetailScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.babylon.wallet.android.presentation.settings.approveddapps.dappdetail
 
 import androidx.activity.compose.BackHandler
@@ -197,7 +195,7 @@ private fun DappDetailContent(
                     onBackClick = onBackClick,
                     windowInsets = WindowInsets.statusBarsAndBanner
                 )
-                HorizontalDivider(color = RadixTheme.colors.gray5)
+                HorizontalDivider(color = RadixTheme.colors.gray4)
             }
         }
     ) { padding ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/PersonasScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/PersonasScreen.kt
@@ -1,13 +1,13 @@
 package com.babylon.wallet.android.presentation.settings.personas
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.HorizontalDivider
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.composable.RadixSecondaryButton
@@ -100,37 +99,33 @@ fun PersonasContent(
             horizontalAlignment = Alignment.Start
         ) {
             HorizontalDivider(color = RadixTheme.colors.gray4)
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
-            Text(
-                modifier = Modifier.padding(
-                    horizontal = RadixTheme.dimensions.paddingDefault,
-                    vertical = RadixTheme.dimensions.paddingMedium
-                ),
-                text = stringResource(id = R.string.personas_subtitle),
-                style = RadixTheme.typography.body1HighImportance,
-                color = RadixTheme.colors.gray2
-            )
-            InfoButton(
-                modifier = Modifier.padding(
-                    horizontal = RadixTheme.dimensions.paddingDefault,
-                    vertical = RadixTheme.dimensions.paddingMedium
-                ),
-                text = stringResource(id = R.string.infoLink_title_personas),
-                onClick = {
-                    onInfoClick(GlossaryItem.personas)
+            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                item {
+                    Text(
+                        modifier = Modifier.padding(
+                            horizontal = RadixTheme.dimensions.paddingDefault,
+                            vertical = RadixTheme.dimensions.paddingMedium
+                        ),
+                        text = stringResource(id = R.string.personas_subtitle),
+                        style = RadixTheme.typography.body1HighImportance,
+                        color = RadixTheme.colors.gray2
+                    )
+                    InfoButton(
+                        modifier = Modifier.padding(
+                            horizontal = RadixTheme.dimensions.paddingDefault,
+                            vertical = RadixTheme.dimensions.paddingMedium
+                        ),
+                        text = stringResource(id = R.string.infoLink_title_personas),
+                        onClick = {
+                            onInfoClick(GlossaryItem.personas)
+                        }
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
                 }
-            )
-            LazyColumn(
-                modifier = Modifier.fillMaxWidth(),
-                contentPadding = PaddingValues(
-                    horizontal = RadixTheme.dimensions.paddingDefault,
-                    vertical = RadixTheme.dimensions.paddingLarge
-                ),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
                 itemsIndexed(items = state.personas) { _, personaItem ->
                     PersonaCard(
                         modifier = Modifier
+                            .padding(horizontal = RadixTheme.dimensions.paddingDefault)
                             .clip(RadixTheme.shapes.roundedRectMedium)
                             .throttleClickable {
                                 onPersonaClick(personaItem.address)
@@ -145,10 +140,13 @@ fun PersonasContent(
                 item {
                     Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
                     RadixSecondaryButton(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .wrapContentWidth(align = Alignment.CenterHorizontally)
+                            .padding(bottom = RadixTheme.dimensions.paddingDefault),
                         text = stringResource(id = R.string.personas_createNewPersona),
                         onClick = createNewPersona
                     )
-                    Spacer(modifier = Modifier.height(100.dp))
                 }
             }
         }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/personas/personadetail/PersonaDetailScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.babylon.wallet.android.presentation.settings.personas.personadetail
 
 import androidx.compose.foundation.layout.Column
@@ -132,7 +130,7 @@ private fun PersonaDetailContent(
                     windowInsets = WindowInsets.statusBarsAndBanner
                 )
 
-                HorizontalDivider(color = RadixTheme.colors.gray5)
+                HorizontalDivider(color = RadixTheme.colors.gray4)
             }
         },
         bottomBar = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/WalletPreferencesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/WalletPreferencesScreen.kt
@@ -96,7 +96,7 @@ private fun WalletPreferencesContent(
             modifier = Modifier.padding(padding),
             horizontalAlignment = Alignment.Start
         ) {
-            HorizontalDivider(color = RadixTheme.colors.gray5)
+            HorizontalDivider(color = RadixTheme.colors.gray4)
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 item {
                     Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXXLarge))

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/assetshiding/HiddenAssetsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/assetshiding/HiddenAssetsScreen.kt
@@ -109,8 +109,7 @@ private fun HiddenAssetsContent(
                     onBackClick = onBackClick,
                     windowInsets = WindowInsets.statusBarsAndBanner
                 )
-
-                HorizontalDivider(color = RadixTheme.colors.gray5)
+                HorizontalDivider(color = RadixTheme.colors.gray4)
             }
         },
         snackbarHost = {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/entityhiding/HiddenEntitiesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/preferences/entityhiding/HiddenEntitiesScreen.kt
@@ -116,13 +116,20 @@ private fun HiddenEntitiesContent(
             confirmText = stringResource(id = R.string.common_confirm)
         )
     }
-    Scaffold(modifier = modifier, topBar = {
-        RadixCenteredTopAppBar(
-            title = stringResource(R.string.hiddenEntities_title),
-            onBackClick = onBackClick,
-            windowInsets = WindowInsets.statusBarsAndBanner
-        )
-    }) { padding ->
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            Column {
+                RadixCenteredTopAppBar(
+                    title = stringResource(R.string.hiddenEntities_title),
+                    onBackClick = onBackClick,
+                    windowInsets = WindowInsets.statusBarsAndBanner
+                )
+                HorizontalDivider(color = RadixTheme.colors.gray4)
+            }
+        }
+    ) { padding ->
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
@@ -135,7 +142,6 @@ private fun HiddenEntitiesContent(
             )
         ) {
             item {
-                HorizontalDivider(color = RadixTheme.colors.gray5)
                 Text(
                     modifier = Modifier.padding(top = RadixTheme.dimensions.paddingDefault),
                     text = stringResource(R.string.hiddenEntities_text),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package com.babylon.wallet.android.presentation.settings.securitycenter.backup
 
 import android.provider.DocumentsContract
@@ -190,11 +188,14 @@ private fun BackupScreenContent(
     Scaffold(
         modifier = modifier,
         topBar = {
-            RadixCenteredTopAppBar(
-                title = stringResource(id = R.string.configurationBackup_title),
-                onBackClick = onBackClick,
-                windowInsets = WindowInsets.statusBarsAndBanner
-            )
+            Column {
+                RadixCenteredTopAppBar(
+                    title = stringResource(id = R.string.configurationBackup_title),
+                    onBackClick = onBackClick,
+                    windowInsets = WindowInsets.statusBarsAndBanner
+                )
+                HorizontalDivider(color = RadixTheme.colors.gray4)
+            }
         },
         snackbarHost = {
             RadixSnackbarHost(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/ledgerhardwarewallets/LedgerHardwareWalletsScreen.kt
@@ -168,9 +168,9 @@ fun LedgerHardwareWalletsScreen(
 @Composable
 private fun LedgerHardwareWalletsContent(
     ledgerDevices: ImmutableList<FactorSource.Ledger>,
-    onAddLedgerDeviceClick: () -> Unit,
-    onBackClick: () -> Unit,
     isNewLinkedConnectorConnected: Boolean,
+    onAddLedgerDeviceClick: () -> Unit,
+    onBackClick: () -> Unit
 ) {
     BackHandler(onBack = onBackClick)
 
@@ -184,67 +184,52 @@ private fun LedgerHardwareWalletsContent(
         },
         containerColor = RadixTheme.colors.gray5
     ) { padding ->
-        Column(modifier = Modifier.padding(padding)) {
-            HorizontalDivider(color = RadixTheme.colors.gray5)
-            LedgerDeviceDetails(
-                modifier = Modifier.fillMaxWidth(),
-                ledgerFactorSources = ledgerDevices,
-                onAddLedgerDeviceClick = onAddLedgerDeviceClick,
-                isNewLinkedConnectorConnected = isNewLinkedConnectorConnected
-            )
-        }
-    }
-}
-
-@Composable
-private fun LedgerDeviceDetails(
-    modifier: Modifier = Modifier,
-    ledgerFactorSources: ImmutableList<FactorSource.Ledger>,
-    onAddLedgerDeviceClick: () -> Unit,
-    isNewLinkedConnectorConnected: Boolean
-) {
-    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
-        Text(
-            modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault),
-            text = stringResource(id = R.string.ledgerHardwareDevices_subtitleAllLedgers),
-            style = RadixTheme.typography.body1HighImportance,
-            color = RadixTheme.colors.gray2
-        )
-        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXXLarge))
-        if (ledgerFactorSources.isNotEmpty()) {
-            LedgerDevicesListContent(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
-                ledgerDevices = ledgerFactorSources,
-                onAddLedgerDeviceClick = onAddLedgerDeviceClick,
-                isNewLinkedConnectorConnected = isNewLinkedConnectorConnected
-            )
-        } else {
-            Text(
-                modifier = Modifier
-                    .padding(horizontal = RadixTheme.dimensions.paddingDefault)
-                    .fillMaxWidth()
-                    .background(RadixTheme.colors.defaultBackground, RadixTheme.shapes.roundedRectSmall)
-                    .padding(RadixTheme.dimensions.paddingLarge),
-                text = stringResource(id = R.string.ledgerHardwareDevices_subtitleNoLedgers),
-                style = RadixTheme.typography.body1Header,
-                color = RadixTheme.colors.gray2,
-                overflow = TextOverflow.Ellipsis,
-                textAlign = TextAlign.Center
-            )
-            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
-            RadixSecondaryButton(
-                text = stringResource(id = R.string.ledgerHardwareDevices_addNewLedger),
-                onClick = onAddLedgerDeviceClick,
-                modifier = Modifier
-                    .fillMaxWidth(0.7f)
-                    .imePadding(),
-                isLoading = isNewLinkedConnectorConnected.not(),
-                enabled = isNewLinkedConnectorConnected,
-                throttleClicks = true
-            )
+        Column(
+            modifier = Modifier.padding(padding),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            HorizontalDivider(color = RadixTheme.colors.gray4)
+            if (ledgerDevices.isNotEmpty()) {
+                LedgerDevicesListContent(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    ledgerDevices = ledgerDevices,
+                    isNewLinkedConnectorConnected = isNewLinkedConnectorConnected,
+                    onAddLedgerDeviceClick = onAddLedgerDeviceClick,
+                )
+            } else {
+                Text(
+                    modifier = Modifier.padding(vertical = RadixTheme.dimensions.paddingDefault),
+                    text = stringResource(id = R.string.ledgerHardwareDevices_subtitleAllLedgers),
+                    style = RadixTheme.typography.body1HighImportance,
+                    color = RadixTheme.colors.gray2
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
+                Text(
+                    modifier = Modifier
+                        .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+                        .fillMaxWidth()
+                        .background(RadixTheme.colors.defaultBackground, RadixTheme.shapes.roundedRectSmall)
+                        .padding(RadixTheme.dimensions.paddingLarge),
+                    text = stringResource(id = R.string.ledgerHardwareDevices_subtitleNoLedgers),
+                    style = RadixTheme.typography.body1Header,
+                    color = RadixTheme.colors.gray2,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingXLarge))
+                RadixSecondaryButton(
+                    text = stringResource(id = R.string.ledgerHardwareDevices_addNewLedger),
+                    onClick = onAddLedgerDeviceClick,
+                    modifier = Modifier
+                        .fillMaxWidth(0.7f)
+                        .imePadding(),
+                    isLoading = isNewLinkedConnectorConnected.not(),
+                    enabled = isNewLinkedConnectorConnected,
+                    throttleClicks = true
+                )
+            }
         }
     }
 }
@@ -253,14 +238,23 @@ private fun LedgerDeviceDetails(
 private fun LedgerDevicesListContent(
     modifier: Modifier = Modifier,
     ledgerDevices: ImmutableList<FactorSource.Ledger>,
+    isNewLinkedConnectorConnected: Boolean,
     onAddLedgerDeviceClick: () -> Unit,
-    isNewLinkedConnectorConnected: Boolean
 ) {
     LazyColumn(
         modifier,
         contentPadding = PaddingValues(horizontal = RadixTheme.dimensions.paddingDefault),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        item {
+            Text(
+                modifier = Modifier.padding(vertical = RadixTheme.dimensions.paddingDefault),
+                text = stringResource(id = R.string.ledgerHardwareDevices_subtitleAllLedgers),
+                style = RadixTheme.typography.body1HighImportance,
+                color = RadixTheme.colors.gray2
+            )
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
+        }
         items(
             items = ledgerDevices,
             key = { factorSource: FactorSource.Ledger ->
@@ -284,7 +278,7 @@ private fun LedgerDevicesListContent(
             RadixSecondaryButton(
                 modifier = Modifier
                     .fillMaxWidth(0.7f)
-                    .padding(bottom = RadixTheme.dimensions.paddingMedium),
+                    .padding(bottom = RadixTheme.dimensions.paddingDefault),
                 text = stringResource(id = R.string.ledgerHardwareDevices_addNewLedger),
                 onClick = onAddLedgerDeviceClick,
                 throttleClicks = true,
@@ -295,19 +289,6 @@ private fun LedgerDevicesListContent(
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-fun LedgerHardwareWalletsScreenEmptyPreview() {
-    RadixWalletTheme {
-        LedgerHardwareWalletsContent(
-            ledgerDevices = persistentListOf(),
-            onAddLedgerDeviceClick = {},
-            onBackClick = {},
-            isNewLinkedConnectorConnected = true
-        )
-    }
-}
-
 @UsesSampleValues
 @Preview(showBackground = true)
 @Composable
@@ -315,6 +296,19 @@ fun LedgerHardwareWalletsScreenPreview() {
     RadixWalletTheme {
         LedgerHardwareWalletsContent(
             ledgerDevices = FactorSource.Ledger.sample.all.toPersistentList(),
+            onAddLedgerDeviceClick = {},
+            onBackClick = {},
+            isNewLinkedConnectorConnected = true
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun LedgerHardwareWalletsScreenEmptyPreview() {
+    RadixWalletTheme {
+        LedgerHardwareWalletsContent(
+            ledgerDevices = persistentListOf(),
             onAddLedgerDeviceClick = {},
             onBackClick = {},
             isNewLinkedConnectorConnected = true

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityfactors/SecurityFactorsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityfactors/SecurityFactorsScreen.kt
@@ -1,5 +1,6 @@
 package com.babylon.wallet.android.presentation.settings.securitycenter.securityfactors
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -52,11 +53,14 @@ private fun SecurityFactorsContent(
     Scaffold(
         modifier = modifier,
         topBar = {
-            RadixCenteredTopAppBar(
-                title = stringResource(id = R.string.securityFactors_title),
-                onBackClick = onBackClick,
-                windowInsets = WindowInsets.statusBarsAndBanner
-            )
+            Column {
+                RadixCenteredTopAppBar(
+                    title = stringResource(id = R.string.securityFactors_title),
+                    onBackClick = onBackClick,
+                    windowInsets = WindowInsets.statusBarsAndBanner
+                )
+                HorizontalDivider(color = RadixTheme.colors.gray4)
+            }
         },
         containerColor = RadixTheme.colors.gray5
     ) { padding ->

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/SeedPhrasesScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/seedphrases/SeedPhrasesScreen.kt
@@ -96,11 +96,14 @@ private fun SeedPhraseContent(
 ) {
     Scaffold(
         topBar = {
-            RadixCenteredTopAppBar(
-                title = stringResource(id = R.string.displayMnemonics_seedPhrases),
-                onBackClick = onBackClick,
-                windowInsets = WindowInsets.statusBarsAndBanner
-            )
+            Column {
+                RadixCenteredTopAppBar(
+                    title = stringResource(id = R.string.displayMnemonics_seedPhrases),
+                    onBackClick = onBackClick,
+                    windowInsets = WindowInsets.statusBarsAndBanner
+                )
+                HorizontalDivider(color = RadixTheme.colors.gray4)
+            }
         },
         containerColor = RadixTheme.colors.defaultBackground
     ) { padding ->
@@ -108,7 +111,6 @@ private fun SeedPhraseContent(
             modifier = Modifier.padding(padding),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            HorizontalDivider(color = RadixTheme.colors.gray5)
             LazyColumn(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/TroubleshootingSettingsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/troubleshooting/TroubleshootingSettingsScreen.kt
@@ -58,11 +58,14 @@ private fun TroubleshootingSettingsContent(
     Scaffold(
         modifier = modifier,
         topBar = {
-            RadixCenteredTopAppBar(
-                title = stringResource(id = R.string.troubleshooting_title),
-                onBackClick = onBackClick,
-                windowInsets = WindowInsets.statusBarsAndBanner
-            )
+            Column {
+                RadixCenteredTopAppBar(
+                    title = stringResource(id = R.string.troubleshooting_title),
+                    onBackClick = onBackClick,
+                    windowInsets = WindowInsets.statusBarsAndBanner
+                )
+                HorizontalDivider(color = RadixTheme.colors.gray4)
+            }
         },
         containerColor = RadixTheme.colors.gray5
     ) { padding ->
@@ -70,7 +73,6 @@ private fun TroubleshootingSettingsContent(
             modifier = Modifier.padding(padding),
             horizontalAlignment = Alignment.Start
         ) {
-            HorizontalDivider(color = RadixTheme.colors.gray5)
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 settings.forEach { troubleshootingItem ->
                     item {


### PR DESCRIPTION
## Description
This PR:
- adjusts `RestoreFromBackupScreen` based on latest zeplin screens
- fixes the scrollable content of settings screens. Now it scrolls all the content of the screen and not only the list items. (see video)
- adds a horizontal divider for all settings screen, see thread [here](https://rdxworks.slack.com/archives/C031A0V1A1W/p1726650979827779)

## Video

https://github.com/user-attachments/assets/3de8dfd1-a599-4f81-8577-14c06a41c32a

## PR submission checklist
- [X] I have tested all screens
