### PR TITLE
Safeguard against 0 total liquidStakeUnitAmount when staking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,7 @@ android {
         minSdk rootProject.ext.minSdk
         targetSdk rootProject.ext.targetSdk
         versionCode 59
-        versionName "1.11.6"
+        versionName "1.11.7"
         buildConfigField "boolean", "DEBUG_MODE", "true"
         buildConfigField "boolean", "CRASH_REPORTING_AVAILABLE", "false"
         buildConfigField "boolean", "EXPERIMENTAL_FEATURES_ENABLED", "true"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,7 +76,7 @@ android {
         applicationId "com.radixpublishing.radixwallet.android"
         minSdk rootProject.ext.minSdk
         targetSdk rootProject.ext.targetSdk
-        versionCode 59
+        versionCode 60
         versionName "1.11.7"
         buildConfigField "boolean", "DEBUG_MODE", "true"
         buildConfigField "boolean", "CRASH_REPORTING_AVAILABLE", "false"

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/summary/execution/ValidatorStakeProcessor.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transaction/analysis/summary/execution/ValidatorStakeProcessor.kt
@@ -8,6 +8,7 @@ import com.radixdlt.sargon.DetailedManifestClass
 import com.radixdlt.sargon.ExecutionSummary
 import com.radixdlt.sargon.ResourceOrNonFungible
 import com.radixdlt.sargon.TrackedValidatorStake
+import com.radixdlt.sargon.extensions.isZero
 import com.radixdlt.sargon.extensions.orZero
 import com.radixdlt.sargon.extensions.plus
 import com.radixdlt.sargon.extensions.toDecimal192
@@ -62,13 +63,19 @@ class ValidatorStakeProcessor @Inject constructor(
                 totalStakedXrd += stake.xrdAmount
             }
 
+            totalStaked = 0.toDecimal192()
+
             lsu.copy(
                 xrdWorth = lsu.amount.calculateWith { decimal ->
-                    lsu.asset.stakeValueXRD(
-                        lsu = decimal,
-                        totalStaked = totalStaked,
-                        totalStakedInXrd = totalStakedXrd
-                    ).orZero()
+                    if (totalStaked.isZero) {
+                        totalStakedXrd
+                    } else {
+                        lsu.asset.stakeValueXRD(
+                            lsu = decimal,
+                            totalStaked = totalStaked,
+                            totalStakedInXrd = totalStakedXrd
+                        ).orZero()
+                    }
                 }
             )
         }


### PR DESCRIPTION
## Description
* Safeguard against division with 0 when RET classifies a transaction as staking with 0 amount as total `liquidStakeUnitAmount`