### PR TITLE
Reject request when empty addresses in proof of ownership

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -207,9 +207,11 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
         // if both requestedPersonaAddress and requestedAccountAddresses are null then return false
         if (requestedPersonaAddress == null && requestedAccountAddresses == null) return false
 
+        val profile = getProfileUseCase()
+
         // validate requestedPersonaAddress if present
         val isIdentityValid = requestedPersonaAddress?.let { address ->
-            getProfileUseCase().activePersonasOnCurrentNetwork.any { it.address == address }
+            profile.activePersonasOnCurrentNetwork.any { it.address == address }
         } ?: true // if requestedPersonaAddress is null then it's considered valid
 
         // if requestedPersonaAddress is not present then return false
@@ -223,7 +225,7 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
 
         // validate requestedAccountAddresses if present and non-empty
         val areAccountsValid = requestedAccountAddresses.all { address ->
-            getProfileUseCase().activeAccountsOnCurrentNetwork.any { it.address == address }
+            profile.activeAccountsOnCurrentNetwork.any { it.address == address }
         }
 
         return areAccountsValid

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -193,29 +193,40 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
                 }
                 return Result.success(Unit)
             } else {
-                return Result.failure(RadixWalletException.DappRequestException.InvalidPersonaOrAccounts)
+                return Result.failure(InvalidPersonaOrAccounts)
             }
         }
         return Result.success(Unit)
     }
 
+    @Suppress("ReturnCount")
     private suspend fun validateRequestedAddressesForProofOfOwnership(
         requestedPersonaAddress: IdentityAddress?,
         requestedAccountAddresses: List<AccountAddress>?
     ): Boolean {
-        // if requestedPersonaAddress is present, then check if it exists in the allPersonasOnCurrentNetwork
+        // if both requestedPersonaAddress and requestedAccountAddresses are null then return false
+        if (requestedPersonaAddress == null && requestedAccountAddresses == null) return false
+
+        // validate requestedPersonaAddress if present
         val isIdentityValid = requestedPersonaAddress?.let { address ->
             getProfileUseCase().activePersonasOnCurrentNetwork.any { it.address == address }
-        } ?: true // if requestedPersonaAddress is null, assume it's valid (no need to check)
+        } ?: true // if requestedPersonaAddress is null then it's considered valid
 
-        // if requestedAccountAddresses are present, then check if all of them exist in the existingAccounts
-        val areAccountsValid = requestedAccountAddresses?.let { addresses ->
-            addresses.all { address ->
-                getProfileUseCase().activeAccountsOnCurrentNetwork.any { it.address == address }
-            }
-        } ?: true // if requestedAccountAddresses is null, assume it's valid (no need to check)
+        // if requestedPersonaAddress is not present then return false
+        if (!isIdentityValid) return false
 
-        return isIdentityValid && areAccountsValid
+        // if requestedPersonaAddress is valid and requestedAccountAddresses is null then return true
+        if (requestedAccountAddresses == null) return true
+
+        // if requestedPersonaAddress is valid but requestedAccountAddresses is empty then return false
+        if (requestedAccountAddresses.isEmpty()) return false
+
+        // validate requestedAccountAddresses if present and non-empty
+        val areAccountsValid = requestedAccountAddresses.all { address ->
+            getProfileUseCase().activeAccountsOnCurrentNetwork.any { it.address == address }
+        }
+
+        return areAccountsValid
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -224,8 +224,8 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
         if (requestedAccountAddresses.isEmpty()) return false
 
         // validate requestedAccountAddresses if present and non-empty
-        val areAccountsValid = requestedAccountAddresses.all { address ->
-            profile.activeAccountsOnCurrentNetwork.any { it.address == address }
+        val areAccountsValid = profile.activeAccountsOnCurrentNetwork.all { account ->
+            requestedAccountAddresses.any { it == account.address }
         }
 
         return areAccountsValid

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -224,8 +224,9 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
         if (requestedAccountAddresses.isEmpty()) return false
 
         // validate requestedAccountAddresses if present and non-empty
-        val areAccountsValid = profile.activeAccountsOnCurrentNetwork.all { account ->
-            requestedAccountAddresses.any { it == account.address }
+        val profileAccountAddresses = profile.activeAccountsOnCurrentNetwork.map { it.address }
+        val areAccountsValid = requestedAccountAddresses.all { address ->
+            address in profileAccountAddresses
         }
 
         return areAccountsValid


### PR DESCRIPTION
## Description
This PR updates validation of account addresses and persona address when proof of ownership is present.


## How to test

1. From the test sandbox dapp send a request with an account request item and a proof of ownership with empty account addresses. It should reject the request.
2. Then send a request with an account request item and proof of ownership with an empty persona address. It should reject the request.



## PR submission checklist
- [X] I have tested several authrorized requests
