### PR TITLE
[ABW-3833, ABW-3834] Fix account locker prompts when locker claim succeeds or fails

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletScreen.kt
@@ -112,6 +112,7 @@ fun WalletScreen(
 
     LifecycleEventEffect(event = Lifecycle.Event.ON_RESUME) {
         viewModel.processBufferedDeepLinkRequest()
+        viewModel.refreshAccountLockers()
     }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/wallet/WalletViewModel.kt
@@ -126,6 +126,8 @@ class WalletViewModel @Inject constructor(
         }
     }
 
+    fun refreshAccountLockers() = accountLockersDelegate.onRefresh()
+
     override fun initialState() = State()
 
     fun onStart() {
@@ -280,7 +282,7 @@ class WalletViewModel @Inject constructor(
 
     fun onRefresh() {
         loadAssets(refreshType = RefreshType.Manual(overrideCache = true, showRefreshIndicator = true))
-        accountLockersDelegate.onRefresh()
+        refreshAccountLockers()
     }
 
     fun onShowHideBalanceToggle(isVisible: Boolean) {


### PR DESCRIPTION
## Description
This PR fixes the account prompts (hide) of the Wallet screen in case the locker claim 
- succeeds 
- fails because a recover has happened in the meantime 


## How to test

### Test 1
1. Airdrop something to your account 
2. Claim it from the wallet screen (click on the account prompt)
➡️ Assert that after the claim (successful transaction) the prompt is gone (it might take 1-2 seconds)

### Test 2
1. Airdrop something to your account
2. At the wallet screen pull to refresh to see the prompt in the corresponding account
3. Now at this point recover back what you airdropped
4. At the wallet screen do not pull to refresh and click on the prompt 
5. You will get an error dialog. Click on this and the app returns back to the Wallet screen
➡️ Assert the prompt is gone


## PR submission checklist
- [X] I have tested the above cases
