### PR TITLE
Send account proof when challenge exists in account request item

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/login/DAppAuthorizedLoginViewModel.kt
@@ -572,7 +572,16 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
             numberOfAccounts = numberOfAccounts,
             quantifier = ongoingAccountsRequestItem.numberOfValues.toRequestedNumberQuantifier()
         )
-        if (request.resetRequestItem?.accounts == true || potentialOngoingAddresses.isEmpty()) {
+
+        // if challenge exists then always navigate to choose accounts screen and get signatures
+        if (ongoingAccountsRequestItem.challenge != null) {
+            sendEvent(
+                event = Event.NavigateToOngoingAccounts(
+                    isExactAccountsCount = isExactAccountsCount,
+                    numberOfAccounts = numberOfAccounts
+                )
+            )
+        } else if (request.resetRequestItem?.accounts == true || potentialOngoingAddresses.isEmpty()) {
             sendEvent(
                 event = Event.NavigateToOngoingAccounts(
                     isExactAccountsCount = isExactAccountsCount,
@@ -581,7 +590,7 @@ class DAppAuthorizedLoginViewModel @Inject constructor(
             )
         } else {
             val selectedAccounts = potentialOngoingAddresses.mapNotNull {
-                getProfileUseCase().activeAccountOnCurrentNetwork(it) // ?.toUiModel(true)
+                getProfileUseCase().activeAccountOnCurrentNetwork(it)
             }.map { it.asProfileEntity() }
             _state.update { it.copy(ongoingAccountsWithSignatures = selectedAccounts.associateWith { null }) }
             mutex.withLock {


### PR DESCRIPTION
## Description
This PR fixes response to dapp when account proof is requested after first login.


## How to test

Before the fix wallet failed to send to the dapp the account(s) proof when this was requested again after the first login. In order to understand the bug, do the following:
1. if sandbox is in approved dapps, then forget it.
2. From sandbox connect to the wallet including proofs in persona and accounts request. 
3. Once connected, then logout from sandbox.
4. Connect again. You will notice that dapp fais to connect.

Try again with the fix.


## PR submission checklist
- [X] I have tested several re-connection to dapp.
