### PR TITLE
[ABW-3880] Fix transaction fee when fully paid by dapp

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -37,6 +37,7 @@ import com.radixdlt.sargon.extensions.compareTo
 import com.radixdlt.sargon.extensions.formatted
 import com.radixdlt.sargon.extensions.hiddenResources
 import com.radixdlt.sargon.extensions.init
+import com.radixdlt.sargon.extensions.isZero
 import com.radixdlt.sargon.extensions.minus
 import com.radixdlt.sargon.extensions.orZero
 import com.radixdlt.sargon.extensions.toDecimal192
@@ -359,15 +360,17 @@ class TransactionReviewViewModel @Inject constructor(
             get() = previewType !is PreviewType.None && !isBalanceInsufficientToPayTheFee
 
         val noFeePayerSelected: Boolean
-            get() = feePayers?.selectedAccountAddress == null
+            get() = if (transactionFees.transactionFeeToLock.isZero) false else feePayers?.selectedAccountAddress == null
 
         val isSelectedFeePayerInvolvedInTransaction: Boolean
             get() = runCatching {
-                request?.transactionManifestData?.feePayerCandidates()?.contains(feePayers?.selectedAccountAddress)
+                if (feePayers?.selectedAccountAddress == null) return@runCatching true
+                request?.transactionManifestData?.feePayerCandidates()?.contains(feePayers.selectedAccountAddress)
             }.getOrNull() ?: false
 
         val isBalanceInsufficientToPayTheFee: Boolean
             get() {
+                if (transactionFees.transactionFeeToLock.isZero) return false
                 if (feePayers == null) return true
                 val candidateAddress = feePayers.selectedAccountAddress ?: return true
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/FeesSheet.kt
@@ -350,7 +350,7 @@ fun FeesSheet(
 }
 
 @Composable
-fun NetworkFeesDefaultView(
+private fun NetworkFeesDefaultView(
     modifier: Modifier = Modifier,
     transactionFees: TransactionFees?
 ) {
@@ -473,7 +473,7 @@ fun NetworkFeesDefaultView(
 }
 
 @Composable
-fun NetworkFeesAdvancedView(
+private fun NetworkFeesAdvancedView(
     modifier: Modifier = Modifier,
     transactionFees: TransactionFees?,
     onFeePaddingAmountChanged: (String) -> Unit,
@@ -598,7 +598,7 @@ fun NetworkFeesAdvancedView(
                 Text(
                     text = stringResource(
                         id = R.string.transactionReview_xrdAmount,
-                        transactionFees?.networkExecutionCost.orEmpty()
+                        transactionFees?.totalExecutionCostDisplayed.orEmpty()
                     ),
                     style = RadixTheme.typography.body1Header,
                     color = RadixTheme.colors.gray1,
@@ -625,7 +625,7 @@ fun NetworkFeesAdvancedView(
                 Text(
                     text = stringResource(
                         id = R.string.transactionReview_xrdAmount,
-                        transactionFees?.networkFinalizationCost.orEmpty()
+                        transactionFees?.finalizationCostDisplayed.orEmpty()
                     ),
                     style = RadixTheme.typography.body1Header,
                     color = RadixTheme.colors.gray1,
@@ -680,7 +680,7 @@ fun NetworkFeesAdvancedView(
                 Text(
                     text = stringResource(
                         id = R.string.transactionReview_xrdAmount,
-                        transactionFees?.networkStorageCost.orEmpty()
+                        transactionFees?.storageExpansionCostDisplayed.orEmpty()
                     ),
                     style = RadixTheme.typography.body1Header,
                     color = RadixTheme.colors.gray1,
@@ -733,7 +733,7 @@ fun NetworkFeesAdvancedView(
                 } else {
                     stringResource(
                         id = R.string.transactionReview_xrdAmount,
-                        transactionFees?.royaltiesCost.orEmpty()
+                        transactionFees?.royaltiesCostDisplayed.orEmpty()
                     )
                 }
                 Text(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/NetworkFeeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/NetworkFeeContent.kt
@@ -109,42 +109,42 @@ fun NetworkFeeContent(
             )
         }
 
-        if (noFeePayerSelected) {
-            if (!isNetworkFeeLoading) {
+        if (isNetworkFeeLoading.not()) {
+            if (noFeePayerSelected) {
                 WarningText(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = RadixTheme.dimensions.paddingSmall),
                     text = AnnotatedString(stringResource(id = R.string.transactionReview_feePayerValidation_feePayerRequired)),
                 )
-            }
-        } else if (insufficientBalanceToPayTheFee) {
-            WarningText(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = RadixTheme.dimensions.paddingSmall),
-                text = AnnotatedString(stringResource(id = R.string.customizeNetworkFees_warning_insufficientBalance)),
-                contentColor = RadixTheme.colors.red1,
-                textStyle = RadixTheme.typography.body1Header
-            )
-        } else if (isSelectedFeePayerInvolvedInTransaction.not()) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(top = RadixTheme.dimensions.paddingSmall),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
-            ) {
+            } else if (insufficientBalanceToPayTheFee) {
                 WarningText(
-                    modifier = Modifier.weight(1f),
-                    text = AnnotatedString(stringResource(id = R.string.transactionReview_feePayerValidation_linksNewAccount)),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = RadixTheme.dimensions.paddingSmall),
+                    text = AnnotatedString(stringResource(id = R.string.customizeNetworkFees_warning_insufficientBalance)),
+                    contentColor = RadixTheme.colors.red1,
                     textStyle = RadixTheme.typography.body1Header
                 )
-                InfoButton(
-                    text = stringResource(R.string.empty),
-                    color = RadixTheme.colors.gray3,
-                    onClick = {
-                        onInfoClick(GlossaryItem.payingaccount)
-                    }
-                )
+            } else if (isSelectedFeePayerInvolvedInTransaction.not()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = RadixTheme.dimensions.paddingSmall),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
+                ) {
+                    WarningText(
+                        modifier = Modifier.weight(1f),
+                        text = AnnotatedString(stringResource(id = R.string.transactionReview_feePayerValidation_linksNewAccount)),
+                        textStyle = RadixTheme.typography.body1Header
+                    )
+                    InfoButton(
+                        text = stringResource(R.string.empty),
+                        color = RadixTheme.colors.gray3,
+                        onClick = {
+                            onInfoClick(GlossaryItem.payingaccount)
+                        }
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFees.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFees.kt
@@ -123,13 +123,7 @@ data class TransactionFees(
      * Finalized fee to lock for the transaction
      **/
     val transactionFeeToLock: Decimal192
-        get() = totalExecutionCost +
-            networkFinalization +
-            effectiveTip +
-            networkStorage +
-            feePaddingAmountForCalculation +
-            royalties -
-            nonContingentFeeLock
+        get() = (networkFee - nonContingentFeeLock).clamped
 
     val transactionFeeTotalUsd: FiatPrice?
         get() = xrdFiatPrice?.let { FiatPrice(transactionFeeToLock * it.price, it.currency) }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFees.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/fees/TransactionFees.kt
@@ -87,20 +87,20 @@ data class TransactionFees(
 
     // ********* ADVANCED *********
 
-    val networkExecutionCost: String
+    val totalExecutionCostDisplayed: String
         get() = totalExecutionCost.formatted()
 
-    val networkFinalizationCost: String
+    val finalizationCostDisplayed: String
         get() = networkFinalization.formatted()
 
-    val networkStorageCost: String
+    val storageExpansionCostDisplayed: String
         get() = networkStorage.formatted()
 
-    val royaltiesCost: String
+    val royaltiesCostDisplayed: String
         get() = royalties.formatted()
 
     val noRoyaltiesCostDue: Boolean
-        get() = royaltiesCost == "0"
+        get() = royaltiesCostDisplayed == "0"
 
     /**
      * This is negative amount (if greater than zero) representation of nonContingentLock for Paid by dApps section

--- a/app/src/test/java/com/babylon/wallet/android/presentation/transaction/FeesResolverTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/transaction/FeesResolverTest.kt
@@ -191,4 +191,38 @@ class FeesResolverTest {
         assertEquals("0.2", fees.defaultRoyaltyFeesDisplayed)
         assertEquals("1.240813", fees.defaultTransactionFee.formatted())
     }
+
+    @Test
+    fun `verify total transaction fee to lock is zero when fully paid by dapp`() = runTest {
+        val summary = emptyExecutionSummary.copy(
+            feeLocks = FeeLocks(
+                lock = 1.1.toDecimal192(),
+                contingentLock = 0.toDecimal192()
+            ),
+            feeSummary = FeeSummary(
+                executionCost = 0.20627775.toDecimal192(),
+                finalizationCost = 0.01525175.toDecimal192(),
+                storageExpansionCost = 0.0343322748.toDecimal192(),
+                royaltyCost = 0.toDecimal192()
+            ),
+            detailedClassification = listOf(
+                DetailedManifestClass.General
+            ),
+            reservedInstructions = emptyList()
+        )
+
+        val fees = FeesResolver.resolve(
+            summary = summary,
+            notaryAndSigners = notaryAndSigners.copy(
+                signers = listOf(Account.sampleMainnet().asProfileEntity())
+            ),
+            previewType = PreviewType.None
+        )
+
+        assertEquals("0.2255169", fees.totalExecutionCostDisplayed)
+        assertEquals("0.0152518", fees.finalizationCostDisplayed)
+        assertEquals("0.0343323", fees.storageExpansionCostDisplayed)
+        assertEquals("0.041265137517", fees.feePaddingAmountToDisplay)
+        assertEquals("0", fees.transactionFeeToLock.formatted())
+    }
 }


### PR DESCRIPTION
## Description
This PR fixes an issue where the wallet show a negative total fee when the fees are fully paid by the dapp.
In short:
- `TransactionsFee` calculates the total fee in two different places. At the one the calculation is correct but the other that was used to display and into the transaction was wrong.
- Added unit test to cover the case of fees paid by dapp.
- Some fixes for the warnings in the review screen to take into account the case where the total fee is zero.

## How to test

1. Send the following transaction to the wallet
```
CALL_METHOD Address("YOUR_ACCOUNT_ADDRESS") "create_proof_of_amount" Address("resource_tdx_2_1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxtfd2jc") Decimal("11");
POP_FROM_AUTH_ZONE Proof("proof");
CALL_METHOD Address("component_tdx_2_1cr2vmx64gjsq3jf38va9q8hfw6sfta97hclevpay6mqn2u53reeux5") "check_and_lock_fee" Proof("proof") Decimal("1.1");
```

## Screenshot
<img width="300" alt="Screenshot 2024-10-21 at 11 26 27" src="https://github.com/user-attachments/assets/2ea64405-2e5f-4a23-a0a3-aa16fe43f848">


## PR submission checklist
- [X] I have tested fully and partially paid fees by dapp
- [X] I have added unit test
