### PR TITLE
Release 1.12.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,7 @@ android {
         minSdk rootProject.ext.minSdk
         targetSdk rootProject.ext.targetSdk
         versionCode 61
-        versionName "1.11.8"
+        versionName "1.12.0"
         buildConfigField "boolean", "DEBUG_MODE", "true"
         buildConfigField "boolean", "CRASH_REPORTING_AVAILABLE", "false"
         buildConfigField "boolean", "EXPERIMENTAL_FEATURES_ENABLED", "true"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,7 +77,7 @@ android {
         applicationId "com.radixpublishing.radixwallet.android"
         minSdk rootProject.ext.minSdk
         targetSdk rootProject.ext.targetSdk
-        versionCode 61
+        versionCode 62
         versionName "1.12.0"
         buildConfigField "boolean", "DEBUG_MODE", "true"
         buildConfigField "boolean", "CRASH_REPORTING_AVAILABLE", "false"

--- a/app/src/main/java/com/babylon/wallet/android/AppLockStateProvider.kt
+++ b/app/src/main/java/com/babylon/wallet/android/AppLockStateProvider.kt
@@ -21,7 +21,9 @@ class AppLockStateProvider @Inject constructor(
     @ApplicationScope private val applicationScope: CoroutineScope
 ) {
 
-    private val _state: MutableStateFlow<State> = MutableStateFlow(State())
+    private val _state: MutableStateFlow<State> = MutableStateFlow(
+        State(lockState = LockState.Unlocked)
+    )
 
     init {
         applicationScope.launch {

--- a/app/src/main/java/com/babylon/wallet/android/AppLockStateProvider.kt
+++ b/app/src/main/java/com/babylon/wallet/android/AppLockStateProvider.kt
@@ -37,11 +37,11 @@ class AppLockStateProvider @Inject constructor(
 
     val lockState: SharedFlow<LockState>
         get() = _state.map { state ->
-                state.lockState
-            }.shareIn(
-                scope = applicationScope,
-                started = SharingStarted.WhileSubscribed()
-            )
+            state.lockState
+        }.shareIn(
+            scope = applicationScope,
+            started = SharingStarted.WhileSubscribed()
+        )
 
     suspend fun lockApp() {
         if (_state.value.isLockingPaused) return

--- a/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
+++ b/app/src/main/java/com/babylon/wallet/android/WalletApp.kt
@@ -73,7 +73,7 @@ fun WalletApp(
             modifier = Modifier.fillMaxSize(),
             startDestination = MAIN_ROUTE,
             navController = navController,
-            state = mainViewModel.state,
+            viewModel = mainViewModel,
             onCloseApp = onCloseApp
         )
         LaunchedEffect(Unit) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainScreen.kt
@@ -9,12 +9,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.babylon.wallet.android.presentation.common.FullscreenCircularProgressContent
 import com.babylon.wallet.android.presentation.wallet.WalletScreen
 import com.radixdlt.sargon.Account
-import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun MainScreen(
     modifier: Modifier = Modifier,
-    mainUiState: StateFlow<MainViewModel.State>,
+    viewModel: MainViewModel,
     onMenuClick: () -> Unit,
     onAccountClick: (Account) -> Unit = { },
     onNavigateToSecurityCenter: () -> Unit,
@@ -26,7 +25,7 @@ fun MainScreen(
     onNavigateToConnectCloudBackup: () -> Unit,
     onNavigateToLinkConnector: () -> Unit
 ) {
-    val state by mainUiState.collectAsStateWithLifecycle()
+    val state by viewModel.state.collectAsStateWithLifecycle()
     when (state.initialAppState) {
         is AppState.Wallet -> {
             WalletScreen(

--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainScreenNav.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainScreenNav.kt
@@ -5,13 +5,12 @@ import androidx.compose.animation.ExitTransition
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.radixdlt.sargon.Account
-import kotlinx.coroutines.flow.StateFlow
 
 const val MAIN_ROUTE = "main"
 
 @Suppress("LongParameterList")
 fun NavGraphBuilder.main(
-    mainUiState: StateFlow<MainViewModel.State>,
+    viewModel: MainViewModel,
     onMenuClick: () -> Unit,
     onAccountClick: (Account) -> Unit,
     onNavigateToSecurityCenter: () -> Unit,
@@ -31,7 +30,7 @@ fun NavGraphBuilder.main(
         popExitTransition = { ExitTransition.None }
     ) {
         MainScreen(
-            mainUiState = mainUiState,
+            viewModel = viewModel,
             onMenuClick = onMenuClick,
             onAccountClick = onAccountClick,
             onAccountCreationClick = onAccountCreationClick,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/main/MainViewModel.kt
@@ -18,10 +18,8 @@ import com.babylon.wallet.android.presentation.main.p2plinks.IncomingRequestsDel
 import com.babylon.wallet.android.utils.AppEvent
 import com.babylon.wallet.android.utils.AppEventBus
 import com.babylon.wallet.android.utils.DeviceCapabilityHelper
-import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.CommonException
 import com.radixdlt.sargon.NetworkId
-import com.radixdlt.sargon.Persona
 import com.radixdlt.sargon.ProfileState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collect
@@ -238,15 +236,6 @@ class MainViewModel @Inject constructor(
     ) : UiState {
         val showDeviceNotSecureDialog: Boolean
             get() = !isDeviceSecure && !isAdvancedLockEnabled
-    }
-
-    data class OlympiaErrorState(
-        val secondsLeft: Int = 30,
-        val affectedAccounts: List<Account>,
-        val affectedPersonas: List<Persona>
-    ) {
-        val isCountdownActive: Boolean
-            get() = secondsLeft > 0
     }
 
     sealed class Event : OneOffEvent {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/navigation/NavigationHost.kt
@@ -88,14 +88,13 @@ import com.babylon.wallet.android.presentation.transfer.transfer
 import com.babylon.wallet.android.presentation.transfer.transferScreen
 import com.babylon.wallet.android.presentation.walletclaimed.claimedByAnotherDevice
 import com.radixdlt.sargon.extensions.networkId
-import kotlinx.coroutines.flow.StateFlow
 import rdx.works.core.domain.resources.XrdResource
 
 @Suppress("CyclomaticComplexMethod")
 @Composable
 fun NavigationHost(
     modifier: Modifier = Modifier,
-    state: StateFlow<MainViewModel.State>,
+    viewModel: MainViewModel,
     startDestination: String,
     navController: NavHostController,
     onCloseApp: () -> Unit,
@@ -209,7 +208,7 @@ fun NavigationHost(
             }
         )
         main(
-            mainUiState = state,
+            viewModel = viewModel,
             onMenuClick = {
                 navController.navigate(Screen.SettingsAllDestination.route)
             },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
@@ -177,12 +177,16 @@ fun PoolResourcesValues(
         val itemsSize = resources.size
         resources.entries.forEachIndexed { index, resourceWithAmount ->
             Column(
-                modifier = Modifier.padding(
-                    horizontal = RadixTheme.dimensions.paddingDefault,
-                    vertical = if (isCompact) RadixTheme.dimensions.paddingMedium else RadixTheme.dimensions.paddingDefault
-                )
+                modifier = Modifier.padding(horizontal = RadixTheme.dimensions.paddingDefault)
             ) {
                 Row(
+                    modifier = Modifier.padding(
+                        vertical = if (isCompact) {
+                            RadixTheme.dimensions.paddingMedium
+                        } else {
+                            RadixTheme.dimensions.paddingDefault
+                        }
+                    ),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingMedium)
                 ) {


### PR DESCRIPTION
Additional fixes attached on the release branch:

1. Fixed advanced lock mechanism. The initial value is read only when the application starts and not each time an activity is subscribed to it. If the `MainActivity` is killed and restored again by the system then the lock screen would appear again. Also changed to initial value to be unlocked (i.e. when in onboarding, the app should be unlocked since there is no profile)
2. Pass down to `MainScreen` and `WalletScreen` the view model reference (`MainViewModel`) instead of the `State<MainViewModel.State>` which forced the screen to redraw and the nav host to lose its state when the app state changed.
3. Fix a UI bug in Pool Units were the separator between resources in a pool was not centered correctly.