### PR TITLE
Change remaining mac os runners to ubuntu

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -112,9 +112,8 @@ jobs:
           SNYK_TOKEN: ${{ env.SNYK_TOKEN }}
 
   unit_tests:
-    # Unit tests depend on sargon-desktop which currently is only supporting mac os
     name: "Unit tests"
-    runs-on: macos-13-xlarge
+    runs-on: ubuntu-latest
 
     steps:
       - uses: RDXWorks-actions/checkout@main
@@ -177,7 +176,7 @@ jobs:
   static_analysis:
     name: "Static analysis and SonarCloud"
     # jacoco runs unit tests and since they depend on sargon-desktop we need mac os
-    runs-on: macos-13-xlarge
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: RDXWorks-actions/checkout@main


### PR DESCRIPTION
## Description
Since babylon wallet now depends on `sargon-desktop-bins` that include linux binaries, all the runners that used to run on Mac os can change to ubuntu.