### PR TITLE
Fix request handling

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/dapp/IncomingRequestRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/dapp/IncomingRequestRepository.kt
@@ -45,6 +45,8 @@ class IncomingRequestRepositoryImpl @Inject constructor(
     private val appEventBus: AppEventBus
 ) : IncomingRequestRepository {
 
+    private val logger = Timber.tag("IncomingRequestRepository")
+
     private val requestQueue = LinkedList<QueueItem>()
 
     /**
@@ -84,7 +86,7 @@ class IncomingRequestRepositoryImpl @Inject constructor(
                 requestQueue.add(requestItem)
             }
             handleNextRequest()
-            Timber.d(
+            logger.d(
                 "🗂 new incoming request with id ${dappToWalletInteraction.interactionId} added in list, " +
                     "so size now is ${getAmountOfRequests()}"
             )
@@ -106,7 +108,7 @@ class IncomingRequestRepositoryImpl @Inject constructor(
             val handlingPaused = requestQueue.contains(QueueItem.HighPriorityScreen)
             when {
                 currentRequest != null -> {
-                    Timber.d("🗂 Deferring request with id ${currentRequest.interactionId}")
+                    logger.d("🗂 Deferring request with id ${currentRequest.interactionId}")
                     appEventBus.sendEvent(AppEvent.DeferRequestHandling(currentRequest.interactionId))
                 }
 
@@ -124,7 +126,7 @@ class IncomingRequestRepositoryImpl @Inject constructor(
             requestQueue.removeIf { it is QueueItem.RequestItem && it.dappToWalletInteraction.interactionId == requestId }
             clearCurrent(requestId)
             handleNextRequest()
-            Timber.d("🗂 request $requestId handled so size of list is now: ${getAmountOfRequests()}")
+            logger.d("🗂 request $requestId handled so size of list is now: ${getAmountOfRequests()}")
         }
     }
 
@@ -132,7 +134,7 @@ class IncomingRequestRepositoryImpl @Inject constructor(
         mutex.withLock {
             clearCurrent(requestId)
             handleNextRequest()
-            Timber.d("🗂 request $requestId handled so size of list is now: ${getAmountOfRequests()}")
+            logger.d("🗂 request $requestId handled so size of list is now: ${getAmountOfRequests()}")
         }
     }
 
@@ -159,7 +161,7 @@ class IncomingRequestRepositoryImpl @Inject constructor(
             } else {
                 requestQueue.addFirst(QueueItem.HighPriorityScreen)
             }
-            Timber.d("🗂 Temporarily pausing incoming message queue")
+            logger.d("🗂 Temporarily pausing incoming message queue")
         }
     }
 
@@ -168,7 +170,7 @@ class IncomingRequestRepositoryImpl @Inject constructor(
             val removed = requestQueue.removeIf { it is QueueItem.HighPriorityScreen }
             if (removed) {
                 handleNextRequest()
-                Timber.d("🗂 Resuming incoming message queue")
+                logger.d("🗂 Resuming incoming message queue")
             }
         }
     }
@@ -178,9 +180,9 @@ class IncomingRequestRepositoryImpl @Inject constructor(
             it is QueueItem.RequestItem && it.dappToWalletInteraction.interactionId == requestId
         }
         if (queueItem == null) {
-            Timber.w("Request with id $requestId is null")
+            logger.w("Request with id $requestId is null")
         }
-        Timber.d("\uD83D\uDDC2 get request $requestId")
+        logger.d("\uD83D\uDDC2 get request $requestId")
         return (queueItem as? QueueItem.RequestItem)?.dappToWalletInteraction
     }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/transaction/TransactionStatusDialogViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dialogs/transaction/TransactionStatusDialogViewModel.kt
@@ -81,6 +81,7 @@ class TransactionStatusDialogViewModel @Inject constructor(
             transactionStatusClient.listenForTransactionStatus(status.transactionId).collectLatest { result ->
                 result.result.onSuccess {
                     // Notify the system and this particular dialog that the transaction is completed
+                    markRequestAsHandled()
                     appEventBus.sendEvent(
                         AppEvent.Status.Transaction.Success(
                             requestId = status.requestId,
@@ -91,8 +92,8 @@ class TransactionStatusDialogViewModel @Inject constructor(
                             dAppName = status.dAppName
                         )
                     )
-                    markRequestAsHandled()
                 }.onFailure { error ->
+                    markRequestAsHandled()
                     if (!status.isInternal) {
                         (error as? RadixWalletException.TransactionSubmitException)?.let { exception ->
                             incomingRequestRepository.getRequest(status.requestId)?.let { transactionRequest ->


### PR DESCRIPTION
## Description
In short, we `markRequestAsHandled` in `TransactionStatusDialogViewModel` which makes sense because this is the last step of the transaction lifecycle, but this doesn't always work as expected.

:warning:  Before explaining the issues an important note to keep in mind:
For each transaction status we create a new `TransactionStatusDialog`. So when we start with "completing" status then we navigate to `TransactionStatusDialog` with "success" status (or "fail").
Therefore each of this dialogs have their own instances of `TransactionStatusDialogViewModel`

**The issues are two**:
1. we `markRequestAsHandled` at
- `onDismiss` :white_check_mark: (it is the dismiss status dialog)
- TransactionStatus: Success :white_check_mark:
- TransactionStatus: Fail :x: This is missing! The request of course has been handled, no matter the result.

2. navigation issues: For example when sign to delete an account
The transaction is processed too quickly; navigation from ‘Completing’ status to ‘Success’ status sometimes happens rapidly. Then, the ‘Account Deleted’ screen briefly appears and immediately closes the Success status dialog. In this flow I noticed that the markRequestAsHandled never gets called.

The above issues might be related to [this](https://rdxworks.slack.com/archives/C05V4202J90/p1732784539591789).


## How to test

1. From the main branch or some other branch other than this,
2. Delete an account
3. After the sign and transaction is complete, see the incoming request queue that it still holds the request.
4. Execute the same steps (1 to 3) with this branch, and confirm that request is marked handled.


## PR submission checklist
- [X] I have tested incoming requests with several transactions
