### PR TITLE
[ABW-4084] Add security shield details screen

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/ConfirmationDelay.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/ConfirmationDelay.kt
@@ -4,11 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -22,9 +19,7 @@ import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.presentation.common.title
 import com.babylon.wallet.android.presentation.ui.composables.DSR
-import com.radixdlt.sargon.Threshold
 import com.radixdlt.sargon.TimePeriod
-import java.util.Locale
 
 @Composable
 fun ConfirmationDelay(
@@ -77,25 +72,4 @@ fun ConfirmationDelay(
             )
         }
     }
-}
-
-@Composable
-fun Threshold.display(): String = when (this) {
-    is Threshold.All -> stringResource(R.string.common_all).uppercase(Locale.getDefault())
-    is Threshold.Specific -> "${v1.toInt()}"
-}
-
-@Suppress("ModifierMissing")
-@Composable
-fun ColumnScope.OrView() {
-    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
-
-    Text(
-        modifier = Modifier.align(Alignment.CenterHorizontally),
-        text = stringResource(R.string.transactionReview_updateShield_combinationLabel),
-        style = RadixTheme.typography.body2Regular,
-        color = RadixTheme.colors.gray2
-    )
-
-    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
 }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/OrView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/OrView.kt
@@ -1,0 +1,27 @@
+package com.babylon.wallet.android.presentation.common.securityshields
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.babylon.wallet.android.R
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+
+@Suppress("ModifierMissing")
+@Composable
+fun ColumnScope.OrView() {
+    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+
+    Text(
+        modifier = Modifier.align(Alignment.CenterHorizontally),
+        text = stringResource(R.string.transactionReview_updateShield_combinationLabel),
+        style = RadixTheme.typography.body2Regular,
+        color = RadixTheme.colors.gray2
+    )
+
+    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/SecurityShieldsCommonComposables.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/SecurityShieldsCommonComposables.kt
@@ -24,6 +24,7 @@ import com.babylon.wallet.android.presentation.common.title
 import com.babylon.wallet.android.presentation.ui.composables.DSR
 import com.radixdlt.sargon.Threshold
 import com.radixdlt.sargon.TimePeriod
+import java.util.Locale
 
 @Composable
 fun ConfirmationDelay(
@@ -80,7 +81,7 @@ fun ConfirmationDelay(
 
 @Composable
 fun Threshold.display(): String = when (this) {
-    is Threshold.All -> "ALL"
+    is Threshold.All -> stringResource(R.string.common_all).uppercase(Locale.getDefault())
     is Threshold.Specific -> "${v1.toInt()}"
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/SecurityShieldsCommonComposables.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/SecurityShieldsCommonComposables.kt
@@ -1,0 +1,100 @@
+package com.babylon.wallet.android.presentation.common.securityshields
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.babylon.wallet.android.R
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.presentation.common.title
+import com.babylon.wallet.android.presentation.ui.composables.DSR
+import com.radixdlt.sargon.Threshold
+import com.radixdlt.sargon.TimePeriod
+
+@Composable
+fun ConfirmationDelay(
+    modifier: Modifier = Modifier,
+    delay: TimePeriod
+) {
+    Column(
+        modifier = modifier
+            .background(
+                color = RadixTheme.colors.lightRed,
+                shape = RadixTheme.shapes.roundedRectMedium
+            )
+            .padding(RadixTheme.dimensions.paddingDefault),
+        verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingMedium)
+    ) {
+        Text(
+            text = stringResource(R.string.transactionReview_updateShield_confirmationDelayMessage),
+            style = RadixTheme.typography.body1Regular,
+            color = RadixTheme.colors.gray1
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = RadixTheme.colors.white,
+                    shape = RadixTheme.shapes.roundedRectSmall
+                )
+                .border(
+                    width = 1.dp,
+                    color = RadixTheme.colors.gray4,
+                    shape = RadixTheme.shapes.roundedRectSmall
+                )
+                .padding(
+                    horizontal = RadixTheme.dimensions.paddingSemiLarge,
+                    vertical = RadixTheme.dimensions.paddingDefault
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+        ) {
+            Icon(
+                painter = painterResource(id = DSR.ic_calendar),
+                contentDescription = null
+            )
+
+            Text(
+                text = delay.title(),
+                style = RadixTheme.typography.body1Header,
+                color = RadixTheme.colors.gray1
+            )
+        }
+    }
+}
+
+@Composable
+fun Threshold.display(): String = when (this) {
+    is Threshold.All -> "ALL"
+    is Threshold.Specific -> "${v1.toInt()}"
+}
+
+@Suppress("ModifierMissing")
+@Composable
+fun ColumnScope.OrView() {
+    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+
+    Text(
+        modifier = Modifier.align(Alignment.CenterHorizontally),
+        text = stringResource(R.string.transactionReview_updateShield_combinationLabel),
+        style = RadixTheme.typography.body2Regular,
+        color = RadixTheme.colors.gray2
+    )
+
+    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/ThresholdDisplay.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/common/securityshields/ThresholdDisplay.kt
@@ -1,0 +1,13 @@
+package com.babylon.wallet.android.presentation.common.securityshields
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.babylon.wallet.android.R
+import com.radixdlt.sargon.Threshold
+import java.util.Locale
+
+@Composable
+fun Threshold.display(): String = when (this) {
+    is Threshold.All -> stringResource(R.string.common_all).uppercase(Locale.getDefault())
+    is Threshold.Specific -> "${v1.toInt()}"
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/verifyentities/VerifyEntitiesContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/dapp/authorized/verifyentities/VerifyEntitiesContent.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -15,8 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -33,10 +30,9 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
 import com.babylon.wallet.android.presentation.ui.composables.card.SimpleAccountCardWithAddress
-import com.babylon.wallet.android.presentation.ui.composables.card.SimplePersonaCard
+import com.babylon.wallet.android.presentation.ui.composables.card.SimplePersonaCardWithShadow
 import com.babylon.wallet.android.presentation.ui.composables.displayName
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
-import com.babylon.wallet.android.presentation.ui.modifier.defaultCardShadow
 import com.babylon.wallet.android.utils.formattedSpans
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.Persona
@@ -124,16 +120,7 @@ fun VerifyEntitiesContent(
             items(profileEntities) { entity ->
                 when (entity) {
                     is ProfileEntity.PersonaEntity -> {
-                        SimplePersonaCard(
-                            modifier = Modifier.defaultCardShadow(elevation = 6.dp)
-                                .background(
-                                    brush = SolidColor(RadixTheme.colors.gray5),
-                                    shape = RadixTheme.shapes.roundedRectMedium
-                                )
-                                .padding(horizontal = RadixTheme.dimensions.paddingDefault)
-                                .clip(RadixTheme.shapes.roundedRectMedium),
-                            persona = entity.persona
-                        )
+                        SimplePersonaCardWithShadow(persona = entity.persona)
                     }
                     is ProfileEntity.AccountEntity -> {
                         SimpleAccountCardWithAddress(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/SecurityShieldsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/SecurityShieldsNav.kt
@@ -19,6 +19,7 @@ import com.babylon.wallet.android.presentation.settings.securitycenter.securitys
 import com.babylon.wallet.android.presentation.settings.securitycenter.securityshields.regularaccess.regularAccess
 import com.babylon.wallet.android.presentation.settings.securitycenter.securityshields.selectfactors.selectFactors
 import com.babylon.wallet.android.presentation.settings.securitycenter.securityshields.shieldcreated.shieldCreated
+import com.babylon.wallet.android.presentation.settings.securitycenter.securityshields.shielddetails.securityShieldDetails
 import com.babylon.wallet.android.presentation.settings.securitycenter.securityshields.shieldname.setupShieldName
 
 const val ROUTE_SECURITY_SHIELDS = "security_shields"
@@ -32,6 +33,8 @@ fun NavGraphBuilder.securityShieldsNavGraph(
         route = ROUTE_SECURITY_SHIELDS_GRAPH
     ) {
         securityShieldsScreen(navController)
+
+        securityShieldDetails(navController)
 
         securityShieldOnboarding(navController)
 
@@ -71,7 +74,9 @@ fun NavGraphBuilder.securityShieldsScreen(
     ) {
         SecurityShieldsScreen(
             viewModel = hiltViewModel(),
-            onNavigateToSecurityShieldDetails = { /* TODO security shield details screen */ },
+            onNavigateToSecurityShieldDetails = { securityShieldId, securityShieldName ->
+                navController.securityShieldDetails(securityShieldId, securityShieldName)
+            },
             onCreateNewSecurityShieldClick = { navController.securityShieldOnboarding() },
             onInfoClick = { glossaryItem -> navController.infoDialog(glossaryItem) },
             onBackClick = { navController.navigateUp() },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/SecurityShieldsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/SecurityShieldsScreen.kt
@@ -66,7 +66,7 @@ import kotlinx.collections.immutable.toPersistentList
 fun SecurityShieldsScreen(
     modifier: Modifier = Modifier,
     viewModel: SecurityShieldsViewModel,
-    onNavigateToSecurityShieldDetails: (securityShieldId: SecurityStructureId) -> Unit,
+    onNavigateToSecurityShieldDetails: (securityShieldId: SecurityStructureId, securityShieldName: String) -> Unit,
     onCreateNewSecurityShieldClick: () -> Unit,
     onInfoClick: (GlossaryItem) -> Unit,
     onBackClick: () -> Unit,
@@ -115,7 +115,7 @@ fun SecurityShieldsContent(
     state: SecurityShieldsViewModel.State,
     onBackClick: () -> Unit,
     onChangeMainSecurityShieldClick: () -> Unit,
-    onSecurityShieldClick: (SecurityStructureId) -> Unit,
+    onSecurityShieldClick: (SecurityStructureId, securityShieldName: String) -> Unit,
     onCreateNewSecurityShieldClick: () -> Unit,
     onInfoClick: (GlossaryItem) -> Unit
 ) {
@@ -157,7 +157,7 @@ private fun SecurityShieldsList(
     mainSecurityShield: SecurityShieldCard?,
     otherSecurityShields: PersistentList<SecurityShieldCard>,
     onChangeMainSecurityShieldClick: () -> Unit,
-    onSecurityShieldClick: (SecurityStructureId) -> Unit,
+    onSecurityShieldClick: (SecurityStructureId, securityShieldName: String) -> Unit,
     onCreateNewSecurityShieldClick: () -> Unit,
     onInfoClick: (GlossaryItem) -> Unit
 ) {
@@ -165,7 +165,7 @@ private fun SecurityShieldsList(
         modifier = modifier.fillMaxWidth(),
         contentPadding = PaddingValues(horizontal = RadixTheme.dimensions.paddingDefault)
     ) {
-        mainSecurityShield?.let {
+        mainSecurityShield?.let { securityShieldCard ->
             item {
                 if (otherSecurityShields.isNotEmpty()) {
                     Row(
@@ -193,9 +193,7 @@ private fun SecurityShieldsList(
                 }
 
                 SecurityShieldCardView(
-                    modifier = Modifier
-                        .padding(bottom = RadixTheme.dimensions.paddingMedium)
-                        .clickable { onSecurityShieldClick(it.id) },
+                    modifier = Modifier.clickable { onSecurityShieldClick(securityShieldCard.id, securityShieldCard.name) },
                     item = mainSecurityShield
                 )
                 if (otherSecurityShields.isEmpty()) {
@@ -238,10 +236,10 @@ private fun SecurityShieldsList(
             }
         }
 
-        items(otherSecurityShields) {
+        items(otherSecurityShields) { securityShieldCard ->
             SecurityShieldCardView(
-                modifier = Modifier.clickable { onSecurityShieldClick(it.id) },
-                item = it
+                modifier = Modifier.clickable { onSecurityShieldClick(securityShieldCard.id, securityShieldCard.name) },
+                item = securityShieldCard
             )
             Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
         }
@@ -364,7 +362,7 @@ private fun SecurityShieldsWithMainAndOthersPreview() {
             ),
             onBackClick = {},
             onChangeMainSecurityShieldClick = {},
-            onSecurityShieldClick = {},
+            onSecurityShieldClick = { _, _ -> },
             onCreateNewSecurityShieldClick = {},
             onInfoClick = {}
         )
@@ -400,7 +398,7 @@ private fun SecurityShieldsWithMainPreview() {
             ),
             onBackClick = {},
             onChangeMainSecurityShieldClick = {},
-            onSecurityShieldClick = {},
+            onSecurityShieldClick = { _, _ -> },
             onCreateNewSecurityShieldClick = {},
             onInfoClick = {}
         )
@@ -421,7 +419,7 @@ private fun SecurityShieldsWithOthersPreview() {
             ),
             onBackClick = {},
             onChangeMainSecurityShieldClick = {},
-            onSecurityShieldClick = {},
+            onSecurityShieldClick = { _, _ -> },
             onCreateNewSecurityShieldClick = {},
             onInfoClick = {}
         )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/shielddetails/SecurityShieldDetailsNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/shielddetails/SecurityShieldDetailsNav.kt
@@ -1,0 +1,67 @@
+package com.babylon.wallet.android.presentation.settings.securitycenter.securityshields.shielddetails
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.radixdlt.sargon.SecurityStructureId
+
+private const val ROUTE_SECURITY_SHIELD_DETAILS_SCREEN = "security_shield_details_screen"
+private const val ARG_SECURITY_STRUCTURE_ID = "arg_security_structure_id"
+private const val ARG_SECURITY_STRUCTURE_NAME = "arg_security_structure_name"
+
+internal class SecurityShieldDetailsArgs(
+    val securityStructureId: SecurityStructureId,
+    val securityStructureName: String
+) {
+    constructor(savedStateHandle: SavedStateHandle) : this(
+        securityStructureId = SecurityStructureId.fromString(
+            requireNotNull(savedStateHandle.get<String>(ARG_SECURITY_STRUCTURE_ID))
+        ),
+        securityStructureName = requireNotNull(savedStateHandle.get<String>(ARG_SECURITY_STRUCTURE_NAME))
+    )
+}
+
+fun NavController.securityShieldDetails(
+    securityStructureId: SecurityStructureId,
+    securityStructureName: String
+) {
+    navigate("$ROUTE_SECURITY_SHIELD_DETAILS_SCREEN/$securityStructureId/$securityStructureName")
+}
+
+fun NavGraphBuilder.securityShieldDetails(navController: NavController) {
+    composable(
+        route = "$ROUTE_SECURITY_SHIELD_DETAILS_SCREEN/{$ARG_SECURITY_STRUCTURE_ID}/{$ARG_SECURITY_STRUCTURE_NAME}",
+        arguments = listOf(
+            navArgument(ARG_SECURITY_STRUCTURE_ID) {
+                type = NavType.StringType
+            },
+            navArgument(ARG_SECURITY_STRUCTURE_NAME) {
+                type = NavType.StringType
+            }
+        ),
+        enterTransition = {
+            slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Left)
+        },
+        exitTransition = {
+            ExitTransition.None
+        },
+        popEnterTransition = {
+            EnterTransition.None
+        },
+        popExitTransition = {
+            slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Right)
+        }
+    ) {
+        SecurityShieldDetailsScreen(
+            viewModel = hiltViewModel(),
+            onBackClick = { navController.navigateUp() }
+        )
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/shielddetails/SecurityShieldDetailsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/shielddetails/SecurityShieldDetailsScreen.kt
@@ -1,0 +1,825 @@
+@file:Suppress("TooManyFunctions")
+
+package com.babylon.wallet.android.presentation.settings.securitycenter.securityshields.shielddetails
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.babylon.wallet.android.R
+import com.babylon.wallet.android.designsystem.composable.RadixSecondaryButton
+import com.babylon.wallet.android.designsystem.composable.RadixTextButton
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+import com.babylon.wallet.android.presentation.common.securityshields.ConfirmationDelay
+import com.babylon.wallet.android.presentation.common.securityshields.OrView
+import com.babylon.wallet.android.presentation.common.securityshields.display
+import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
+import com.babylon.wallet.android.presentation.ui.composables.DSR
+import com.babylon.wallet.android.presentation.ui.composables.RadixBottomBar
+import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
+import com.babylon.wallet.android.presentation.ui.composables.RenameBottomSheet
+import com.babylon.wallet.android.presentation.ui.composables.card.CollapsibleCommonCard
+import com.babylon.wallet.android.presentation.ui.composables.card.CommonCard
+import com.babylon.wallet.android.presentation.ui.composables.card.FactorSourceCardView
+import com.babylon.wallet.android.presentation.ui.composables.card.SimpleAccountCard
+import com.babylon.wallet.android.presentation.ui.composables.card.SimplePersonaCardWithShadow
+import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
+import com.babylon.wallet.android.presentation.ui.composables.utils.SyncSheetState
+import com.babylon.wallet.android.presentation.ui.model.factors.toFactorSourceCard
+import com.babylon.wallet.android.utils.formattedSpans
+import com.radixdlt.sargon.Account
+import com.radixdlt.sargon.ConfirmationRoleWithFactorSources
+import com.radixdlt.sargon.FactorSource
+import com.radixdlt.sargon.Persona
+import com.radixdlt.sargon.PrimaryRoleWithFactorSources
+import com.radixdlt.sargon.RecoveryRoleWithFactorSources
+import com.radixdlt.sargon.SecurityStructureOfFactorSources
+import com.radixdlt.sargon.TimePeriod
+import com.radixdlt.sargon.annotation.UsesSampleValues
+import com.radixdlt.sargon.newSecurityStructureOfFactorSourcesSample
+import com.radixdlt.sargon.newSecurityStructureOfFactorSourcesSampleOther
+import com.radixdlt.sargon.samples.sampleMainnet
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SecurityShieldDetailsScreen(
+    modifier: Modifier = Modifier,
+    viewModel: SecurityShieldDetailsViewModel,
+    onBackClick: () -> Unit
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    SyncSheetState(
+        sheetState = bottomSheetState,
+        isSheetVisible = state.isRenameBottomSheetVisible,
+        onSheetClosed = viewModel::onRenameSecurityShieldDismissed
+    )
+
+    if (state.isRenameBottomSheetVisible) {
+        RenameBottomSheet(
+            sheetState = bottomSheetState,
+            renameInput = state.renameSecurityShieldInput,
+            titleRes = R.string.renameLabel_factorSource_title, // TODO crowdin
+            subtitleRes = R.string.renameLabel_factorSource_subtitle, // TODO crowdin
+            errorValidationMessageRes = R.string.renameLabel_factorSource_empty, // TODO crowdin
+            errorTooLongNameMessageRes = R.string.renameLabel_factorSource_tooLong, // TODO crowdin
+            onNameChange = viewModel::onRenameSecurityShieldChanged,
+            onUpdateNameClick = viewModel::onRenameSecurityShieldUpdateClick,
+            onDismiss = viewModel::onRenameSecurityShieldDismissed,
+        )
+    }
+
+    SecurityShieldDetailsContent(
+        modifier = modifier,
+        securityShieldName = state.securityShieldName,
+        securityStructureOfFactorSources = state.securityStructureOfFactorSources,
+        linkedAccounts = state.linkedAccounts,
+        linkedPersonas = state.linkedPersonas,
+        hasAnyHiddenLinkedEntities = state.hasAnyHiddenLinkedEntities,
+        onRenameSecurityShieldClick = viewModel::onRenameSecurityShieldClick,
+        onEditFactorsClick = viewModel::onEditFactorsClick,
+        onBackClick = onBackClick
+    )
+}
+
+@Composable
+private fun SecurityShieldDetailsContent(
+    modifier: Modifier = Modifier,
+    securityShieldName: String,
+    securityStructureOfFactorSources: SecurityStructureOfFactorSources?,
+    linkedAccounts: PersistentList<Account>,
+    linkedPersonas: PersistentList<Persona>,
+    hasAnyHiddenLinkedEntities: Boolean,
+    onRenameSecurityShieldClick: () -> Unit,
+    onEditFactorsClick: () -> Unit,
+    onBackClick: () -> Unit
+) {
+    var isRegularAccessCardCollapsed by remember { mutableStateOf(true) }
+    var isLogInCardCollapsed by remember { mutableStateOf(true) }
+    var isRecoveryCardCollapsed by remember { mutableStateOf(true) }
+
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .background(color = RadixTheme.colors.gray5),
+        topBar = {
+            RadixCenteredTopAppBar(
+                title = stringResource(id = R.string.empty),
+                onBackClick = onBackClick,
+                windowInsets = WindowInsets.statusBarsAndBanner,
+                contentColor = RadixTheme.colors.gray1,
+                containerColor = RadixTheme.colors.gray5
+            )
+        },
+        bottomBar = {
+            RadixBottomBar(
+                button = {
+                    RadixSecondaryButton(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+                        text = "Edit Factors", // TODO crowdin
+                        onClick = onEditFactorsClick
+                    )
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(color = RadixTheme.colors.gray5)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Column {
+                Text(
+                    modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
+                    text = securityShieldName,
+                    style = RadixTheme.typography.title,
+                    color = RadixTheme.colors.gray1
+                )
+
+                RadixTextButton(
+                    modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
+                    text = "Rename", // TODO crowdin
+                    isWithoutPadding = true,
+                    onClick = onRenameSecurityShieldClick
+                )
+
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+                securityStructureOfFactorSources?.let {
+                    RegularAccessCollapsibleCard(
+                        modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingMedium),
+                        isCollapsed = isRegularAccessCardCollapsed,
+                        primaryRoleWithFactorSources = securityStructureOfFactorSources.matrixOfFactors.primaryRole,
+                        onToggleCollapse = { isRegularAccessCardCollapsed = !isRegularAccessCardCollapsed }
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+                    LogInAndProveOwnershipCollapsibleCard(
+                        modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingMedium),
+                        isCollapsed = isLogInCardCollapsed,
+                        authenticationSigningFactor = securityStructureOfFactorSources.authenticationSigningFactor,
+                        onToggleCollapse = { isLogInCardCollapsed = !isLogInCardCollapsed }
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+                    RecoveryCollapsibleCard(
+                        modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingMedium),
+                        isCollapsed = isRecoveryCardCollapsed,
+                        recoveryRoleWithFactorSources = securityStructureOfFactorSources.matrixOfFactors.recoveryRole,
+                        confirmationRoleWithFactorSources = securityStructureOfFactorSources.matrixOfFactors.confirmationRole,
+                        confirmationDelay = securityStructureOfFactorSources.matrixOfFactors.timeUntilDelayedConfirmationIsCallable,
+                        onToggleCollapse = { isRecoveryCardCollapsed = !isRecoveryCardCollapsed }
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+                }
+            }
+
+            LinkedEntitiesView(
+                modifier = Modifier.fillMaxHeight(1f),
+                linkedAccounts = linkedAccounts,
+                linkedPersonas = linkedPersonas,
+                hasAnyHiddenLinkedEntities = hasAnyHiddenLinkedEntities
+            )
+        }
+    }
+}
+
+@Composable
+private fun RegularAccessCollapsibleCard(
+    modifier: Modifier = Modifier,
+    isCollapsed: Boolean,
+    primaryRoleWithFactorSources: PrimaryRoleWithFactorSources,
+    onToggleCollapse: () -> Unit
+) {
+    Column(modifier = modifier) {
+        CollapsibleCommonCard(
+            isCollapsed = isCollapsed,
+            collapsedItems = 1
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onToggleCollapse() }
+                    .padding(RadixTheme.dimensions.paddingLarge),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+            ) {
+                Column {
+                    Text(
+                        text = stringResource(R.string.transactionReview_updateShield_regularAccessTitle),
+                        style = RadixTheme.typography.secondaryHeader,
+                        color = RadixTheme.colors.gray1
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+                    Text(
+                        text = stringResource(R.string.transactionReview_updateShield_regularAccessMessage),
+                        style = RadixTheme.typography.body2Regular,
+                        color = RadixTheme.colors.gray2
+                    )
+                }
+            }
+        }
+
+        AnimatedVisibility(visible = isCollapsed.not()) {
+            CommonCard(
+                roundTopCorners = false,
+                roundBottomCorners = true
+            ) {
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
+                    colors = CardDefaults.cardColors(containerColor = RadixTheme.colors.gray5),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(all = RadixTheme.dimensions.paddingSemiLarge)
+                    ) {
+                        Text(
+                            text = stringResource(
+                                R.string.transactionReview_updateShield_primaryThersholdMessage,
+                                primaryRoleWithFactorSources.threshold.display()
+                            ).formattedSpans(
+                                SpanStyle(fontWeight = FontWeight.Bold)
+                            ),
+                            style = RadixTheme.typography.body1Regular,
+                            color = RadixTheme.colors.gray1
+                        )
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+                        primaryRoleWithFactorSources.thresholdFactors.forEachIndexed { index, factorSource ->
+                            FactorSourceCardView(
+                                item = factorSource.toFactorSourceCard(includeLastUsedOn = false),
+                                castsShadow = false,
+                                isOutlined = true
+                            )
+
+                            if (index != primaryRoleWithFactorSources.thresholdFactors.lastIndex) {
+                                OrView()
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+                        if (primaryRoleWithFactorSources.overrideFactors.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+                            Text(
+                                text = stringResource(
+                                    R.string.transactionReview_updateShield_primaryOverrideMessage,
+                                ).formattedSpans(
+                                    SpanStyle(fontWeight = FontWeight.Bold)
+                                ),
+                                style = RadixTheme.typography.body1Regular,
+                                color = RadixTheme.colors.gray1
+                            )
+
+                            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+                            primaryRoleWithFactorSources.overrideFactors.forEachIndexed { index, factorSource ->
+                                FactorSourceCardView(
+                                    item = factorSource.toFactorSourceCard(includeLastUsedOn = false),
+                                    castsShadow = false,
+                                    isOutlined = true
+                                )
+
+                                if (index != primaryRoleWithFactorSources.overrideFactors.lastIndex) {
+                                    OrView()
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSemiLarge))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LogInAndProveOwnershipCollapsibleCard(
+    modifier: Modifier = Modifier,
+    isCollapsed: Boolean,
+    authenticationSigningFactor: FactorSource,
+    onToggleCollapse: () -> Unit
+) {
+    Column(modifier = modifier) {
+        CollapsibleCommonCard(
+            isCollapsed = isCollapsed,
+            collapsedItems = 1
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onToggleCollapse() }
+                    .padding(RadixTheme.dimensions.paddingLarge),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+            ) {
+                Column {
+                    Text(
+                        text = stringResource(R.string.transactionReview_updateShield_authSigningTitle),
+                        style = RadixTheme.typography.secondaryHeader,
+                        color = RadixTheme.colors.gray1
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+                    Text(
+                        text = stringResource(R.string.transactionReview_updateShield_authSigningMessage),
+                        style = RadixTheme.typography.body2Regular,
+                        color = RadixTheme.colors.gray2
+                    )
+                }
+            }
+        }
+
+        AnimatedVisibility(visible = isCollapsed.not()) {
+            CommonCard(
+                roundTopCorners = false,
+                roundBottomCorners = true
+            ) {
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
+                    colors = CardDefaults.cardColors(containerColor = RadixTheme.colors.gray5),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(all = RadixTheme.dimensions.paddingSemiLarge)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.transactionReview_updateShield_authSigningThreshold),
+                            style = RadixTheme.typography.body1Regular,
+                            color = RadixTheme.colors.gray1
+                        )
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+                        FactorSourceCardView(
+                            item = authenticationSigningFactor.toFactorSourceCard(includeLastUsedOn = false),
+                            castsShadow = false,
+                            isOutlined = true
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSemiLarge))
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecoveryCollapsibleCard(
+    modifier: Modifier = Modifier,
+    isCollapsed: Boolean,
+    recoveryRoleWithFactorSources: RecoveryRoleWithFactorSources,
+    confirmationRoleWithFactorSources: ConfirmationRoleWithFactorSources,
+    confirmationDelay: TimePeriod,
+    onToggleCollapse: () -> Unit
+) {
+    Column(modifier = modifier) {
+        CollapsibleCommonCard(
+            isCollapsed = isCollapsed,
+            collapsedItems = 1
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onToggleCollapse() }
+                    .padding(RadixTheme.dimensions.paddingLarge),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+            ) {
+                Column {
+                    Text(
+                        text = stringResource(R.string.transactionReview_updateShield_startConfirmTitle),
+                        style = RadixTheme.typography.secondaryHeader,
+                        color = RadixTheme.colors.gray1
+                    )
+                    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+                    Text(
+                        text = stringResource(R.string.transactionReview_updateShield_startConfirmMessage),
+                        style = RadixTheme.typography.body2Regular,
+                        color = RadixTheme.colors.gray2
+                    )
+                }
+            }
+        }
+
+        AnimatedVisibility(visible = isCollapsed.not()) {
+            CommonCard(
+                roundTopCorners = false,
+                roundBottomCorners = true
+            ) {
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingLarge))
+                Text(
+                    modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
+                    text = stringResource(R.string.transactionReview_updateShield_startRecoveryTitle),
+                    style = RadixTheme.typography.body1Header,
+                    color = RadixTheme.colors.gray1
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
+                    colors = CardDefaults.cardColors(containerColor = RadixTheme.colors.gray5),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(all = RadixTheme.dimensions.paddingSemiLarge)
+                    ) {
+                        Text(
+                            text = stringResource(
+                                R.string.transactionReview_updateShield_nonPrimaryOverrideMessage
+                            ).formattedSpans(
+                                SpanStyle(fontWeight = FontWeight.Bold)
+                            ),
+                            style = RadixTheme.typography.body1Regular,
+                            color = RadixTheme.colors.gray1
+                        )
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+                        recoveryRoleWithFactorSources.overrideFactors.forEachIndexed { index, factorSource ->
+                            FactorSourceCardView(
+                                item = factorSource.toFactorSourceCard(includeLastUsedOn = false),
+                                castsShadow = false,
+                                isOutlined = true
+                            )
+
+                            if (index != recoveryRoleWithFactorSources.overrideFactors.lastIndex) {
+                                OrView()
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                Text(
+                    modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
+                    text = stringResource(R.string.transactionReview_updateShield_confirmRecoveryTitle),
+                    style = RadixTheme.typography.body1Header,
+                    color = RadixTheme.colors.gray1
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingMedium))
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
+                    colors = CardDefaults.cardColors(containerColor = RadixTheme.colors.gray5),
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(all = RadixTheme.dimensions.paddingSemiLarge)
+                    ) {
+                        Text(
+                            text = stringResource(
+                                R.string.transactionReview_updateShield_nonPrimaryOverrideMessage
+                            ).formattedSpans(
+                                SpanStyle(fontWeight = FontWeight.Bold)
+                            ),
+                            style = RadixTheme.typography.body1Regular,
+                            color = RadixTheme.colors.gray1
+                        )
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+                        confirmationRoleWithFactorSources.overrideFactors.forEachIndexed { index, factorSource ->
+                            FactorSourceCardView(
+                                item = factorSource.toFactorSourceCard(includeLastUsedOn = false),
+                                castsShadow = false,
+                                isOutlined = true
+                            )
+
+                            if (index != confirmationRoleWithFactorSources.overrideFactors.lastIndex) {
+                                OrView()
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+                ConfirmationDelay(
+                    modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
+                    delay = confirmationDelay
+                )
+
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSemiLarge))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LinkedEntitiesView(
+    modifier: Modifier = Modifier,
+    linkedAccounts: PersistentList<Account>,
+    linkedPersonas: PersistentList<Persona>,
+    hasAnyHiddenLinkedEntities: Boolean,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(color = RadixTheme.colors.gray4)
+            .padding(top = RadixTheme.dimensions.paddingDefault)
+            .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+    ) {
+        SecurityShieldStatusText()
+
+        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+        LinkedAccountsView(linkedAccounts = linkedAccounts)
+
+        LinkedPersonasView(linkedPersonas = linkedPersonas)
+
+        if (hasAnyHiddenLinkedEntities) {
+            LinkedHiddenEntitiesText()
+        }
+
+        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+    }
+}
+
+@Composable
+private fun SecurityShieldStatusText() {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(
+            modifier = Modifier.size(80.dp),
+            painter = painterResource(id = DSR.ic_shield_not_applied),
+            contentDescription = null,
+            tint = Color.Unspecified
+        )
+        Text(
+            text = "This Security Shield is applied to these Accounts and Personas", // TODO crowdin
+            style = RadixTheme.typography.body1Link,
+            color = RadixTheme.colors.gray1
+        )
+    }
+}
+
+@Composable
+private fun LinkedAccountsView(linkedAccounts: PersistentList<Account>) {
+    Column {
+        Text(
+            modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSmall),
+            text = "Accounts", // TODO crowdin
+            style = RadixTheme.typography.body1Header,
+            color = RadixTheme.colors.gray1
+        )
+
+        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+        if (linkedAccounts.isNotEmpty()) {
+            linkedAccounts.forEach { account ->
+                SimpleAccountCard(
+                    account = account,
+                    shape = RadixTheme.shapes.roundedRectMedium
+                )
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+            }
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+        } else {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(RadixTheme.dimensions.paddingDefault),
+                text = "No Accounts", // TODO crowdin
+                style = RadixTheme.typography.body1Header,
+                color = RadixTheme.colors.gray2,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+        }
+    }
+}
+
+@Composable
+private fun LinkedPersonasView(linkedPersonas: PersistentList<Persona>) {
+    Column {
+        Text(
+            modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSmall),
+            text = "Personas", // TODO crowdin
+            style = RadixTheme.typography.body1Header,
+            color = RadixTheme.colors.gray1
+        )
+
+        Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+
+        if (linkedPersonas.isNotEmpty()) {
+            linkedPersonas.forEach { persona ->
+                SimplePersonaCardWithShadow(persona = persona)
+                Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+            }
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
+        } else {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(RadixTheme.dimensions.paddingDefault),
+                text = "No Personas", // TODO crowdin
+                style = RadixTheme.typography.body1Header,
+                color = RadixTheme.colors.gray2,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingDefault))
+        }
+    }
+}
+
+@Composable
+private fun LinkedHiddenEntitiesText() {
+    Text(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(RadixTheme.dimensions.paddingDefault),
+        text = stringResource(R.string.securityShields_assigned_onlyHiddenEntities), // TODO crowdin
+        style = RadixTheme.typography.body1Header,
+        color = RadixTheme.colors.gray2,
+        textAlign = TextAlign.Center
+    )
+}
+
+@UsesSampleValues
+@Preview
+@Composable
+private fun SecurityShieldDetailsWithAllLinkedEntitiesPreview() {
+    RadixWalletPreviewTheme {
+        SecurityShieldDetailsContent(
+            securityShieldName = "DPG7000",
+            securityStructureOfFactorSources = newSecurityStructureOfFactorSourcesSample(),
+            linkedAccounts = persistentListOf(
+                Account.sampleMainnet.alice,
+                Account.sampleMainnet.bob,
+                Account.sampleMainnet.carol
+            ),
+            linkedPersonas = persistentListOf(
+                Persona.sampleMainnet.batman,
+                Persona.sampleMainnet.ripley,
+            ),
+            hasAnyHiddenLinkedEntities = true,
+            onRenameSecurityShieldClick = {},
+            onEditFactorsClick = {},
+            onBackClick = {}
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview
+@Composable
+private fun SecurityShieldDetailsWithLinkedPersonasPreview() {
+    RadixWalletPreviewTheme {
+        SecurityShieldDetailsContent(
+            securityShieldName = "DPG7000",
+            securityStructureOfFactorSources = newSecurityStructureOfFactorSourcesSampleOther(),
+            linkedAccounts = persistentListOf(),
+            linkedPersonas = persistentListOf(
+                Persona.sampleMainnet.batman,
+                Persona.sampleMainnet.ripley,
+            ),
+            hasAnyHiddenLinkedEntities = false,
+            onRenameSecurityShieldClick = {},
+            onEditFactorsClick = {},
+            onBackClick = {}
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview
+@Composable
+private fun LogInAndProveOwnershipCollapsibleCardPreview() {
+    RadixWalletPreviewTheme {
+        val securityStructureOfFactorSourcesSample = newSecurityStructureOfFactorSourcesSample()
+        LogInAndProveOwnershipCollapsibleCard(
+            authenticationSigningFactor = securityStructureOfFactorSourcesSample.authenticationSigningFactor,
+            isCollapsed = false,
+            onToggleCollapse = {}
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview
+@Composable
+private fun RecoveryCollapsibleCardPreview() {
+    RadixWalletPreviewTheme {
+        val securityStructureOfFactorSourcesSample = newSecurityStructureOfFactorSourcesSample()
+        RecoveryCollapsibleCard(
+            recoveryRoleWithFactorSources = securityStructureOfFactorSourcesSample.matrixOfFactors.recoveryRole,
+            confirmationRoleWithFactorSources = securityStructureOfFactorSourcesSample.matrixOfFactors.confirmationRole,
+            confirmationDelay = securityStructureOfFactorSourcesSample.matrixOfFactors.timeUntilDelayedConfirmationIsCallable,
+            isCollapsed = false,
+            onToggleCollapse = {}
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview
+@Composable
+private fun SecurityShieldDetailsWithLinkedAccountsAndHiddenPreview() {
+    RadixWalletPreviewTheme {
+        LinkedEntitiesView(
+            linkedAccounts = persistentListOf(
+                Account.sampleMainnet.alice,
+                Account.sampleMainnet.bob,
+                Account.sampleMainnet.carol
+            ),
+            linkedPersonas = persistentListOf(),
+            hasAnyHiddenLinkedEntities = true
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview
+@Composable
+private fun SecurityShieldDetailsWithLinkedPersonasAndHiddenPreview() {
+    RadixWalletPreviewTheme {
+        LinkedEntitiesView(
+            linkedAccounts = persistentListOf(),
+            linkedPersonas = persistentListOf(
+                Persona.sampleMainnet.batman,
+                Persona.sampleMainnet.ripley,
+            ),
+            hasAnyHiddenLinkedEntities = true
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview
+@Composable
+private fun SecurityShieldDetailsWithOnlyLinkedHiddenEntitiesPreview() {
+    RadixWalletPreviewTheme {
+        LinkedEntitiesView(
+            linkedAccounts = persistentListOf(),
+            linkedPersonas = persistentListOf(),
+            hasAnyHiddenLinkedEntities = true
+        )
+    }
+}
+
+@UsesSampleValues
+@Preview
+@Composable
+private fun SecurityShieldDetailsWithoutLinkedEntitiesPreview() {
+    RadixWalletPreviewTheme {
+        LinkedEntitiesView(
+            linkedAccounts = persistentListOf(),
+            linkedPersonas = persistentListOf(),
+            hasAnyHiddenLinkedEntities = false
+        )
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/shielddetails/SecurityShieldDetailsScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/shielddetails/SecurityShieldDetailsScreen.kt
@@ -97,10 +97,10 @@ fun SecurityShieldDetailsScreen(
         RenameBottomSheet(
             sheetState = bottomSheetState,
             renameInput = state.renameSecurityShieldInput,
-            titleRes = R.string.renameLabel_factorSource_title, // TODO crowdin
-            subtitleRes = R.string.renameLabel_factorSource_subtitle, // TODO crowdin
-            errorValidationMessageRes = R.string.renameLabel_factorSource_empty, // TODO crowdin
-            errorTooLongNameMessageRes = R.string.renameLabel_factorSource_tooLong, // TODO crowdin
+            titleRes = R.string.renameLabel_securityShield_title,
+            subtitleRes = R.string.renameLabel_securityShield_subtitle,
+            errorValidationMessageRes = R.string.renameLabel_securityShield_empty,
+            errorTooLongNameMessageRes = R.string.renameLabel_securityShield_tooLong,
             onNameChange = viewModel::onRenameSecurityShieldChanged,
             onUpdateNameClick = viewModel::onRenameSecurityShieldUpdateClick,
             onDismiss = viewModel::onRenameSecurityShieldDismissed,
@@ -156,7 +156,7 @@ private fun SecurityShieldDetailsContent(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = RadixTheme.dimensions.paddingDefault),
-                        text = "Edit Factors", // TODO crowdin
+                        text = stringResource(R.string.securityShields_editFactors),
                         onClick = onEditFactorsClick
                     )
                 }
@@ -180,7 +180,7 @@ private fun SecurityShieldDetailsContent(
 
                 RadixTextButton(
                     modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSemiLarge),
-                    text = "Rename", // TODO crowdin
+                    text = stringResource(R.string.renameLabel_securityShield_title),
                     isWithoutPadding = true,
                     onClick = onRenameSecurityShieldClick
                 )
@@ -600,7 +600,7 @@ private fun SecurityShieldStatusText() {
             tint = Color.Unspecified
         )
         Text(
-            text = "This Security Shield is applied to these Accounts and Personas", // TODO crowdin
+            text = stringResource(R.string.securityShields_applied_accountsAndPersonas),
             style = RadixTheme.typography.body1Link,
             color = RadixTheme.colors.gray1
         )
@@ -612,7 +612,7 @@ private fun LinkedAccountsView(linkedAccounts: PersistentList<Account>) {
     Column {
         Text(
             modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSmall),
-            text = "Accounts", // TODO crowdin
+            text = stringResource(R.string.securityShields_accounts),
             style = RadixTheme.typography.body1Header,
             color = RadixTheme.colors.gray1
         )
@@ -633,7 +633,7 @@ private fun LinkedAccountsView(linkedAccounts: PersistentList<Account>) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(RadixTheme.dimensions.paddingDefault),
-                text = "No Accounts", // TODO crowdin
+                text = stringResource(R.string.securityShields_noAccounts),
                 style = RadixTheme.typography.body1Header,
                 color = RadixTheme.colors.gray2,
                 textAlign = TextAlign.Center
@@ -648,7 +648,7 @@ private fun LinkedPersonasView(linkedPersonas: PersistentList<Persona>) {
     Column {
         Text(
             modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingSmall),
-            text = "Personas", // TODO crowdin
+            text = stringResource(R.string.securityShields_personas),
             style = RadixTheme.typography.body1Header,
             color = RadixTheme.colors.gray1
         )
@@ -666,7 +666,7 @@ private fun LinkedPersonasView(linkedPersonas: PersistentList<Persona>) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(RadixTheme.dimensions.paddingDefault),
-                text = "No Personas", // TODO crowdin
+                text = stringResource(R.string.securityShields_noPersonas),
                 style = RadixTheme.typography.body1Header,
                 color = RadixTheme.colors.gray2,
                 textAlign = TextAlign.Center
@@ -682,7 +682,7 @@ private fun LinkedHiddenEntitiesText() {
         modifier = Modifier
             .fillMaxWidth()
             .padding(RadixTheme.dimensions.paddingDefault),
-        text = stringResource(R.string.securityShields_assigned_onlyHiddenEntities), // TODO crowdin
+        text = stringResource(R.string.common_hiddenAccountsOrPersonas),
         style = RadixTheme.typography.body1Header,
         color = RadixTheme.colors.gray2,
         textAlign = TextAlign.Center

--- a/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/shielddetails/SecurityShieldDetailsViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/settings/securitycenter/securityshields/shielddetails/SecurityShieldDetailsViewModel.kt
@@ -1,0 +1,163 @@
+package com.babylon.wallet.android.presentation.settings.securitycenter.securityshields.shielddetails
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.babylon.wallet.android.di.coroutines.DefaultDispatcher
+import com.babylon.wallet.android.presentation.common.OneOffEvent
+import com.babylon.wallet.android.presentation.common.OneOffEventHandler
+import com.babylon.wallet.android.presentation.common.OneOffEventHandlerImpl
+import com.babylon.wallet.android.presentation.common.StateViewModel
+import com.babylon.wallet.android.presentation.common.UiMessage
+import com.babylon.wallet.android.presentation.common.UiState
+import com.babylon.wallet.android.presentation.ui.composables.RenameInput
+import com.babylon.wallet.android.utils.callSafely
+import com.radixdlt.sargon.Account
+import com.radixdlt.sargon.Persona
+import com.radixdlt.sargon.ProfileToCheck
+import com.radixdlt.sargon.SecurityStructureId
+import com.radixdlt.sargon.SecurityStructureOfFactorSources
+import com.radixdlt.sargon.os.SargonOsManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class SecurityShieldDetailsViewModel @Inject constructor(
+    private val sargonOsManager: SargonOsManager,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+    savedStateHandle: SavedStateHandle
+) : StateViewModel<SecurityShieldDetailsViewModel.State>(),
+    OneOffEventHandler<SecurityShieldDetailsViewModel.Event> by OneOffEventHandlerImpl() {
+
+    private val args = SecurityShieldDetailsArgs(savedStateHandle)
+
+    override fun initialState() = State()
+
+    init {
+        val shieldId = args.securityStructureId
+        val shieldName = args.securityStructureName
+        _state.update { state ->
+            state.copy(securityShieldName = shieldName)
+        }
+
+        getSecurityStructuresOfFactorSources(shieldId = shieldId)
+
+        getEntitiesLinkedToSecurityStructure(shieldId = shieldId)
+    }
+
+    private fun getSecurityStructuresOfFactorSources(shieldId: SecurityStructureId) {
+        viewModelScope.launch {
+            sargonOsManager.callSafely(defaultDispatcher) {
+                securityStructuresOfFactorSources()
+                    .find { it.metadata.id == shieldId }
+                    ?: error("Security structure not found.")
+            }.onSuccess { securityStructureOfFactorSources ->
+                _state.update { state ->
+                    state.copy(securityStructureOfFactorSources = securityStructureOfFactorSources)
+                }
+            }.onFailure {
+                Timber.e("Failed to get security structure.")
+            }
+        }
+    }
+
+    private fun getEntitiesLinkedToSecurityStructure(shieldId: SecurityStructureId) {
+        viewModelScope.launch {
+            sargonOsManager.callSafely(defaultDispatcher) {
+                entitiesLinkedToSecurityStructure(
+                    shieldId = shieldId,
+                    profileToCheck = ProfileToCheck.Current
+                )
+            }.onSuccess { linkedEntities ->
+                _state.update { state ->
+                    state.copy(
+                        linkedAccounts = linkedEntities.accounts.toPersistentList(),
+                        linkedPersonas = linkedEntities.personas.toPersistentList(),
+                        hasAnyHiddenLinkedEntities = linkedEntities.hiddenAccounts.isNotEmpty() ||
+                            linkedEntities.hiddenPersonas.isNotEmpty()
+                    )
+                }
+            }.onFailure {
+                Timber.e("Failed to get linked entities for security structure id: $shieldId")
+            }
+        }
+    }
+
+    fun onRenameSecurityShieldClick() {
+        _state.update { state ->
+            state.copy(
+                isRenameBottomSheetVisible = true,
+                renameSecurityShieldInput = RenameSecurityShieldInput(name = state.securityShieldName)
+            )
+        }
+    }
+
+    fun onRenameSecurityShieldChanged(updatedName: String) {
+        _state.update { state ->
+            state.copy(
+                renameSecurityShieldInput = RenameSecurityShieldInput(name = updatedName)
+            )
+        }
+    }
+
+    fun onRenameSecurityShieldUpdateClick() {
+        viewModelScope.launch {
+            _state.update { state ->
+                state.copy(
+                    renameSecurityShieldInput = state.renameSecurityShieldInput.copy(isUpdating = true)
+                )
+            }
+//            currentSecurityShield?.let {
+//                sargonOsManager.callSafely(defaultDispatcher) {
+//                    updateSecurityShieldName( // TODO future task: add updateSecurityShieldName in sargon
+//                        securityShield = it, // or id
+//                        name = state.value.renameSecurityShieldInput.name
+//                    )
+//                }.onFailure { error ->
+//                    Timber.e("Failed to rename security shield: $error")
+//                }
+//            }
+            _state.update { state ->
+                state.copy(
+                    isRenameBottomSheetVisible = false,
+                    uiMessage = UiMessage.InfoMessage.RenameSuccessful
+                )
+            }
+        }
+    }
+
+    fun onRenameSecurityShieldDismissed() {
+        _state.update { state -> state.copy(isRenameBottomSheetVisible = false) }
+    }
+
+    fun onEditFactorsClick() {
+        // TODO
+    }
+
+    data class State(
+        val isLoading: Boolean = true,
+        val securityShieldName: String = "",
+        val securityStructureOfFactorSources: SecurityStructureOfFactorSources? = null,
+        val linkedAccounts: PersistentList<Account> = persistentListOf(),
+        val linkedPersonas: PersistentList<Persona> = persistentListOf(),
+        val hasAnyHiddenLinkedEntities: Boolean = false,
+        val isRenameBottomSheetVisible: Boolean = false,
+        val renameSecurityShieldInput: RenameSecurityShieldInput = RenameSecurityShieldInput(),
+        val uiMessage: UiMessage? = null
+    ) : UiState
+
+    data class RenameSecurityShieldInput(
+        override val name: String = "",
+        override val isUpdating: Boolean = false
+    ) : RenameInput()
+
+    sealed interface Event : OneOffEvent {
+        data object Dismiss : Event
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/SecurifyEntityTypeContent.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/composables/SecurifyEntityTypeContent.kt
@@ -1,11 +1,7 @@
 package com.babylon.wallet.android.presentation.transaction.composables
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,13 +10,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -28,7 +21,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
-import com.babylon.wallet.android.presentation.common.title
+import com.babylon.wallet.android.presentation.common.securityshields.ConfirmationDelay
+import com.babylon.wallet.android.presentation.common.securityshields.OrView
+import com.babylon.wallet.android.presentation.common.securityshields.display
 import com.babylon.wallet.android.presentation.dialogs.info.DSR
 import com.babylon.wallet.android.presentation.transaction.PreviewType
 import com.babylon.wallet.android.presentation.transaction.model.InvolvedAccount
@@ -43,7 +38,6 @@ import com.radixdlt.sargon.Persona
 import com.radixdlt.sargon.PrimaryRoleWithFactorSources
 import com.radixdlt.sargon.RecoveryRoleWithFactorSources
 import com.radixdlt.sargon.SecurityStructureOfFactorSources
-import com.radixdlt.sargon.Threshold
 import com.radixdlt.sargon.TimePeriod
 import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.extensions.ProfileEntity
@@ -378,79 +372,6 @@ private fun RecoveryAndConfirmationView(
             delay = confirmationDelay
         )
     }
-}
-
-@Composable
-private fun ConfirmationDelay(
-    modifier: Modifier = Modifier,
-    delay: TimePeriod
-) {
-    Column(
-        modifier = modifier
-            .background(
-                color = RadixTheme.colors.lightRed,
-                shape = RadixTheme.shapes.roundedRectMedium
-            )
-            .padding(RadixTheme.dimensions.paddingDefault),
-        verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingMedium)
-    ) {
-        Text(
-            text = stringResource(R.string.transactionReview_updateShield_confirmationDelayMessage),
-            style = RadixTheme.typography.body1Regular,
-            color = RadixTheme.colors.gray1
-        )
-
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    color = RadixTheme.colors.white,
-                    shape = RadixTheme.shapes.roundedRectSmall
-                )
-                .border(
-                    width = 1.dp,
-                    color = RadixTheme.colors.gray4,
-                    shape = RadixTheme.shapes.roundedRectSmall
-                )
-                .padding(
-                    horizontal = RadixTheme.dimensions.paddingSemiLarge,
-                    vertical = RadixTheme.dimensions.paddingDefault
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
-        ) {
-            Icon(
-                painter = painterResource(id = DSR.ic_calendar),
-                contentDescription = null
-            )
-
-            Text(
-                text = delay.title(),
-                style = RadixTheme.typography.body1Header,
-                color = RadixTheme.colors.gray1
-            )
-        }
-    }
-}
-
-@Composable
-private fun Threshold.display(): String = when (this) {
-    is Threshold.All -> "ALL"
-    is Threshold.Specific -> "${v1.toInt()}"
-}
-
-@Composable
-private fun ColumnScope.OrView() {
-    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
-
-    Text(
-        modifier = Modifier.align(Alignment.CenterHorizontally),
-        text = stringResource(R.string.transactionReview_updateShield_combinationLabel),
-        style = RadixTheme.typography.body2Regular,
-        color = RadixTheme.colors.gray2
-    )
-
-    Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSmall))
 }
 
 @UsesSampleValues

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsCommonViews.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsCommonViews.kt
@@ -1,32 +1,17 @@
 package com.babylon.wallet.android.presentation.ui.composables.assets
 
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithCache
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -88,131 +73,6 @@ fun Modifier.strokeLine() = composed {
             }
         }
     )
-}
-
-@Composable
-fun AssetCard(
-    modifier: Modifier = Modifier,
-    backgroundColor: Color = RadixTheme.colors.defaultBackground,
-    elevation: Dp = 4.dp,
-    roundTopCorners: Boolean = true,
-    roundBottomCorners: Boolean = true,
-    removeTopShadow: Boolean = false,
-    cornerSizeRadius: Dp = 12.dp,
-    content: @Composable ColumnScope.() -> Unit
-) {
-    val topCorners = if (roundTopCorners) cornerSizeRadius else 0.dp
-    val bottomCorners by animateDpAsState(
-        targetValue = if (roundBottomCorners) cornerSizeRadius else 0.dp,
-        label = "bottomCorners"
-    )
-    val shadowPadding = RadixTheme.dimensions.paddingDefault
-    Card(
-        modifier = modifier
-            .drawWithContent {
-                // Needed to remove shadow casted above of previous elements in the top side
-                if (removeTopShadow) {
-                    val shadowPaddingPx = shadowPadding.toPx()
-                    clipRect(
-                        top = 0f,
-                        left = -shadowPaddingPx,
-                        right = size.width + shadowPaddingPx,
-                        bottom = size.height + shadowPaddingPx
-                    ) {
-                        this@drawWithContent.drawContent()
-                    }
-                } else {
-                    this@drawWithContent.drawContent()
-                }
-            },
-        shape = RoundedCornerShape(
-            topStart = topCorners,
-            topEnd = topCorners,
-            bottomEnd = bottomCorners,
-            bottomStart = bottomCorners
-        ),
-        colors = CardDefaults.cardColors(containerColor = backgroundColor),
-        elevation = CardDefaults.cardElevation(defaultElevation = elevation),
-        content = content
-    )
-}
-
-@Composable
-fun AssetCard(
-    modifier: Modifier = Modifier,
-    itemIndex: Int = 0,
-    allItemsSize: Int = 1,
-    backgroundColor: Color = RadixTheme.colors.defaultBackground,
-    elevation: Dp = 4.dp,
-    roundTopCorners: Boolean = true,
-    roundBottomCorners: Boolean = true,
-    cornerSizeRadius: Dp = 12.dp,
-    content: @Composable ColumnScope.() -> Unit
-) {
-    AssetCard(
-        modifier = modifier,
-        backgroundColor = backgroundColor,
-        elevation = elevation,
-        roundTopCorners = itemIndex == 0 && roundTopCorners,
-        roundBottomCorners = itemIndex == allItemsSize - 1 && roundBottomCorners,
-        cornerSizeRadius = cornerSizeRadius,
-        removeTopShadow = itemIndex != 0 && allItemsSize != 1,
-        content = content
-    )
-}
-
-@Composable
-fun CollapsibleAssetCard(
-    modifier: Modifier = Modifier,
-    isCollapsed: Boolean,
-    collapsedItems: Int,
-    backgroundColor: Color = RadixTheme.colors.defaultBackground,
-    groupInnerPadding: Dp = 8.dp,
-    elevation: Dp = 6.dp,
-    cornerSizeRadius: Dp = 12.dp,
-    content: @Composable ColumnScope.() -> Unit
-) {
-    val visibleCollapsedItems = collapsedItems.coerceAtMost(2)
-    Box(modifier = modifier.padding(bottom = if (isCollapsed) groupInnerPadding * visibleCollapsedItems else 0.dp)) {
-        if (isCollapsed) {
-            repeat(visibleCollapsedItems) { index ->
-                val collapsedIndex = visibleCollapsedItems - index
-                val shape = RoundedCornerShape(
-                    topStart = 0.dp,
-                    topEnd = 0.dp,
-                    bottomStart = cornerSizeRadius,
-                    bottomEnd = cornerSizeRadius
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .offset(y = groupInnerPadding * collapsedIndex)
-                        .height(groupInnerPadding)
-                        .padding(horizontal = groupInnerPadding * collapsedIndex)
-                        .align(Alignment.BottomCenter)
-                        .shadow(
-                            elevation = elevation - collapsedIndex.dp,
-                            shape = shape
-                        )
-                        .background(
-                            color = backgroundColor,
-                            shape = shape
-                        )
-                )
-            }
-        }
-
-        AssetCard(
-            modifier = Modifier
-                .fillMaxWidth(),
-            backgroundColor = backgroundColor,
-            roundBottomCorners = isCollapsed,
-            elevation = elevation,
-            cornerSizeRadius = cornerSizeRadius
-        ) {
-            content()
-        }
-    }
 }
 
 @Composable

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
@@ -32,6 +32,8 @@ import com.babylon.wallet.android.presentation.model.displaySubtitle
 import com.babylon.wallet.android.presentation.model.displayTitle
 import com.babylon.wallet.android.presentation.transfer.assets.AssetsTab
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
+import com.babylon.wallet.android.presentation.ui.composables.card.CollapsibleCommonCard
+import com.babylon.wallet.android.presentation.ui.composables.card.CommonCard
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.google.accompanist.placeholder.PlaceholderHighlight
 import com.google.accompanist.placeholder.placeholder
@@ -93,7 +95,7 @@ private fun NFTItem(
     state: AssetsViewState,
     action: AssetsViewAction
 ) {
-    AssetCard(
+    CommonCard(
         modifier = Modifier
             .padding(top = 1.dp)
             .padding(horizontal = RadixTheme.dimensions.paddingDefault),
@@ -130,7 +132,7 @@ private fun NFTHeader(
     modifier: Modifier = Modifier
 ) {
     val isCollapsed = state.isCollapsed(collection.resource.address.string)
-    CollapsibleAssetCard(
+    CollapsibleCommonCard(
         modifier = modifier
             .padding(horizontal = RadixTheme.dimensions.paddingDefault),
         isCollapsed = isCollapsed,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
@@ -35,6 +35,7 @@ import com.babylon.wallet.android.presentation.transaction.composables.UnknownAm
 import com.babylon.wallet.android.presentation.transfer.assets.AssetsTab
 import com.babylon.wallet.android.presentation.ui.composables.ShimmeringView
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
+import com.babylon.wallet.android.presentation.ui.composables.card.CommonCard
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.extensions.string
@@ -84,7 +85,7 @@ private fun PoolUnitItem(
     isLoadingBalance: Boolean,
     action: AssetsViewAction,
 ) {
-    AssetCard(
+    CommonCard(
         modifier = modifier
             .throttleClickable {
                 when (action) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
@@ -42,6 +42,8 @@ import com.babylon.wallet.android.presentation.ui.RadixWalletPreviewTheme
 import com.babylon.wallet.android.presentation.ui.composables.DSR
 import com.babylon.wallet.android.presentation.ui.composables.ShimmeringView
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
+import com.babylon.wallet.android.presentation.ui.composables.card.CollapsibleCommonCard
+import com.babylon.wallet.android.presentation.ui.composables.card.CommonCard
 import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.radixdlt.sargon.Decimal192
@@ -114,7 +116,7 @@ private fun StakingSummary(
     action: AssetsViewAction,
 ) {
     val stakeSummary = assetsViewData.stakeSummary
-    AssetCard(
+    CommonCard(
         modifier = modifier
             .padding(horizontal = RadixTheme.dimensions.paddingDefault)
             .padding(top = RadixTheme.dimensions.paddingSemiLarge),
@@ -347,7 +349,7 @@ fun ValidatorDetails(
             cards
         }
         val isCollapsed = state.isCollapsed(validatorWithStakes.validator.address.string)
-        CollapsibleAssetCard(
+        CollapsibleCommonCard(
             modifier = modifier
                 .padding(horizontal = RadixTheme.dimensions.paddingDefault),
             isCollapsed = isCollapsed,
@@ -366,7 +368,7 @@ fun ValidatorDetails(
 
         if (!isCollapsed) {
             if (validatorWithStakes.hasLSU) {
-                AssetCard(
+                CommonCard(
                     modifier = Modifier
                         .padding(horizontal = RadixTheme.dimensions.paddingDefault)
                         .padding(top = RadixTheme.dimensions.paddingXXXSmall),
@@ -383,7 +385,7 @@ fun ValidatorDetails(
             }
 
             if (validatorWithStakes.hasClaims) {
-                AssetCard(
+                CommonCard(
                     modifier = Modifier
                         .padding(horizontal = RadixTheme.dimensions.paddingDefault)
                         .padding(top = RadixTheme.dimensions.paddingXXXSmall),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TokensTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TokensTab.kt
@@ -27,6 +27,7 @@ import com.babylon.wallet.android.presentation.model.displayTitle
 import com.babylon.wallet.android.presentation.transfer.assets.AssetsTab
 import com.babylon.wallet.android.presentation.ui.composables.ShimmeringView
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
+import com.babylon.wallet.android.presentation.ui.composables.card.CommonCard
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
 import com.radixdlt.sargon.Decimal192
 import com.radixdlt.sargon.NetworkId
@@ -72,7 +73,7 @@ fun LazyListScope.tokensTab(
 
     item {
         if (assetsViewData.xrd != null) {
-            AssetCard(
+            CommonCard(
                 modifier = Modifier
                     .padding(horizontal = RadixTheme.dimensions.paddingDefault)
                     .padding(top = RadixTheme.dimensions.paddingSemiLarge)
@@ -91,7 +92,7 @@ fun LazyListScope.tokensTab(
         items = assetsViewData.nonXrdTokens,
         key = { _, token -> token.resource.address.string },
         itemContent = { index, token ->
-            AssetCard(
+            CommonCard(
                 modifier = Modifier
                     .padding(top = if (index == 0) RadixTheme.dimensions.paddingSemiLarge else 0.dp)
                     .padding(horizontal = RadixTheme.dimensions.paddingDefault),

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/CommonCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/CommonCard.kt
@@ -1,0 +1,149 @@
+package com.babylon.wallet.android.presentation.ui.composables.card
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.babylon.wallet.android.designsystem.theme.RadixTheme
+
+@Composable
+fun CommonCard(
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = RadixTheme.colors.defaultBackground,
+    elevation: Dp = 4.dp,
+    roundTopCorners: Boolean = true,
+    roundBottomCorners: Boolean = true,
+    removeTopShadow: Boolean = false,
+    cornerSizeRadius: Dp = 12.dp,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val topCorners = if (roundTopCorners) cornerSizeRadius else 0.dp
+    val bottomCorners by animateDpAsState(
+        targetValue = if (roundBottomCorners) cornerSizeRadius else 0.dp,
+        label = "bottomCorners"
+    )
+    val shadowPadding = RadixTheme.dimensions.paddingDefault
+    Card(
+        modifier = modifier
+            .drawWithContent {
+                // Needed to remove shadow casted above of previous elements in the top side
+                if (removeTopShadow) {
+                    val shadowPaddingPx = shadowPadding.toPx()
+                    clipRect(
+                        top = 0f,
+                        left = -shadowPaddingPx,
+                        right = size.width + shadowPaddingPx,
+                        bottom = size.height + shadowPaddingPx
+                    ) {
+                        this@drawWithContent.drawContent()
+                    }
+                } else {
+                    this@drawWithContent.drawContent()
+                }
+            },
+        shape = RoundedCornerShape(
+            topStart = topCorners,
+            topEnd = topCorners,
+            bottomEnd = bottomCorners,
+            bottomStart = bottomCorners
+        ),
+        colors = CardDefaults.cardColors(containerColor = backgroundColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = elevation),
+        content = content
+    )
+}
+
+@Composable
+fun CommonCard(
+    modifier: Modifier = Modifier,
+    itemIndex: Int = 0,
+    allItemsSize: Int = 1,
+    backgroundColor: Color = RadixTheme.colors.defaultBackground,
+    elevation: Dp = 4.dp,
+    roundTopCorners: Boolean = true,
+    roundBottomCorners: Boolean = true,
+    cornerSizeRadius: Dp = 12.dp,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    CommonCard(
+        modifier = modifier,
+        backgroundColor = backgroundColor,
+        elevation = elevation,
+        roundTopCorners = itemIndex == 0 && roundTopCorners,
+        roundBottomCorners = itemIndex == allItemsSize - 1 && roundBottomCorners,
+        cornerSizeRadius = cornerSizeRadius,
+        removeTopShadow = itemIndex != 0 && allItemsSize != 1,
+        content = content
+    )
+}
+
+@Composable
+fun CollapsibleCommonCard(
+    modifier: Modifier = Modifier,
+    isCollapsed: Boolean,
+    collapsedItems: Int,
+    backgroundColor: Color = RadixTheme.colors.defaultBackground,
+    groupInnerPadding: Dp = 8.dp,
+    elevation: Dp = 6.dp,
+    cornerSizeRadius: Dp = 12.dp,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val visibleCollapsedItems = collapsedItems.coerceAtMost(2)
+    Box(modifier = modifier.padding(bottom = if (isCollapsed) groupInnerPadding * visibleCollapsedItems else 0.dp)) {
+        if (isCollapsed) {
+            repeat(visibleCollapsedItems) { index ->
+                val collapsedIndex = visibleCollapsedItems - index
+                val shape = RoundedCornerShape(
+                    topStart = 0.dp,
+                    topEnd = 0.dp,
+                    bottomStart = cornerSizeRadius,
+                    bottomEnd = cornerSizeRadius
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .offset(y = groupInnerPadding * collapsedIndex)
+                        .height(groupInnerPadding)
+                        .padding(horizontal = groupInnerPadding * collapsedIndex)
+                        .align(Alignment.BottomCenter)
+                        .shadow(
+                            elevation = elevation - collapsedIndex.dp,
+                            shape = shape
+                        )
+                        .background(
+                            color = backgroundColor,
+                            shape = shape
+                        )
+                )
+            }
+        }
+
+        CommonCard(
+            modifier = Modifier
+                .fillMaxWidth(),
+            backgroundColor = backgroundColor,
+            roundBottomCorners = isCollapsed,
+            elevation = elevation,
+            cornerSizeRadius = cornerSizeRadius
+        ) {
+            content()
+        }
+    }
+}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/PersonaCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/card/PersonaCard.kt
@@ -17,7 +17,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -50,6 +52,42 @@ fun SimplePersonaCard(
     Column(modifier) {
         Row(
             Modifier
+                .fillMaxWidth()
+                .padding(RadixTheme.dimensions.paddingDefault),
+            horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Thumbnail.Persona(
+                modifier = Modifier.size(54.dp),
+                persona = persona
+            )
+            Text(
+                modifier = Modifier.weight(1f),
+                text = persona.displayName.value,
+                textAlign = TextAlign.Start,
+                maxLines = 2,
+                style = RadixTheme.typography.secondaryHeader,
+                color = RadixTheme.colors.gray1
+            )
+        }
+    }
+}
+
+@Composable
+fun SimplePersonaCardWithShadow(
+    modifier: Modifier = Modifier,
+    persona: Persona,
+) {
+    Column(modifier) {
+        Row(
+            Modifier
+                .defaultCardShadow(elevation = 6.dp)
+                .background(
+                    brush = SolidColor(RadixTheme.colors.gray5),
+                    shape = RadixTheme.shapes.roundedRectMedium
+                )
+                .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+                .clip(RadixTheme.shapes.roundedRectMedium)
                 .fillMaxWidth()
                 .padding(RadixTheme.dimensions.paddingDefault),
             horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault),
@@ -223,6 +261,15 @@ fun SimplePersonaSelectionCard(
 fun SimplePersonaCardPreview() {
     RadixWalletTheme {
         SimplePersonaCard(persona = Persona.sampleMainnet())
+    }
+}
+
+@UsesSampleValues
+@Preview(showBackground = true)
+@Composable
+fun SimplePersonaCardWithShadowPreview() {
+    RadixWalletTheme {
+        SimplePersonaCardWithShadow(persona = Persona.sampleMainnet())
     }
 }
 

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/model/securityshields/SecurityShieldCard.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/model/securityshields/SecurityShieldCard.kt
@@ -10,6 +10,8 @@ data class SecurityShieldCard(
 ) {
     val id: SecurityStructureId = shieldForDisplay.metadata.id
 
+    val name: String = shieldForDisplay.metadata.displayName.value
+
     val numberOfLinkedAccounts: Int = shieldForDisplay.numberOfLinkedAccounts.toInt()
 
     val numberOfLinkedPersonas: Int = shieldForDisplay.numberOfLinkedPersonas.toInt()

--- a/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/RadixTextButton.kt
+++ b/designsystem/src/main/java/com/babylon/wallet/android/designsystem/composable/RadixTextButton.kt
@@ -66,7 +66,7 @@ fun RadixTextButton(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun RadixTextButtonPreview() {
     RadixWalletTheme {
@@ -74,7 +74,7 @@ fun RadixTextButtonPreview() {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun RadixTextButtonDisabledPreview() {
     RadixWalletTheme {


### PR DESCRIPTION
## Description
This PR solves adds the Security Shield details screen. (read commit messages for more details).
This PR is on top of this [PR](https://github.com/radixdlt/babylon-wallet-android/pull/1334). So you can apply a shield and test the details screen.

Future tasks (**NOT** for this PR):
- rename shield functionality
- edit factors functionality
- security shield status functionality


## How to test

1. Build shields and navigate to details screen


## Video
[here](https://rdxworks.slack.com/archives/C03Q8QK1GLW/p1740414917985659)

## PR submission checklist
- [X] I have tested security shield details screen with multiple shields.
