### PR TITLE
Fix NFT unselect

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -504,7 +504,7 @@ class TransferViewModel @Inject constructor(
                             nonFungibles = assets.nonFungibles.mapWhen(
                                 predicate = {
                                     it.collection.address == forResource.address &&
-                                        it.collection.items.size < forResource.items.size
+                                            it.collection.items.size < forResource.items.size
                                 },
                                 mutation = { NonFungibleCollection(forResource) }
                             )
@@ -610,9 +610,16 @@ sealed class TargetAccount {
         }
     }
 
-    fun removeAsset(asset: SpendingAsset): TargetAccount {
+    fun removeAsset(removingAsset: SpendingAsset): TargetAccount {
         val newSpendingAssets = spendingAssets.toMutableSet().apply {
-            removeIf { it.resourceAddress == asset.resourceAddress }
+            removeIf { asset ->
+                when (asset) {
+                    is SpendingAsset.Fungible -> removingAsset is SpendingAsset.Fungible &&
+                            removingAsset.resourceAddress == asset.resourceAddress
+                    is SpendingAsset.NFT -> removingAsset is SpendingAsset.NFT &&
+                            removingAsset.item.globalId == asset.item.globalId
+                }
+            }
         }.toPersistentSet()
 
         return when (this) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -504,7 +504,7 @@ class TransferViewModel @Inject constructor(
                             nonFungibles = assets.nonFungibles.mapWhen(
                                 predicate = {
                                     it.collection.address == forResource.address &&
-                                            it.collection.items.size < forResource.items.size
+                                        it.collection.items.size < forResource.items.size
                                 },
                                 mutation = { NonFungibleCollection(forResource) }
                             )
@@ -614,9 +614,11 @@ sealed class TargetAccount {
         val newSpendingAssets = spendingAssets.toMutableSet().apply {
             removeIf { asset ->
                 when (asset) {
-                    is SpendingAsset.Fungible -> removingAsset is SpendingAsset.Fungible &&
+                    is SpendingAsset.Fungible ->
+                        removingAsset is SpendingAsset.Fungible &&
                             removingAsset.resourceAddress == asset.resourceAddress
-                    is SpendingAsset.NFT -> removingAsset is SpendingAsset.NFT &&
+                    is SpendingAsset.NFT ->
+                        removingAsset is SpendingAsset.NFT &&
                             removingAsset.item.globalId == asset.item.globalId
                 }
             }


### PR DESCRIPTION
## Description
This PR solves a bug reported: When a user selects multiple NFTs to transfer, but tries to unselect one, the whole collection gets unselected.


## How to test

1. Open Transfer screen.
2. Select Multiple NFTs to transfer in the same collection
3. Unselect one
4. Only the one you unselected should be unchecked.