### PR TITLE
[ABW-3929] - Fix pre-auth tx displaying as complex

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/summary/manifest/ManifestSummaryExtensions.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/summary/manifest/ManifestSummaryExtensions.kt
@@ -137,6 +137,7 @@ private fun AccountAddress.toInvolvedAccount(profile: Profile): InvolvedAccount 
     }
 }
 
+@Suppress("LongMethod")
 private fun ManifestSummary.resolveWithdraws(
     onLedgerAssets: List<Asset>,
     profile: Profile


### PR DESCRIPTION
[ABW-3929](https://radixdlt.atlassian.net/browse/ABW-3929)
[Thread](https://rdxworks.slack.com/archives/C03Q8QK1GLW/p1731330628453889)

## Description
This PR fixes pre-auth tx displaying as complex and unnecessarily displaying more NFTs than required for the transaction.


[ABW-3929]: https://radixdlt.atlassian.net/browse/ABW-3929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ