### PR TITLE
Fixes on responding to dApp and assertions

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
+++ b/app/src/main/java/com/babylon/wallet/android/domain/RadixWalletException.kt
@@ -43,7 +43,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
         data object GetEpoch : DappRequestException()
         data object RejectedByUser : DappRequestException()
         data object InvalidRequest : DappRequestException()
-        data object UnacceptableManifest : DappRequestException()
+        data class UnacceptableManifest(override val cause: Throwable) : DappRequestException(cause = cause)
         data object InvalidPersona : DappRequestException()
         data object InvalidPersonaOrAccounts : DappRequestException()
         data object InvalidRequestChallenge : DappRequestException()
@@ -74,7 +74,7 @@ sealed class RadixWalletException(cause: Throwable? = null) : Throwable(cause = 
                 InvalidRequestChallenge -> DappWalletInteractionErrorType.FAILED_TO_SIGN_AUTH_CHALLENGE
                 NotPossibleToAuthenticateAutomatically -> DappWalletInteractionErrorType.INVALID_REQUEST
                 RejectedByUser -> DappWalletInteractionErrorType.REJECTED_BY_USER
-                UnacceptableManifest -> DappWalletInteractionErrorType.INVALID_REQUEST
+                is UnacceptableManifest -> DappWalletInteractionErrorType.INVALID_REQUEST
                 is WrongNetwork -> DappWalletInteractionErrorType.WRONG_NETWORK
                 is PreviewError -> DappWalletInteractionErrorType.FAILED_TO_PREPARE_TRANSACTION
                 InvalidPersonaOrAccounts -> DappWalletInteractionErrorType.INVALID_PERSONA_OR_ACCOUNTS
@@ -292,7 +292,7 @@ fun RadixWalletException.DappRequestException.toUserFriendlyMessage(context: Con
             R.string.dAppRequest_validationOutcome_invalidRequestMessage
         )
 
-        RadixWalletException.DappRequestException.UnacceptableManifest -> context.getString(
+        is RadixWalletException.DappRequestException.UnacceptableManifest -> context.getString(
             R.string.transactionReview_unacceptableManifest_rejected
         )
 
@@ -471,7 +471,7 @@ fun Throwable.getDappMessage(): String? {
             "Wallet is using network ID: $currentNetworkId, request sent specified network ID: $requestNetworkId"
         }
 
-        else -> message
+        else -> message ?: cause?.message
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -268,8 +268,6 @@ class TransactionReviewViewModel @Inject constructor(
     }
 
     fun dismissTerminalErrorDialog() {
-        _state.update { it.copy(error = null) }
-
         viewModelScope.launch {
             val error = state.value.error?.error
             if (error is DappRequestException) {
@@ -279,6 +277,8 @@ class TransactionReviewViewModel @Inject constructor(
                 sendEvent(Event.Dismiss)
             }
         }
+
+        _state.update { it.copy(error = null) }
     }
 
     fun onAcknowledgeRawTransactionWarning() {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/TransactionReviewViewModel.kt
@@ -276,9 +276,8 @@ class TransactionReviewViewModel @Inject constructor(
                 incomingRequestRepository.requestHandled(args.interactionId)
                 sendEvent(Event.Dismiss)
             }
+            _state.update { it.copy(error = null) }
         }
-
-        _state.update { it.copy(error = null) }
     }
 
     fun onAcknowledgeRawTransactionWarning() {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/TransactionAnalysisDelegate.kt
@@ -144,7 +144,7 @@ class TransactionAnalysisDelegate @Inject constructor(
     private fun mapPreviewError(error: Throwable): RadixWalletException {
         return when (error) {
             is CommonException.ReservedInstructionsNotAllowedInManifest -> {
-                RadixWalletException.DappRequestException.UnacceptableManifest
+                RadixWalletException.DappRequestException.UnacceptableManifest(cause = error)
             }
             is CommonException.OneOfReceivingAccountsDoesNotAllowDeposits -> {
                 RadixWalletException.PrepareTransactionException.ReceivingAccountDoesNotAllowDeposits

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/submit/TransactionSubmitDelegate.kt
@@ -326,7 +326,7 @@ class TransactionSubmitDelegateImpl @Inject constructor(
             val fungibleAsset = (transferable.asset as? Asset.Fungible) ?: return@mapNotNull null
 
             TransactionGuarantee(
-                amount = amount.estimated,
+                amount = amount.guaranteed,
                 instructionIndex = amount.instructionIndex.toULong(),
                 resourceAddress = fungibleAsset.resource.address,
                 resourceDivisibility = fungibleAsset.resource.divisibility?.value,


### PR DESCRIPTION
## Description
* When analysis fails, when responding back to dApp the message of the throwable, or the message of the cause of the throwable, is communicated back to CE.
* The manifest modification regarding assertions was incorrectly placing the predicted and not the calculated guaranteed amount to the assertion.
