### PR TITLE
Special characters in profile import

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -39,7 +38,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -77,7 +75,6 @@ import com.radixdlt.sargon.Timestamp
 import com.radixdlt.sargon.annotation.UsesSampleValues
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
-import kotlinx.coroutines.launch
 import rdx.works.profile.domain.backup.BackupType
 import rdx.works.profile.domain.backup.CloudBackupFileEntity
 import java.time.ZoneId
@@ -448,30 +445,6 @@ private fun OtherRestoreOptionsSection(onOtherRestoreOptionsClick: () -> Unit, m
             onClick = onOtherRestoreOptionsClick
         )
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SyncSheetState(
-    state: SheetState,
-    isSheetVisible: Boolean,
-    onSheetClosed: () -> Unit,
-) {
-    val scope = rememberCoroutineScope()
-
-    LaunchedEffect(isSheetVisible) {
-        if (isSheetVisible) {
-            scope.launch { state.show() }
-        } else {
-            scope.launch { state.hide() }
-        }
-    }
-
-    LaunchedEffect(state.isVisible) {
-        if (!state.isVisible) {
-            onSheetClosed()
-        }
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -33,7 +34,6 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -64,7 +64,6 @@ import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.model.Selectable
 import com.babylon.wallet.android.presentation.onboarding.restore.backup.RestoreFromBackupViewModel.State.PasswordSheet
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
-import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
 import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixRadioButton
@@ -156,19 +155,6 @@ private fun RestoreFromBackupContent(
         message = state.uiMessage,
         snackbarHostState = snackBarHostState,
         onMessageShown = onMessageShown
-    )
-
-    val modalBottomSheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = true
-    )
-    SyncSheetState(
-        state = modalBottomSheetState,
-        isSheetVisible = state.isPasswordSheetVisible,
-        onSheetClosed = {
-            if (state.isPasswordSheetVisible) {
-                onBackClick()
-            }
-        }
     )
 
     Scaffold(
@@ -282,7 +268,9 @@ private fun RestoreFromBackupContent(
 
     if (state.passwordSheetState is PasswordSheet.Open) {
         BottomSheetDialogWrapper(
-            modifier = Modifier.imePadding(),
+            modifier = Modifier
+                .imePadding()
+                .navigationBarsPadding(),
             addScrim = true,
             showDragHandle = true,
             headerBackIcon = Icons.AutoMirrored.Filled.ArrowBack,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/onboarding/restore/backup/RestoreFromBackupScreen.kt
@@ -16,10 +16,13 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -59,6 +62,8 @@ import com.babylon.wallet.android.designsystem.composable.RadixTextField
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
 import com.babylon.wallet.android.domain.model.Selectable
+import com.babylon.wallet.android.presentation.onboarding.restore.backup.RestoreFromBackupViewModel.State.PasswordSheet
+import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
 import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
@@ -275,24 +280,22 @@ private fun RestoreFromBackupContent(
         }
     }
 
-    if (state.isPasswordSheetVisible) {
-        DefaultModalSheetLayout(
-            sheetState = modalBottomSheetState,
-            enableImePadding = true,
-            wrapContent = true,
-            sheetContent = {
-                if (state.passwordSheetState is RestoreFromBackupViewModel.State.PasswordSheet.Open) {
-                    PasswordSheet(
-                        state = state.passwordSheetState,
-                        onBackClick = onBackClick,
-                        onPasswordTyped = onPasswordTyped,
-                        onPasswordRevealToggle = onPasswordRevealToggle,
-                        onPasswordSubmitted = onPasswordSubmitted
-                    )
-                }
-            },
-            onDismissRequest = onBackClick
-        )
+    if (state.passwordSheetState is PasswordSheet.Open) {
+        BottomSheetDialogWrapper(
+            modifier = Modifier.imePadding(),
+            addScrim = true,
+            showDragHandle = true,
+            headerBackIcon = Icons.AutoMirrored.Filled.ArrowBack,
+            showDefaultTopBar = true,
+            onDismiss = onBackClick,
+        ) {
+            PasswordSheet(
+                state = state.passwordSheetState,
+                onPasswordTyped = onPasswordTyped,
+                onPasswordRevealToggle = onPasswordRevealToggle,
+                onPasswordSubmitted = onPasswordSubmitted
+            )
+        }
     }
 }
 
@@ -488,7 +491,6 @@ private fun SyncSheetState(
 private fun PasswordSheet(
     modifier: Modifier = Modifier,
     state: RestoreFromBackupViewModel.State.PasswordSheet.Open,
-    onBackClick: () -> Unit,
     onPasswordTyped: (String) -> Unit,
     onPasswordRevealToggle: () -> Unit,
     onPasswordSubmitted: () -> Unit
@@ -496,11 +498,6 @@ private fun PasswordSheet(
     Column(
         modifier = modifier
     ) {
-        RadixCenteredTopAppBar(
-            title = "",
-            onBackClick = onBackClick,
-        )
-
         RadixTextField(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
@@ -747,6 +747,8 @@ private fun EncryptSheet(
                 visualTransformation = if (state.isPasswordRevealed) VisualTransformation.None else PasswordVisualTransformation()
             )
 
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
             val focusManager = LocalFocusManager.current
             var isConfirmFocused by remember { mutableStateOf(false) }
             RadixTextField(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -43,7 +42,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -84,7 +82,6 @@ import com.babylon.wallet.android.presentation.ui.composables.SwitchSettingsItem
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
 import com.babylon.wallet.android.utils.biometricAuthenticateSuspend
 import com.babylon.wallet.android.utils.rememberLauncherForSignInToGoogle
-import kotlinx.coroutines.launch
 import rdx.works.core.InstantGenerator
 import rdx.works.core.TimestampGenerator
 import rdx.works.core.domain.cloudbackup.BackupState
@@ -625,30 +622,6 @@ private fun ExportWalletBackupFileDialog(
             )
         }
     )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SyncSheetState(
-    sheetState: SheetState,
-    isSheetVisible: Boolean,
-    onSheetClosed: () -> Unit,
-) {
-    val scope = rememberCoroutineScope()
-
-    LaunchedEffect(isSheetVisible) {
-        if (isSheetVisible) {
-            scope.launch { sheetState.show() }
-        } else {
-            scope.launch { sheetState.hide() }
-        }
-    }
-
-    LaunchedEffect(sheetState.isVisible) {
-        if (!sheetState.isVisible) {
-            onSheetClosed()
-        }
-    }
 }
 
 @Composable

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
@@ -18,12 +18,18 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -68,7 +74,9 @@ import com.babylon.wallet.android.designsystem.composable.RadixTextButton
 import com.babylon.wallet.android.designsystem.composable.RadixTextField
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.RadixWalletTheme
+import com.babylon.wallet.android.presentation.settings.securitycenter.backup.BackupViewModel.State.EncryptSheet
 import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
+import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.DSR
 import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
 import com.babylon.wallet.android.presentation.ui.composables.PromptLabel
@@ -288,24 +296,27 @@ private fun BackupScreenContent(
         }
     }
 
-    if (state.isEncryptSheetVisible) {
-        DefaultModalSheetLayout(
-            sheetState = modalBottomSheetState,
-            sheetContent = {
-                if (state.encryptSheet is BackupViewModel.State.EncryptSheet.Open) {
-                    EncryptSheet(
-                        state = state.encryptSheet,
-                        onPasswordTyped = onEncryptPasswordTyped,
-                        onPasswordRevealToggle = onEncryptPasswordRevealToggle,
-                        onPasswordConfirmTyped = onEncryptConfirmPasswordTyped,
-                        onPasswordConfirmRevealToggle = onEncryptPasswordConfirmRevealToggle,
-                        onSubmitClick = onEncryptSubmitClick,
-                        onBackClick = onBackClick
-                    )
-                }
-            },
-            onDismissRequest = onBackClick
-        )
+    if (state.encryptSheet is EncryptSheet.Open) {
+        BottomSheetDialogWrapper(
+            modifier = Modifier
+                .windowInsetsPadding(WindowInsets.statusBarsAndBanner)
+                .imePadding()
+                .navigationBarsPadding(),
+            addScrim = true,
+            showDragHandle = true,
+            headerBackIcon = Icons.AutoMirrored.Filled.ArrowBack,
+            showDefaultTopBar = true,
+            onDismiss = onBackClick,
+        ) {
+            EncryptSheet(
+                state = state.encryptSheet,
+                onPasswordTyped = onEncryptPasswordTyped,
+                onPasswordRevealToggle = onEncryptPasswordRevealToggle,
+                onPasswordConfirmTyped = onEncryptConfirmPasswordTyped,
+                onPasswordConfirmRevealToggle = onEncryptPasswordConfirmRevealToggle,
+                onSubmitClick = onEncryptSubmitClick
+            )
+        }
     }
 }
 
@@ -666,17 +677,9 @@ private fun EncryptSheet(
     onPasswordConfirmTyped: (String) -> Unit,
     onPasswordConfirmRevealToggle: () -> Unit,
     onSubmitClick: () -> Unit,
-    onBackClick: () -> Unit
 ) {
     Scaffold(
         modifier = modifier,
-        topBar = {
-            RadixCenteredTopAppBar(
-                title = stringResource(id = R.string.empty),
-                onBackClick = onBackClick,
-                windowInsets = WindowInsets.statusBarsAndBanner
-            )
-        },
         bottomBar = {
             RadixPrimaryButton(
                 modifier = Modifier

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/backup/BackupScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -39,7 +38,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -78,7 +76,6 @@ import com.babylon.wallet.android.presentation.settings.securitycenter.backup.Ba
 import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.DSR
-import com.babylon.wallet.android.presentation.ui.composables.DefaultModalSheetLayout
 import com.babylon.wallet.android.presentation.ui.composables.PromptLabel
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
@@ -173,20 +170,6 @@ private fun BackupScreenContent(
             onDeny = onFileBackupDeny
         )
     }
-
-    val modalBottomSheetState = rememberModalBottomSheetState(
-        skipPartiallyExpanded = true
-    )
-
-    SyncSheetState(
-        sheetState = modalBottomSheetState,
-        isSheetVisible = state.isEncryptSheetVisible,
-        onSheetClosed = {
-            if (state.isEncryptSheetVisible) {
-                onBackClick()
-            }
-        }
-    )
 
     val snackBarHostState = remember { SnackbarHostState() }
     SnackbarUIMessage(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Dialogs.kt
@@ -117,6 +117,7 @@ fun BottomSheetDialogWrapper(
     addScrim: Boolean = false,
     showDragHandle: Boolean = false,
     showDefaultTopBar: Boolean = true,
+    headerBackIcon: ImageVector = Icons.Filled.Clear,
     isDismissible: Boolean = true,
     title: String? = null,
     heightFraction: Float = 1f,
@@ -214,6 +215,7 @@ fun BottomSheetDialogWrapper(
                                 .padding(top = RadixTheme.dimensions.paddingMedium)
                                 .fillMaxWidth()
                                 .background(RadixTheme.colors.defaultBackground, shape = RadixTheme.shapes.roundedRectTopDefault),
+                            backIcon = headerBackIcon,
                             onDismissRequest = { onDismissRequest() },
                             title = title
                         )

--- a/core/src/main/java/rdx/works/core/serializers/StringBase64EncodedSerializer.kt
+++ b/core/src/main/java/rdx/works/core/serializers/StringBase64EncodedSerializer.kt
@@ -1,7 +1,5 @@
 package rdx.works.core.serializers
 
-import android.util.Base64
-import android.util.Log
 import io.ktor.util.decodeBase64String
 import io.ktor.util.encodeBase64
 import kotlinx.serialization.KSerializer
@@ -11,7 +9,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-object StringBase64EncodedSerializer: KSerializer<String> {
+object StringBase64EncodedSerializer : KSerializer<String> {
     private const val SERIAL_NAME = "rdx.works.core.serializers.StringBase64EncodedSerializer"
 
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(

--- a/core/src/main/java/rdx/works/core/serializers/StringBase64EncodedSerializer.kt
+++ b/core/src/main/java/rdx/works/core/serializers/StringBase64EncodedSerializer.kt
@@ -1,17 +1,18 @@
 package rdx.works.core.serializers
 
+import android.util.Base64
 import android.util.Log
+import io.ktor.util.decodeBase64String
+import io.ktor.util.encodeBase64
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import java.net.URLDecoder
-import java.net.URLEncoder
 
-object StringUrlEncodedSerializer: KSerializer<String> {
-    private const val SERIAL_NAME = "rdx.works.core.serializers.StringUrlEncodedSerializer"
+object StringBase64EncodedSerializer: KSerializer<String> {
+    private const val SERIAL_NAME = "rdx.works.core.serializers.StringBase64EncodedSerializer"
 
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
         serialName = SERIAL_NAME,
@@ -19,10 +20,10 @@ object StringUrlEncodedSerializer: KSerializer<String> {
     )
 
     override fun serialize(encoder: Encoder, value: String) {
-        encoder.encodeString(URLEncoder.encode(value, "UTF-8"))
+        encoder.encodeString(value.encodeBase64())
     }
 
     override fun deserialize(decoder: Decoder): String {
-        return URLDecoder.decode(decoder.decodeString(), "UTF-8")
+        return decoder.decodeString().decodeBase64String()
     }
 }

--- a/core/src/main/java/rdx/works/core/serializers/StringUrlEncodedSerializer.kt
+++ b/core/src/main/java/rdx/works/core/serializers/StringUrlEncodedSerializer.kt
@@ -1,0 +1,28 @@
+package rdx.works.core.serializers
+
+import android.util.Log
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.net.URLDecoder
+import java.net.URLEncoder
+
+object StringUrlEncodedSerializer: KSerializer<String> {
+    private const val SERIAL_NAME = "rdx.works.core.serializers.StringUrlEncodedSerializer"
+
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
+        serialName = SERIAL_NAME,
+        kind = PrimitiveKind.STRING
+    )
+
+    override fun serialize(encoder: Encoder, value: String) {
+        encoder.encodeString(URLEncoder.encode(value, "UTF-8"))
+    }
+
+    override fun deserialize(decoder: Decoder): String {
+        return URLDecoder.decode(decoder.decodeString(), "UTF-8")
+    }
+}

--- a/profile/src/main/java/rdx/works/profile/domain/backup/BackupType.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/BackupType.kt
@@ -1,7 +1,7 @@
 package rdx.works.profile.domain.backup
 
 import kotlinx.serialization.Serializable
-import rdx.works.core.serializers.StringUrlEncodedSerializer
+import rdx.works.core.serializers.StringBase64EncodedSerializer
 
 @Serializable
 sealed interface BackupType {
@@ -21,7 +21,7 @@ sealed interface BackupType {
 
         @Serializable
         data class Encrypted(
-            @Serializable(with = StringUrlEncodedSerializer::class)
+            @Serializable(with = StringBase64EncodedSerializer::class)
             val password: String
         ) : File
     }

--- a/profile/src/main/java/rdx/works/profile/domain/backup/BackupType.kt
+++ b/profile/src/main/java/rdx/works/profile/domain/backup/BackupType.kt
@@ -1,6 +1,7 @@
 package rdx.works.profile.domain.backup
 
 import kotlinx.serialization.Serializable
+import rdx.works.core.serializers.StringUrlEncodedSerializer
 
 @Serializable
 sealed interface BackupType {
@@ -19,6 +20,9 @@ sealed interface BackupType {
         data object PlainText : File
 
         @Serializable
-        data class Encrypted(val password: String) : File
+        data class Encrypted(
+            @Serializable(with = StringUrlEncodedSerializer::class)
+            val password: String
+        ) : File
     }
 }


### PR DESCRIPTION
## Description
This PR solves a problem reported by users when importing a profile with password. The culprit was that special characters could not be used when passed as input in our nav system. A base64 encoding is used in combination with kotlinx serialization.

This PR also solves 3 more UI bugs related to profile export/import with password:
1. When exporting the profile with password, the textfields had no space between them.
2. Used `BottomSheetDialogWrapper` in `BackupScreen` that allows text field context actions such as paste, which is valuable to a user that might want to paste a password. 
3. Did the same in `RestoreFromBackupScreen`

## How to test
1. Create passwords with special characters
4. Export and import the profile.
5. Try to use copy-paste functionality to also test the change to the bottom sheets