### PR TITLE
Fix newly created NFT details

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/AssetDialogNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/assets/AssetDialogNav.kt
@@ -61,7 +61,7 @@ fun NavController.nonFungibleAssetDialog(
         Serializer.kotlinxSerializationJson.encodeToString(
             BoundedAmounts(amounts = mapOf(resourceAddress.string to it))
         )
-    }?.let { "&$ARG_AMOUNTS=$it" }
+    }?.let { "&$ARG_AMOUNTS=$it" }.orEmpty()
 
     navigate(
         route = "$ROUTE/$ARG_RESOURCE_TYPE_VALUE_NFT" +


### PR DESCRIPTION
## Description
This PR fixes the issue when the details of a newly created NFT were indefinitely loading on the details screen opened from the transaction review.


## How to test

1. Launch a create NFTs tx from sandbox
2. Tap on an NFT item
3. Make sure there is no loading state for the NFT details like current supply or behaviors