### PR TITLE
Force check origin metadata on dapp validation

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/EntityMetadataCollectionExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/gateway/extensions/EntityMetadataCollectionExtensions.kt
@@ -276,7 +276,7 @@ fun EntityMetadataItem.toMetadata(): Metadata? = when (val typed = value.typed) 
     is MetadataOriginValue -> Metadata.Primitive(
         key = key,
         value = typed.value,
-        valueType = MetadataType.Url,
+        valueType = MetadataType.Origin,
         isLocked = isLocked
     )
 
@@ -286,7 +286,7 @@ fun EntityMetadataItem.toMetadata(): Metadata? = when (val typed = value.typed) 
             Metadata.Primitive(
                 key = key,
                 value = it,
-                valueType = MetadataType.Url,
+                valueType = MetadataType.Origin,
                 isLocked = isLocked
             )
         },

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/cache/database/StateDatabase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/cache/database/StateDatabase.kt
@@ -64,8 +64,11 @@ abstract class StateDatabase : RoomDatabase() {
         @Deprecated("Added next cursor to metadata column and locked flag")
         const val VERSION_9 = 9
 
-        // Add account locker logic
+        @Deprecated("Add account locker logic")
         const val VERSION_10 = 10
+
+        // Updated metadata schema: Added Origin MetadataType
+        const val VERSION_11 = 11
 
         private const val NAME = "STATE_DATABASE"
 

--- a/app/src/main/java/com/babylon/wallet/android/data/repository/cache/database/StateDatabase.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/cache/database/StateDatabase.kt
@@ -25,7 +25,7 @@ import com.babylon.wallet.android.data.repository.cache.database.locker.AccountL
         AccountLockerTouchedAtEntity::class,
         AccountLockerVaultItemEntity::class
     ],
-    version = StateDatabase.VERSION_10
+    version = StateDatabase.VERSION_11
 )
 @TypeConverters(StateDatabaseConverters::class)
 abstract class StateDatabase : RoomDatabase() {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
@@ -199,7 +199,7 @@ fun Metadata.ValueView(
                 maxLines = 2
             )
 
-            MetadataType.Url -> Row(
+            MetadataType.Url, MetadataType.Origin -> Row(
                 modifier = modifier
                     .fillMaxWidth()
                     .clickable { context.openUrl(value) },
@@ -224,6 +224,6 @@ fun Metadata.ValueView(
 private const val ASSET_METADATA_SHORT_STRING_THRESHOLD = 40
 private val Metadata.isRenderedInNewLine: Boolean
     get() = this is Metadata.Primitive && (
-        valueType is MetadataType.Url ||
-            (valueType is MetadataType.String && value.length > ASSET_METADATA_SHORT_STRING_THRESHOLD)
-        )
+            valueType is MetadataType.Url || valueType is MetadataType.Origin ||
+                    (valueType is MetadataType.String && value.length > ASSET_METADATA_SHORT_STRING_THRESHOLD)
+            )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/AssetMetadataRow.kt
@@ -224,6 +224,6 @@ fun Metadata.ValueView(
 private const val ASSET_METADATA_SHORT_STRING_THRESHOLD = 40
 private val Metadata.isRenderedInNewLine: Boolean
     get() = this is Metadata.Primitive && (
-            valueType is MetadataType.Url || valueType is MetadataType.Origin ||
-                    (valueType is MetadataType.String && value.length > ASSET_METADATA_SHORT_STRING_THRESHOLD)
-            )
+        valueType is MetadataType.Url || valueType is MetadataType.Origin ||
+            (valueType is MetadataType.String && value.length > ASSET_METADATA_SHORT_STRING_THRESHOLD)
+        )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/MetadataView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/composable/MetadataView.kt
@@ -353,7 +353,7 @@ fun MetadataValueView(
                 )
             }
 
-            MetadataType.Url -> LinkText(
+            MetadataType.Url, MetadataType.Origin -> LinkText(
                 modifier = modifier.fillMaxWidth(),
                 url = metadata.value
             )
@@ -365,7 +365,7 @@ private const val SHORT_KEY_THRESHOLD = 30
 private const val SHORT_VALUE_THRESHOLD = 40
 private val Metadata.isRenderedInNewLine: Boolean
     get() = this is Metadata.Primitive && (
-        valueType is MetadataType.Url ||
+        valueType is MetadataType.Url || valueType is MetadataType.Origin ||
             (valueType is MetadataType.String && value.length > SHORT_VALUE_THRESHOLD) ||
             (valueType is MetadataType.NonFungibleGlobalId)
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransactionTypeExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/processor/TransactionTypeExtensions.kt
@@ -448,7 +448,7 @@ private fun NewlyCreatedResource.toMetadata(): List<Metadata> {
             Metadata.Collection(
                 key = ExplicitMetadataKey.TAGS.key,
                 values = it.map { tag ->
-                    Metadata.Primitive(key = ExplicitMetadataKey.TAGS.key, value = tag, valueType = MetadataType.Url)
+                    Metadata.Primitive(key = ExplicitMetadataKey.TAGS.key, value = tag, valueType = MetadataType.String)
                 }
             )
         )

--- a/core/src/main/java/rdx/works/core/domain/DApp.kt
+++ b/core/src/main/java/rdx/works/core/domain/DApp.kt
@@ -68,12 +68,12 @@ data class DApp(
                             Metadata.Primitive(
                                 ExplicitMetadataKey.CLAIMED_WEBSITES.key,
                                 "https://hammunet-dashboard.rdx-works-main.extratools.works",
-                                MetadataType.Url
+                                MetadataType.Origin
                             ),
                             Metadata.Primitive(
                                 ExplicitMetadataKey.CLAIMED_WEBSITES.key,
                                 "https://ansharnet-dashboard.rdx-works-main.extratools.works",
-                                MetadataType.Url
+                                MetadataType.Origin
                             ),
                         )
                     ),

--- a/core/src/main/java/rdx/works/core/domain/resources/metadata/Metadata.kt
+++ b/core/src/main/java/rdx/works/core/domain/resources/metadata/Metadata.kt
@@ -113,4 +113,8 @@ sealed interface MetadataType {
     @Serializable
     @SerialName("url")
     data object Url : MetadataType
+
+    @Serializable
+    @SerialName("origin")
+    data object Origin : MetadataType
 }

--- a/core/src/main/java/rdx/works/core/domain/resources/metadata/StandardMetadata.kt
+++ b/core/src/main/java/rdx/works/core/domain/resources/metadata/StandardMetadata.kt
@@ -110,7 +110,7 @@ fun List<Metadata>.dAppDefinitions(): List<String> = findCollection(
 
 fun List<Metadata>.claimedWebsites(): List<String>? = findCollection(
     key = ExplicitMetadataKey.CLAIMED_WEBSITES,
-    type = MetadataType.Url
+    type = MetadataType.Origin
 )?.map { it.value }
 
 fun List<Metadata>.claimedEntities(): List<String>? = findCollection(


### PR DESCRIPTION
## Description
In the previous versions we allowed dApp definitions to set the `claimed_websites` metadata as `Url`, `UrlArray`, `Origin` and `OriginArray`. This PR makes the definition of `claimed_websites` more strict that verifies dApps that define their claimed websites as `Origin` or `OriginArray`.

In order to allow that, 
1. `MetadataType.Origin` domain type was created and origin metadata are mapped to this type
2. In 2-way link verification we query the claimed websites as origin and not just url.
3. Url and Origin are both rendered the same in UI.
4. DB should migrate in order to force the cache to refresh.

## How to test
1. Try to login to many dapps with dev mode off. If you try to login to dev-sandbox, it should not allow you to validate it. (Although this may vary according to what dapp definition is set. If it is set to `dApp 4` from a previous test with claims, that dapp definition contains the correct claimed websites. Otherwise it should fail verification)
2. Check the ticket's description to see the related conversation.