### PR TITLE
Fix RNS custom gateway usage

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/data/repository/rns/RNSRepository.kt
+++ b/app/src/main/java/com/babylon/wallet/android/data/repository/rns/RNSRepository.kt
@@ -41,11 +41,11 @@ class RNSRepositoryImpl @Inject constructor(
         applicationScope.launch {
             profileRepository
                 .profile
-                .map { it.currentGateway.network.id }
+                .map { it.currentGateway }
                 .distinctUntilChanged()
-                .collect { networkId ->
+                .collect { gateway ->
                     runCatching {
-                        RadixNameService(networkingDriver, networkId)
+                        RadixNameService(networkingDriver, gateway)
                     }.onSuccess { service ->
                         nameServiceState.update { RNSState.Instantiated(service) }
                     }.onFailure { error ->


### PR DESCRIPTION
## Summary

- Pass the full current `Gateway` into `RadixNameService` instead of only the current network id.
- Ensures RNS lookups honor custom gateway URLs configured by the user.

## Requires simultaneous Sargon merge

This PR depends on a breaking public UniFFI API change in Sargon: `RadixNameService` now takes `gateway` instead of `networkId`.

Do not merge this PR independently. It must be merged and consumed together with the Sargon PR below, otherwise this wallet branch will not compile against the old Sargon API.

Required companion PRs:

- Sargon: https://github.com/radixdlt/sargon/pull/450
- iOS: https://github.com/radixdlt/babylon-wallet-ios/pull/1511

## Validation

- [ ] Full Android build not run.
