### PR TITLE
Accounts personas seed phrase missing dialog

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
@@ -305,7 +305,7 @@ class BuildUnauthorizedDappResponseUseCase @Inject constructor(
             ).onSuccess { result ->
                 entitiesWithSignatures = result.signersWithSignatures
             }.onFailure { error ->
-                return Result.failure(error)
+                return Result.failure(RadixWalletException.DappRequestException.FailedToSignAuthChallenge(error))
             }
         }
 

--- a/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/usecases/BuildDappResponseUseCase.kt
@@ -166,7 +166,7 @@ class BuildAuthorizedDappResponseUseCase @Inject constructor(
                             )
                         )
                     }.onFailure {
-                        response = Result.failure(it)
+                        response = Result.failure(RadixWalletException.DappRequestException.FailedToSignAuthChallenge(it))
                     }
                     response
                 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -264,7 +264,9 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
                     _state.update { it.copy(isNoMnemonicErrorVisible = true) }
                 }
 
-                is RadixWalletException.LedgerCommunicationException, is RadixWalletException.SignatureCancelled -> {}
+                is RadixWalletException.LedgerCommunicationException,
+                is RadixWalletException.SignatureCancelled,
+                is RadixWalletException.DappRequestException.RejectedByUser -> {}
 
                 else -> {
                     respondToIncomingRequestUseCase.respondWithFailure(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginViewModel.kt
@@ -136,9 +136,6 @@ class DAppUnauthorizedLoginViewModel @Inject constructor(
     }
 
     private suspend fun handleRequestError(exception: Throwable) {
-        if (exception is RadixWalletException.DappRequestException.RejectedByUser) {
-            return // user rejected/cancelled signing, do not close the request screen
-        }
         if (exception is RadixWalletException.DappRequestException) {
             logNonFatalException(exception)
             when (exception.cause) {
@@ -150,7 +147,9 @@ class DAppUnauthorizedLoginViewModel @Inject constructor(
                     _state.update { it.copy(isNoMnemonicErrorVisible = true) }
                 }
 
-                is RadixWalletException.LedgerCommunicationException, is RadixWalletException.SignatureCancelled -> {}
+                is RadixWalletException.LedgerCommunicationException,
+                is RadixWalletException.SignatureCancelled,
+                is RadixWalletException.DappRequestException.RejectedByUser -> {}
 
                 else -> {
                     respondToIncomingRequestUseCase.respondWithFailure(
@@ -160,10 +159,6 @@ class DAppUnauthorizedLoginViewModel @Inject constructor(
                     )
                     _state.update { it.copy(failureDialogState = FailureDialogState.Open(exception)) }
                 }
-            }
-        } else {
-            if (exception is ProfileException.NoMnemonic) {
-                _state.update { it.copy(isNoMnemonicErrorVisible = true) }
             }
         }
     }


### PR DESCRIPTION
## Description
If the user hasn't provided the seed phrase for the associated accounts/personas while restoring from backup, when logging in a dapp we should display the same error message as in other similar cases in the wallet.

## How to test

1. Perform logins with personas or accounts with our stokenet dapps, while the seed phrase is missing.
