### PR TITLE
Reset mnemonic key spec when is invalidated and before any seed phras…

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/createaccount/CreateAccountViewModel.kt
@@ -105,7 +105,7 @@ class CreateAccountViewModel @Inject constructor(
 
     private suspend fun createWallet(): Result<Unit> {
         val sargonOs = sargonOsManager.sargonOs
-        keystoreManager.resetKeySpecs()
+        keystoreManager.resetMnemonicKeySpecWhenInvalidated()
 
         return runCatching {
             sargonOs.newWallet()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/mnemonics/RestoreMnemonicsViewModel.kt
@@ -24,6 +24,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import rdx.works.core.KeystoreManager
 import rdx.works.core.sargon.changeGatewayToNetworkId
 import rdx.works.core.sargon.currentNetwork
 import rdx.works.core.sargon.factorSourceId
@@ -52,7 +53,8 @@ class RestoreMnemonicsViewModel @Inject constructor(
     private val restoreProfileFromBackupUseCase: RestoreProfileFromBackupUseCase,
     private val discardTemporaryRestoredFileForBackupUseCase: DiscardTemporaryRestoredFileForBackupUseCase,
     private val appEventBus: AppEventBus,
-    private val homeCardsRepository: HomeCardsRepository
+    private val homeCardsRepository: HomeCardsRepository,
+    private val keystoreManager: KeystoreManager
 ) : StateViewModel<RestoreMnemonicsViewModel.State>(),
     OneOffEventHandler<RestoreMnemonicsViewModel.Event> by OneOffEventHandlerImpl() {
 
@@ -65,6 +67,9 @@ class RestoreMnemonicsViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             val profile = args.backupType?.let { backupType ->
+                // Reset keyspec before importing any mnemonic, when keyspec is invalid
+                keystoreManager.resetMnemonicKeySpecWhenInvalidated()
+
                 getTemporaryRestoringProfileForBackupUseCase(backupType)?.changeGatewayToNetworkId(NetworkId.MAINNET)
             } ?: run {
                 getProfileUseCase.flow.firstOrNull()

--- a/core/src/main/java/rdx/works/core/KeystoreManager.kt
+++ b/core/src/main/java/rdx/works/core/KeystoreManager.kt
@@ -27,5 +27,4 @@ class KeystoreManager @Inject constructor() {
     } else {
         Result.success(false)
     }
-
 }

--- a/core/src/main/java/rdx/works/core/KeystoreManager.kt
+++ b/core/src/main/java/rdx/works/core/KeystoreManager.kt
@@ -5,12 +5,27 @@ import javax.inject.Inject
 
 class KeystoreManager @Inject constructor() {
 
-    fun resetKeySpecs(): Result<Unit> = KeySpec.reset(
-        listOf(
-            KeySpec.Profile(),
-            KeySpec.Mnemonic()
-        )
-    )
+    /**
+     * The user, at any time, can reset their device PIN/PATTERN, thus making the mnemonic master key useless. The reason is that the
+     * mnemonic is tied to the device's biometrics. In order to be able to encrypt the mnemonic again, with the same master key alias,
+     * we need to delete the old entry (or generate a new one in versions <31).
+     *
+     * This method deletes (or regenerates in older android versions) the master key **only** when is deemed useless.
+     * Check the [KeySpec.Mnemonic.checkIfPermanentlyInvalidated] method for more info.
+     *
+     * This method should be called when:
+     * - The user is about to create a new wallet
+     * - restore a wallet from backup
+     * - derive a wallet from a seed phrase
+     * - whenever a profile exists, and the app comes to the foreground. The previous cases, so far require no profile. In those cases, we
+     * cannot just reset the mnemonic key spec on the fly, due to the complex nature of multiple mnemonics entries. On the other hand
+     * when a profile exists, we can reset the master key, delete the mnemonics, and notify the user that recovery is required.
+     * - deleting a wallet
+     */
+    fun resetMnemonicKeySpecWhenInvalidated(): Result<Boolean> = if (KeySpec.Mnemonic().checkIfPermanentlyInvalidated()) {
+        KeySpec.reset(listOf(KeySpec.Mnemonic())).map { true }
+    } else {
+        Result.success(false)
+    }
 
-    fun resetMnemonicKeySpec(): Result<Unit> = KeySpec.reset(listOf(KeySpec.Mnemonic()))
 }

--- a/profile/src/main/java/rdx/works/profile/data/repository/CheckKeystoreIntegrityUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/data/repository/CheckKeystoreIntegrityUseCase.kt
@@ -1,12 +1,12 @@
 package rdx.works.profile.data.repository
 
 import com.radixdlt.sargon.extensions.asGeneral
-import com.radixdlt.sargon.os.storage.KeySpec
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import rdx.works.core.KeystoreManager
+import rdx.works.core.logNonFatalException
 import rdx.works.core.sargon.deviceFactorSources
 import rdx.works.profile.domain.GetProfileUseCase
 import timber.log.Timber
@@ -28,18 +28,19 @@ class CheckKeystoreIntegrityUseCase @Inject constructor(
 
         val deviceFactorSources = profile.deviceFactorSources
         if (deviceFactorSources.isEmpty()) return
-        // try to encrypt random string
-        val keyInvalid = KeySpec.Mnemonic().checkIfPermanentlyInvalidated()
-        if (keyInvalid) {
-            // if we have invalid mnemonic encryption key we delete all mnemonics which we can no longer decrypt
-            deviceFactorSources.forEach { deviceFactorSource ->
-                mnemonicRepository.deleteMnemonic(deviceFactorSource.value.id.asGeneral())
-            }
-            // just for safety, removing key, although it seem that Android system delete it so it is always null
-            keystoreManager.resetMnemonicKeySpec().onFailure {
+
+        keystoreManager.resetMnemonicKeySpecWhenInvalidated()
+            .onSuccess { invalidated ->
+                if (invalidated) {
+                    deviceFactorSources.forEach { deviceFactorSource ->
+                        mnemonicRepository.deleteMnemonic(deviceFactorSource.value.id.asGeneral())
+                    }
+
+                    _didMnemonicIntegrityChange.update { true }
+                }
+            }.onFailure {
+                logNonFatalException(it)
                 Timber.d(it, "Failed to regenerate encryption key")
             }
-            _didMnemonicIntegrityChange.update { true }
-        }
     }
 }

--- a/profile/src/main/java/rdx/works/profile/data/repository/ProfileRepository.kt
+++ b/profile/src/main/java/rdx/works/profile/data/repository/ProfileRepository.kt
@@ -130,7 +130,7 @@ class ProfileRepositoryImpl @Inject constructor(
         }.onFailure {
             Timber.w(it, "Failed to delete wallet")
         }.then {
-            keystoreManager.resetKeySpecs().onFailure { error ->
+            keystoreManager.resetMnemonicKeySpecWhenInvalidated().onFailure { error ->
                 Timber.w(error, "Failed to reset encryption keys")
             }
         }

--- a/profile/src/main/java/rdx/works/profile/domain/DeriveProfileUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/DeriveProfileUseCase.kt
@@ -33,7 +33,7 @@ class DeriveProfileUseCase @Inject constructor(
         else -> withContext(defaultDispatcher) {
             val sargonOs = sargonOsManager.sargonOs
 
-            keystoreManager.resetKeySpecs()
+            keystoreManager.resetMnemonicKeySpecWhenInvalidated()
 
             runCatching {
                 sargonOs.newWalletWithDerivedBdfs(

--- a/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
@@ -2,7 +2,6 @@ package rdx.works.profile.domain.backup
 
 import com.radixdlt.sargon.NetworkId
 import com.radixdlt.sargon.os.SargonOsManager
-import rdx.works.core.KeystoreManager
 import rdx.works.core.sargon.changeGatewayToNetworkId
 import rdx.works.profile.cloudbackup.domain.CheckMigrationToNewBackupSystemUseCase
 import rdx.works.profile.data.repository.BackupProfileRepository

--- a/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/RestoreProfileFromBackupUseCase.kt
@@ -11,8 +11,7 @@ import javax.inject.Inject
 class RestoreProfileFromBackupUseCase @Inject constructor(
     private val backupProfileRepository: BackupProfileRepository,
     private val checkMigrationToNewBackupSystemUseCase: CheckMigrationToNewBackupSystemUseCase,
-    private val sargonOsManager: SargonOsManager,
-    private val keystoreManager: KeystoreManager
+    private val sargonOsManager: SargonOsManager
 ) {
 
     suspend operator fun invoke(
@@ -24,8 +23,6 @@ class RestoreProfileFromBackupUseCase @Inject constructor(
         // always restore backup on mainnet
         val profile = backupProfileRepository.getTemporaryRestoringProfile(backupType)
             ?.changeGatewayToNetworkId(NetworkId.MAINNET) ?: return Result.failure(RuntimeException("No restoring profile available"))
-
-        keystoreManager.resetKeySpecs()
 
         return runCatching {
             sargonOs.importWallet(


### PR DESCRIPTION
## Description
Fixes the problem that sargon boot PR introduced, when the user imports a wallet from backup. Check the comments in code for more details.

## How to test
There are many cases that involve keyspec invalidation. In all cases the common path to verify that we handle keyspec invalidation is

1. While in wallet, put the app in the background.
2. Go to app settings and reset the device's PIN/PATTERN to a new one. This will mark the mnemonic key spec useless.
3. DO NOT go back to the app, instead DELETE the wallet's data from settings. 
4. Then proceed to **any** of the steps below:
    * Create a new wallet. Go to the seed phrases and verify that you see the seed phrase
    *  Import a wallet from backup. Go to the seed phrases and verify that you see the seed phrase
    * Derive a wallet from seed phrase. Go to the seed phrases and verify that you see the seed phrase

___
The previous cases are involving key spec invalidation. Although you could reproduce the problem with a simpler step without resetting the PIN/PATTERN. Just by importing a backup. This had to do with the invalidating method being placed in `RestoreProfileFromBackupUseCase` were the user had already provided the mnemonics in a previous step.
