### PR TITLE
Fix handling of authorization errors in login flows

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsScreen.kt
@@ -63,6 +63,7 @@ fun ChooseAccountsScreen(
                     )
                 }
                 ChooseAccountsEvent.TerminateFlow -> sharedViewModel.onAbortDappLogin()
+                is ChooseAccountsEvent.AuthorizationFailed -> sharedViewModel.handleRequestError(exception = event.throwable)
             }
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/account/ChooseAccountsViewModel.kt
@@ -3,6 +3,7 @@ package com.babylon.wallet.android.presentation.dapp.authorized.account
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
+import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.model.messages.DappToWalletInteraction
 import com.babylon.wallet.android.domain.model.messages.WalletAuthorizedRequest
 import com.babylon.wallet.android.domain.model.signing.SignPurpose
@@ -212,6 +213,9 @@ class ChooseAccountsViewModel @Inject constructor(
             )
             setSigningInProgress(false)
         }.onFailure {
+            sendEvent(
+                ChooseAccountsEvent.AuthorizationFailed(throwable = RadixWalletException.DappRequestException.FailedToSignAuthChallenge(it))
+            )
             setSigningInProgress(false)
         }
     }
@@ -227,6 +231,8 @@ sealed interface ChooseAccountsEvent : OneOffEvent {
         val accountsWithSignatures: Map<ProfileEntity.AccountEntity, SignatureWithPublicKey?>,
         val isOneTimeRequest: Boolean = false
     ) : ChooseAccountsEvent
+
+    data class AuthorizationFailed(val throwable: RadixWalletException) : ChooseAccountsEvent
 }
 
 data class ChooseAccountUiState(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaScreen.kt
@@ -97,6 +97,7 @@ fun SelectPersonaScreen(
                     authorizedPersona = event.persona,
                     signature = event.signature
                 )
+                is SelectPersonaViewModel.Event.AuthorizationFailed -> sharedViewModel.handleRequestError(exception = event.throwable)
             }
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/selectpersona/SelectPersonaViewModel.kt
@@ -3,6 +3,7 @@ package com.babylon.wallet.android.presentation.dapp.authorized.selectpersona
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
+import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.model.messages.DappToWalletInteraction
 import com.babylon.wallet.android.domain.model.messages.WalletAuthorizedRequest
 import com.babylon.wallet.android.domain.model.signing.SignPurpose
@@ -156,6 +157,9 @@ class SelectPersonaViewModel @Inject constructor(
             )
             setSigningInProgress(false)
         }.onFailure {
+            sendEvent(
+                Event.AuthorizationFailed(throwable = RadixWalletException.DappRequestException.FailedToSignAuthChallenge(it))
+            )
             setSigningInProgress(false)
         }
     }
@@ -172,6 +176,8 @@ class SelectPersonaViewModel @Inject constructor(
             val persona: ProfileEntity.PersonaEntity,
             val signature: SignatureWithPublicKey? = null
         ) : Event
+
+        data class AuthorizationFailed(val throwable: RadixWalletException) : Event
     }
 
     data class State(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/verifyentities/VerifyEntitiesViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/verifyentities/VerifyEntitiesViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
 import com.babylon.wallet.android.di.coroutines.DefaultDispatcher
+import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.model.messages.WalletAuthorizedRequest
 import com.babylon.wallet.android.domain.model.signing.SignPurpose
 import com.babylon.wallet.android.domain.model.signing.SignRequest
@@ -122,7 +123,12 @@ class VerifyEntitiesViewModel @Inject constructor(
                             sendEvent(Event.EntitiesVerified)
                         }
                         setSigningInProgress(false)
-                    }.onFailure {
+                    }.onFailure { exception ->
+                        sendEvent(
+                            Event.AuthorizationFailed(
+                                throwable = RadixWalletException.DappRequestException.FailedToSignAuthChallenge(exception)
+                            )
+                        )
                         setSigningInProgress(false)
                     }
                 }
@@ -172,5 +178,7 @@ class VerifyEntitiesViewModel @Inject constructor(
             val walletAuthorizedRequestInteractionId: String,
             val entitiesForProofWithSignatures: EntitiesForProofWithSignatures
         ) : Event
+
+        data class AuthorizationFailed(val throwable: RadixWalletException) : Event
     }
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/verifyentities/accounts/VerifyAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/verifyentities/accounts/VerifyAccountsScreen.kt
@@ -44,6 +44,10 @@ fun VerifyAccountsScreen(
                 is VerifyEntitiesViewModel.Event.NavigateToVerifyAccounts -> {
                     // do nothing here
                 }
+
+                is VerifyEntitiesViewModel.Event.AuthorizationFailed -> {
+                    sharedViewModel.handleRequestError(exception = event.throwable)
+                }
             }
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/verifyentities/persona/VerifyPersonaScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/verifyentities/persona/VerifyPersonaScreen.kt
@@ -46,6 +46,10 @@ fun VerifyPersonaScreen(
                 VerifyEntitiesViewModel.Event.TerminateVerification -> {
                     sharedViewModel.onAbortDappLogin()
                 }
+
+                is VerifyEntitiesViewModel.Event.AuthorizationFailed -> {
+                    sharedViewModel.handleRequestError(exception = event.throwable)
+                }
             }
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsScreen.kt
@@ -57,6 +57,9 @@ fun OneTimeChooseAccountsScreen(
                     sharedViewModel.onOneTimeAccountsCollected(accountsWithSignatures = event.accountsWithSignatures)
                 }
                 OneTimeChooseAccountsEvent.TerminateFlow -> exitRequestFlow()
+                is OneTimeChooseAccountsEvent.AuthorizationFailed -> {
+                    sharedViewModel.handleRequestError(exception = event.throwable)
+                }
             }
         }
     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/accountonetime/OneTimeChooseAccountsViewModel.kt
@@ -3,6 +3,7 @@ package com.babylon.wallet.android.presentation.dapp.unauthorized.accountonetime
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.babylon.wallet.android.data.dapp.IncomingRequestRepository
+import com.babylon.wallet.android.domain.RadixWalletException
 import com.babylon.wallet.android.domain.model.messages.DappToWalletInteraction
 import com.babylon.wallet.android.domain.model.messages.WalletUnauthorizedRequest
 import com.babylon.wallet.android.domain.model.signing.SignPurpose
@@ -180,6 +181,11 @@ class OneTimeChooseAccountsViewModel @Inject constructor(
             )
             setSigningInProgress(false)
         }.onFailure {
+            sendEvent(
+                OneTimeChooseAccountsEvent.AuthorizationFailed(
+                    throwable = RadixWalletException.DappRequestException.FailedToSignAuthChallenge(it)
+                )
+            )
             setSigningInProgress(false)
         }
     }
@@ -188,10 +194,14 @@ class OneTimeChooseAccountsViewModel @Inject constructor(
 }
 
 sealed interface OneTimeChooseAccountsEvent : OneOffEvent {
+
     data object TerminateFlow : OneTimeChooseAccountsEvent
+
     data class AccountsCollected(
         val accountsWithSignatures: Map<ProfileEntity.AccountEntity, SignatureWithPublicKey?>
     ) : OneTimeChooseAccountsEvent
+
+    data class AuthorizationFailed(val throwable: RadixWalletException) : OneTimeChooseAccountsEvent
 }
 
 data class OneTimeChooseAccountUiState(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/unauthorized/login/DAppUnauthorizedLoginViewModel.kt
@@ -239,29 +239,31 @@ class DAppUnauthorizedLoginViewModel @Inject constructor(
         }
     }
 
-    private suspend fun handleRequestError(exception: Throwable) {
-        if (exception is RadixWalletException.DappRequestException) {
-            logNonFatalException(exception)
-            when (exception.cause) {
-                is ProfileException.SecureStorageAccess -> {
-                    appEventBus.sendEvent(AppEvent.SecureFolderWarning)
-                }
+    fun handleRequestError(exception: Throwable) {
+        viewModelScope.launch {
+            if (exception is RadixWalletException.DappRequestException) {
+                logNonFatalException(exception)
+                when (exception.cause) {
+                    is ProfileException.SecureStorageAccess -> {
+                        appEventBus.sendEvent(AppEvent.SecureFolderWarning)
+                    }
 
-                is ProfileException.NoMnemonic -> {
-                    _state.update { it.copy(isNoMnemonicErrorVisible = true) }
-                }
+                    is ProfileException.NoMnemonic -> {
+                        _state.update { it.copy(isNoMnemonicErrorVisible = true) }
+                    }
 
-                is RadixWalletException.LedgerCommunicationException,
-                is RadixWalletException.DappRequestException.RejectedByUser -> {
-                }
+                    is RadixWalletException.LedgerCommunicationException,
+                    is RadixWalletException.DappRequestException.RejectedByUser -> {
+                    }
 
-                else -> {
-                    respondToIncomingRequestUseCase.respondWithFailure(
-                        request = request,
-                        dappWalletInteractionErrorType = exception.dappWalletInteractionErrorType,
-                        message = exception.getDappMessage()
-                    )
-                    _state.update { it.copy(failureDialogState = FailureDialogState.Open(exception)) }
+                    else -> {
+                        respondToIncomingRequestUseCase.respondWithFailure(
+                            request = request,
+                            dappWalletInteractionErrorType = exception.dappWalletInteractionErrorType,
+                            message = exception.getDappMessage()
+                        )
+                        _state.update { it.copy(failureDialogState = FailureDialogState.Open(exception)) }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
Before the [refactoring](https://github.com/radixdlt/babylon-wallet-android/pull/1216) every authorization operation was executed in `DAppAuthorizedLoginViewModel` and `DAppUnauthorizedLoginViewModel` thus the error handling.
After the refactoring authorization has been moved to each request item screen. This PR handles the missing error handling when authorization fails. Sadly the screens have to call again the `DAppAuthorizedLoginViewModel` or `DAppUnauthorizedLoginViewModel` to handle errors. This has to be improved when we work on the login screens.


## How to test

1. Sign an authorized request with an entity in recovery required state and you should see an error dialog.


## PR submission checklist
- [X] I have tested failed authorization scenarios.
