### PR TITLE
Add NFT collection view modes

### DIFF
--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountScreen.kt
@@ -76,6 +76,7 @@ import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.composables.actionableaddress.ActionableAddressView
 import com.babylon.wallet.android.presentation.ui.composables.assets.AssetsViewAction
 import com.babylon.wallet.android.presentation.ui.composables.assets.AssetsViewData
+import com.babylon.wallet.android.presentation.ui.composables.assets.NFTsViewMode
 import com.babylon.wallet.android.presentation.ui.composables.assets.TotalFiatBalanceView
 import com.babylon.wallet.android.presentation.ui.composables.assets.TotalFiatBalanceViewToggle
 import com.babylon.wallet.android.presentation.ui.composables.assets.assetsView
@@ -147,6 +148,7 @@ fun AccountScreen(
         onClaimClick = viewModel::onClaimClick,
         onTabClick = viewModel::onTabSelected,
         onCollectionClick = viewModel::onCollectionToggle,
+        onNFTsViewModeClick = viewModel::onNFTsViewModeSelected,
         onHistoryClick = onHistoryClick,
         onInfoClick = onInfoClick,
         onTimedRecoveryClick = { onNavigateToTimedRecovery(AddressOfAccountOrPersona.Account(it)) }
@@ -189,6 +191,7 @@ private fun AccountScreenContent(
     onMessageShown: () -> Unit,
     onTabClick: (AssetsTab) -> Unit,
     onCollectionClick: (String) -> Unit,
+    onNFTsViewModeClick: (NFTsViewMode) -> Unit,
     onFungibleItemClicked: (Resource.FungibleResource) -> Unit,
     onNonFungibleItemClicked: (Resource.NonFungibleResource, Resource.NonFungibleResource.Item) -> Unit,
     onApplySecuritySettingsClick: () -> Unit,
@@ -289,6 +292,7 @@ private fun AccountScreenContent(
                 onClaimClick = onClaimClick,
                 onTabClick = onTabClick,
                 onCollectionClick = onCollectionClick,
+                onNFTsViewModeClick = onNFTsViewModeClick,
                 onInfoClick = onInfoClick,
                 onTimedRecoveryClick = onTimedRecoveryClick
             )
@@ -316,6 +320,7 @@ fun AssetsContent(
     onShowHideBalanceToggle: (isVisible: Boolean) -> Unit,
     onTabClick: (AssetsTab) -> Unit,
     onCollectionClick: (String) -> Unit,
+    onNFTsViewModeClick: (NFTsViewMode) -> Unit,
     onFungibleTokenClick: (Resource.FungibleResource) -> Unit,
     onNonFungibleItemClick: (Resource.NonFungibleResource, Resource.NonFungibleResource.Item) -> Unit,
     onPoolUnitClick: (PoolUnit) -> Unit,
@@ -385,7 +390,8 @@ fun AssetsContent(
                     onStakesRequest = onStakesRequest,
                     onClaimClick = onClaimClick,
                     onCollectionClick = onCollectionClick,
-                    onTabClick = onTabClick
+                    onTabClick = onTabClick,
+                    onNFTsViewModeClick = onNFTsViewModeClick
                 ),
                 onInfoClick = onInfoClick
             )
@@ -637,6 +643,7 @@ fun AccountContentPreview() {
             onMessageShown = {},
             onTabClick = {},
             onCollectionClick = {},
+            onNFTsViewModeClick = {},
             onFungibleItemClicked = {},
             onNonFungibleItemClicked = { _, _ -> },
             onApplySecuritySettingsClick = {},
@@ -673,6 +680,7 @@ fun AccountContentWithFiatBalancesDisabledPreview() {
             onMessageShown = {},
             onTabClick = {},
             onCollectionClick = {},
+            onNFTsViewModeClick = {},
             onFungibleItemClicked = {},
             onNonFungibleItemClicked = { _, _ -> },
             onApplySecuritySettingsClick = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/account/AccountViewModel.kt
@@ -27,6 +27,7 @@ import com.babylon.wallet.android.presentation.common.UiMessage
 import com.babylon.wallet.android.presentation.common.UiState
 import com.babylon.wallet.android.presentation.timedrecovery.remainingTime
 import com.babylon.wallet.android.presentation.transfer.assets.AssetsTab
+import com.babylon.wallet.android.presentation.ui.composables.assets.NFTsViewMode
 import com.babylon.wallet.android.presentation.ui.composables.assets.AssetsViewState
 import com.babylon.wallet.android.presentation.ui.model.shared.TimedRecoveryDisplayData
 import com.babylon.wallet.android.utils.AppEvent.FixSecurityIssue.ImportedMnemonic
@@ -370,6 +371,10 @@ class AccountViewModel @Inject constructor(
 
     fun onCollectionToggle(collectionId: String) {
         _state.update { it.copy(assetsViewState = it.assetsViewState.onCollectionToggle(collectionId)) }
+    }
+
+    fun onNFTsViewModeSelected(viewMode: NFTsViewMode) {
+        _state.update { it.copy(assetsViewState = it.assetsViewState.copy(nftsViewMode = viewMode)) }
     }
 
     fun onLockerDepositClick(deposit: AccountLockerDeposit) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferScreen.kt
@@ -47,6 +47,7 @@ import com.babylon.wallet.android.presentation.ui.composables.BasicPromptAlertDi
 import com.babylon.wallet.android.presentation.ui.composables.BottomSheetDialogWrapper
 import com.babylon.wallet.android.presentation.ui.composables.RadixCenteredTopAppBar
 import com.babylon.wallet.android.presentation.ui.composables.card.SimpleAccountCard
+import com.babylon.wallet.android.presentation.ui.composables.assets.NFTsViewMode
 import com.babylon.wallet.android.presentation.ui.composables.statusBarsAndBanner
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.AddressBookEntry
@@ -98,6 +99,7 @@ fun TransferScreen(
         cancelQrScan = viewModel::cancelQrScan,
         onChooseAssetTabClick = viewModel::onChooseAssetTabSelected,
         onChooseAssetCollectionClick = viewModel::onChooseAssetCollectionToggle,
+        onChooseAssetNFTsViewModeClick = viewModel::onChooseAssetNFTsViewModeSelected,
         onSheetClosed = viewModel::onSheetClose,
         onAddAssetsClick = viewModel::onAddAssetsClick,
         onRemoveAssetClick = viewModel::onRemoveAsset,
@@ -142,6 +144,7 @@ fun TransferContent(
     cancelQrScan: () -> Unit,
     onChooseAssetTabClick: (AssetsTab) -> Unit,
     onChooseAssetCollectionClick: (String) -> Unit,
+    onChooseAssetNFTsViewModeClick: (NFTsViewMode) -> Unit,
     onSheetClosed: () -> Unit,
     onAddAssetsClick: (TargetAccount) -> Unit,
     onRemoveAssetClick: (TargetAccount, SpendingAsset) -> Unit,
@@ -410,6 +413,7 @@ fun TransferContent(
                         state = sheetState,
                         onTabClick = onChooseAssetTabClick,
                         onCollectionClick = onChooseAssetCollectionClick,
+                        onNFTsViewModeClick = onChooseAssetNFTsViewModeClick,
                         onCloseClick = onSheetClosed,
                         onAssetSelectionChanged = onAssetSelectionChanged,
                         onNextNFtsPageRequest = onNextNFTsPageRequest,
@@ -455,6 +459,7 @@ fun TransferContentPreview() {
             cancelQrScan = {},
             onChooseAssetTabClick = {},
             onChooseAssetCollectionClick = {},
+            onChooseAssetNFTsViewModeClick = {},
             onSheetClosed = {},
             onAddAssetsClick = {},
             onRemoveAssetClick = { _, _ -> },

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/TransferViewModel.kt
@@ -16,6 +16,7 @@ import com.babylon.wallet.android.presentation.transfer.assets.AssetsChooserDele
 import com.babylon.wallet.android.presentation.transfer.assets.AssetsTab
 import com.babylon.wallet.android.presentation.transfer.prepare.PrepareManifestDelegate
 import com.babylon.wallet.android.presentation.ui.composables.assets.AssetsViewState
+import com.babylon.wallet.android.presentation.ui.composables.assets.NFTsViewMode
 import com.radixdlt.sargon.Account
 import com.radixdlt.sargon.AccountAddress
 import com.radixdlt.sargon.AddressBookEntry
@@ -278,6 +279,8 @@ class TransferViewModel @Inject constructor(
     fun onChooseAssetTabSelected(tab: AssetsTab) = assetsChooserDelegate.onTabSelected(tab)
 
     fun onChooseAssetCollectionToggle(collectionId: String) = assetsChooserDelegate.onCollectionToggle(collectionId)
+
+    fun onChooseAssetNFTsViewModeSelected(viewMode: NFTsViewMode) = assetsChooserDelegate.onNFTsViewModeSelected(viewMode)
 
     fun onAddAssetsClick(targetAccount: TargetAccount) {
         val currentState = state.value

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsChooserDelegate.kt
@@ -13,6 +13,7 @@ import com.babylon.wallet.android.presentation.transfer.SpendingAsset
 import com.babylon.wallet.android.presentation.transfer.TargetAccount
 import com.babylon.wallet.android.presentation.transfer.TransferViewModel
 import com.babylon.wallet.android.presentation.transfer.TransferViewModel.State.Sheet
+import com.babylon.wallet.android.presentation.ui.composables.assets.NFTsViewMode
 import com.radixdlt.sargon.Account
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
@@ -86,6 +87,10 @@ class AssetsChooserDelegate @Inject constructor(
 
     fun onCollectionToggle(collectionId: String) {
         updateSheetState { it.copy(assetsViewState = it.assetsViewState.onCollectionToggle(collectionId)) }
+    }
+
+    fun onNFTsViewModeSelected(viewMode: NFTsViewMode) {
+        updateSheetState { it.copy(assetsViewState = it.assetsViewState.copy(nftsViewMode = viewMode)) }
     }
 
     fun onAssetSelectionChanged(asset: SpendingAsset, isChecked: Boolean) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsTabs.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/AssetsTabs.kt
@@ -1,24 +1,34 @@
 package com.babylon.wallet.android.presentation.transfer.assets
 
+import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
-import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.zIndex
+import androidx.compose.ui.unit.IntOffset
 import com.babylon.wallet.android.R
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
 import com.babylon.wallet.android.designsystem.theme.White
 import com.babylon.wallet.android.presentation.dialogs.info.GlossaryItem
+import kotlin.math.roundToInt
 
 @Composable
 fun AssetsTabs(
@@ -26,52 +36,89 @@ fun AssetsTabs(
     selectedTab: AssetsTab,
     onTabSelected: (AssetsTab) -> Unit
 ) {
-    val tabIndex = remember(selectedTab) {
-        AssetsTab.entries.indexOf(selectedTab)
-    }
-    TabRow(
+    val tabBounds = remember { mutableStateMapOf<AssetsTab, TabBounds>() }
+    val selectedBounds = tabBounds[selectedTab]
+    val indicatorX by animateIntAsState(
+        targetValue = selectedBounds?.position?.x?.roundToInt() ?: 0,
+        label = "assetTabIndicatorX"
+    )
+    val indicatorY by animateIntAsState(
+        targetValue = selectedBounds?.position?.y?.roundToInt() ?: 0,
+        label = "assetTabIndicatorY"
+    )
+    val indicatorWidth by animateIntAsState(
+        targetValue = selectedBounds?.width ?: 0,
+        label = "assetTabIndicatorWidth"
+    )
+    val indicatorHeight by animateIntAsState(
+        targetValue = selectedBounds?.height ?: 0,
+        label = "assetTabIndicatorHeight"
+    )
+
+    Box(
         modifier = modifier
-            .padding(horizontal = RadixTheme.dimensions.paddingDefault),
-        selectedTabIndex = tabIndex,
-        containerColor = Color.Transparent,
-        divider = {},
-        indicator = { tabPositions ->
+            .fillMaxWidth()
+            .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+    ) {
+        if (selectedBounds != null) {
             Box(
                 modifier = Modifier
-                    .tabIndicatorOffset(tabPositions[tabIndex])
-                    .fillMaxHeight()
-                    .zIndex(-1f)
+                    .offset { IntOffset(indicatorX, indicatorY) }
+                    .width(with(androidx.compose.ui.platform.LocalDensity.current) { indicatorWidth.toDp() })
+                    .height(with(androidx.compose.ui.platform.LocalDensity.current) { indicatorHeight.toDp() })
                     .background(
                         color = RadixTheme.colors.chipBackground,
                         shape = RadixTheme.shapes.circle
                     )
             )
         }
-    ) {
-        AssetsTab.entries.forEach { tab ->
-            val isSelected = tab == selectedTab
-            Tab(
-                modifier = Modifier.wrapContentWidth(),
-                selected = isSelected,
-                onClick = {
-                    if (!isSelected) {
-                        onTabSelected(tab)
-                    }
-                },
-                selectedContentColor = White,
-                unselectedContentColor = RadixTheme.colors.text
-            ) {
-                Text(
-                    modifier = Modifier.padding(
-                        vertical = RadixTheme.dimensions.paddingSmall
-                    ),
-                    text = tab.name(),
-                    style = RadixTheme.typography.body1HighImportance,
-                )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AssetsTab.entries.forEach { tab ->
+                val isSelected = tab == selectedTab
+                val interactionSource = remember { MutableInteractionSource() }
+                Box(
+                    modifier = Modifier
+                        .onGloballyPositioned { coordinates ->
+                            tabBounds[tab] = TabBounds(
+                                position = coordinates.positionInParent(),
+                                width = coordinates.size.width,
+                                height = coordinates.size.height
+                            )
+                        }
+                        .clickable(
+                            enabled = !isSelected,
+                            interactionSource = interactionSource,
+                            indication = null
+                        ) {
+                            onTabSelected(tab)
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        modifier = Modifier.padding(
+                            horizontal = RadixTheme.dimensions.paddingDefault,
+                            vertical = RadixTheme.dimensions.paddingSmall
+                        ),
+                        text = tab.name(),
+                        style = RadixTheme.typography.body1HighImportance,
+                        color = if (isSelected) White else RadixTheme.colors.text
+                    )
+                }
             }
         }
     }
 }
+
+private data class TabBounds(
+    val position: Offset,
+    val width: Int,
+    val height: Int
+)
 
 @Composable
 private fun AssetsTab.name(): String = when (this) {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/ChooseAssetsSheet.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/transfer/assets/ChooseAssetsSheet.kt
@@ -25,6 +25,7 @@ import com.babylon.wallet.android.presentation.ui.composables.RadixSnackbarHost
 import com.babylon.wallet.android.presentation.ui.composables.SnackbarUIMessage
 import com.babylon.wallet.android.presentation.ui.composables.assets.AssetsViewAction
 import com.babylon.wallet.android.presentation.ui.composables.assets.AssetsViewData
+import com.babylon.wallet.android.presentation.ui.composables.assets.NFTsViewMode
 import com.babylon.wallet.android.presentation.ui.composables.assets.assetsView
 import rdx.works.core.domain.resources.Resource
 
@@ -35,6 +36,7 @@ fun ChooseAssetsSheet(
     state: ChooseAssets,
     onTabClick: (AssetsTab) -> Unit,
     onCollectionClick: (String) -> Unit,
+    onNFTsViewModeClick: (NFTsViewMode) -> Unit,
     onCloseClick: () -> Unit,
     onAssetSelectionChanged: (SpendingAsset, Boolean) -> Unit,
     onNextNFtsPageRequest: (Resource.NonFungibleResource) -> Unit,
@@ -125,6 +127,7 @@ fun ChooseAssetsSheet(
                     onStakesRequest = onStakesRequest,
                     onTabClick = onTabClick,
                     onCollectionClick = onCollectionClick,
+                    onNFTsViewModeClick = onNFTsViewModeClick,
                 ),
                 onInfoClick = {
                     onInfoClick(state.assetsViewState.selectedTab.toInfoTag())
@@ -144,6 +147,7 @@ fun ChooseAssetsSheetPreview() {
             ),
             onTabClick = {},
             onCollectionClick = {},
+            onNFTsViewModeClick = {},
             onCloseClick = {},
             onAssetSelectionChanged = { _, _ -> },
             onNextNFtsPageRequest = {},

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/Thumbnail.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -191,7 +192,10 @@ object Thumbnail {
         nft: Resource.NonFungibleResource.Item,
         cropped: Boolean = true, // When false the NFT will appear in full height
         cornerRadius: Dp = NFTCornerRadius,
-        maxAspectRatio: Float = NFTAspectRatio
+        maxAspectRatio: Float = NFTAspectRatio,
+        forcedAspectRatio: Float? = null,
+        contentScale: ContentScale? = null,
+        backgroundColor: Color = RadixTheme.colors.backgroundTertiary
     ) {
         NFT(
             modifier = modifier,
@@ -199,7 +203,10 @@ object Thumbnail {
             localId = nft.localId.formatted(),
             cropped = cropped,
             cornerRadius = cornerRadius,
-            maxAspectRatio = maxAspectRatio
+            maxAspectRatio = maxAspectRatio,
+            forcedAspectRatio = forcedAspectRatio,
+            contentScale = contentScale,
+            backgroundColor = backgroundColor
         )
     }
 
@@ -210,7 +217,10 @@ object Thumbnail {
         localId: String?,
         cropped: Boolean = true, // When false the NFT will appear in full height
         cornerRadius: Dp = NFTCornerRadius,
-        maxAspectRatio: Float = NFTAspectRatio
+        maxAspectRatio: Float = NFTAspectRatio,
+        forcedAspectRatio: Float? = null,
+        contentScale: ContentScale? = null,
+        backgroundColor: Color = RadixTheme.colors.backgroundTertiary
     ) {
         if (image != null) {
             val context = LocalContext.current
@@ -229,7 +239,10 @@ object Thumbnail {
             var painterState: AsyncImagePainter.State by remember(image) { mutableStateOf(AsyncImagePainter.State.Empty) }
             val density = LocalDensity.current
             SubcomposeAsyncImage(
-                modifier = modifier,
+                modifier = modifier.applyIf(
+                    condition = forcedAspectRatio != null,
+                    modifier = Modifier.aspectRatio(forcedAspectRatio ?: 1f)
+                ),
                 model = request,
                 contentDescription = localId,
                 onState = { painterState = it }
@@ -238,11 +251,17 @@ object Thumbnail {
                     modifier = Modifier
                         .clip(RoundedCornerShape(cornerRadius))
                         .applyIf(
-                            condition = painterState !is AsyncImagePainter.State.Success,
-                            modifier = Modifier.background(RadixTheme.colors.backgroundTertiary)
+                            condition = forcedAspectRatio != null,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(backgroundColor)
                         )
                         .applyIf(
-                            condition = cropped,
+                            condition = painterState !is AsyncImagePainter.State.Success,
+                            modifier = Modifier.background(backgroundColor)
+                        )
+                        .applyIf(
+                            condition = cropped && forcedAspectRatio == null,
                             modifier = when (val state = painterState) {
                                 is AsyncImagePainter.State.Empty -> Modifier
                                 is AsyncImagePainter.State.Error -> Modifier.aspectRatio(maxAspectRatio)
@@ -271,7 +290,7 @@ object Thumbnail {
                             }
                         )
                         .applyIf(
-                            condition = !cropped,
+                            condition = !cropped && forcedAspectRatio == null,
                             modifier = when (painterState) {
                                 is AsyncImagePainter.State.Error -> Modifier.aspectRatio(maxAspectRatio)
                                 else -> Modifier.wrapContentHeight()
@@ -279,7 +298,7 @@ object Thumbnail {
                         ),
                     painter = painter,
                     contentDescription = null,
-                    contentScale = when (painterState) {
+                    contentScale = contentScale ?: when (painterState) {
                         is AsyncImagePainter.State.Error -> CustomContentScale.standard(density)
                         else -> if (cropped) ContentScale.Crop else ContentScale.FillWidth
                     }

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsView.kt
@@ -150,7 +150,13 @@ data class AssetsViewState(
 enum class NFTsViewMode {
     Full,
     Grid,
-    Row
+    Row;
+
+    fun next(): NFTsViewMode = when (this) {
+        Full -> Grid
+        Grid -> Row
+        Row -> Full
+    }
 }
 
 sealed interface AssetsViewAction {

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsView.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsView.kt
@@ -102,10 +102,22 @@ data class AssetsViewState(
     val selectedTab: AssetsTab,
     val collapsedCollections: Map<String, Boolean>,
     val fetchingNFTsPerCollection: Set<ResourceAddress>,
+    val nftsViewMode: NFTsViewMode = NFTsViewMode.Full,
+    val openedNFTCollectionId: String? = null,
 ) {
     fun isCollapsed(collectionId: String) = collapsedCollections.getOrDefault(collectionId, true)
 
     fun onCollectionToggle(collectionId: String): AssetsViewState {
+        if (selectedTab == AssetsTab.Nfts) {
+            return copy(
+                openedNFTCollectionId = if (openedNFTCollectionId == collectionId) {
+                    null
+                } else {
+                    collectionId
+                }
+            )
+        }
+
         val isCollapsed = isCollapsed(collectionId)
         val collapsedCollections = collapsedCollections.toMutableMap().apply {
             this[collectionId] = !isCollapsed
@@ -127,10 +139,18 @@ data class AssetsViewState(
             return AssetsViewState(
                 selectedTab = selectedTab,
                 collapsedCollections = emptyMap(),
-                fetchingNFTsPerCollection = emptySet()
+                fetchingNFTsPerCollection = emptySet(),
+                nftsViewMode = NFTsViewMode.Full,
+                openedNFTCollectionId = null
             )
         }
     }
+}
+
+enum class NFTsViewMode {
+    Full,
+    Grid,
+    Row
 }
 
 sealed interface AssetsViewAction {
@@ -139,6 +159,7 @@ sealed interface AssetsViewAction {
     val onCollectionClick: (String) -> Unit
     val onNextNFtsPageRequest: (Resource.NonFungibleResource) -> Unit
     val onStakesRequest: () -> Unit
+    val onNFTsViewModeClick: (NFTsViewMode) -> Unit
 
     data class Click(
         val onFungibleClick: (Resource.FungibleResource) -> Unit,
@@ -150,6 +171,7 @@ sealed interface AssetsViewAction {
         override val onCollectionClick: (String) -> Unit,
         override val onNextNFtsPageRequest: (Resource.NonFungibleResource) -> Unit,
         override val onStakesRequest: () -> Unit,
+        override val onNFTsViewModeClick: (NFTsViewMode) -> Unit,
     ) : AssetsViewAction
 
     data class Selection(
@@ -161,6 +183,7 @@ sealed interface AssetsViewAction {
         override val onCollectionClick: (String) -> Unit,
         override val onNextNFtsPageRequest: (Resource.NonFungibleResource) -> Unit,
         override val onStakesRequest: () -> Unit,
+        override val onNFTsViewModeClick: (NFTsViewMode) -> Unit,
     ) : AssetsViewAction {
 
         fun isSelected(resourceAddress: ResourceAddress) = selectedResources.contains(resourceAddress)
@@ -187,7 +210,8 @@ fun AssetsViewWithLoadingAssets() {
                     onClaimClick = {},
                     onStakesRequest = {},
                     onCollectionClick = {},
-                    onTabClick = {}
+                    onTabClick = {},
+                    onNFTsViewModeClick = {}
                 ),
                 onInfoClick = {}
             )
@@ -213,7 +237,8 @@ fun AssetsViewWithEmptyAssets() {
                     onClaimClick = {},
                     onStakesRequest = {},
                     onCollectionClick = {},
-                    onTabClick = {}
+                    onTabClick = {},
+                    onNFTsViewModeClick = {}
                 ),
                 onInfoClick = {}
             )
@@ -272,6 +297,9 @@ fun AssetsViewWithAssets() {
                     },
                     onCollectionClick = {
                         state = state.onCollectionToggle(it)
+                    },
+                    onNFTsViewModeClick = {
+                        state = state.copy(nftsViewMode = it)
                     }
                 ),
                 onInfoClick = {}

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
@@ -1,5 +1,11 @@
 package com.babylon.wallet.android.presentation.ui.composables.assets
 
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,15 +18,28 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.babylon.wallet.android.designsystem.theme.RadixTheme
@@ -31,7 +50,6 @@ import com.babylon.wallet.android.presentation.model.displaySubtitle
 import com.babylon.wallet.android.presentation.model.displayTitle
 import com.babylon.wallet.android.presentation.transfer.assets.AssetsTab
 import com.babylon.wallet.android.presentation.ui.composables.Thumbnail
-import com.babylon.wallet.android.presentation.ui.composables.card.CollapsibleCommonCard
 import com.babylon.wallet.android.presentation.ui.composables.card.CommonCard
 import com.babylon.wallet.android.presentation.ui.modifier.radixPlaceholder
 import com.babylon.wallet.android.presentation.ui.modifier.throttleClickable
@@ -40,9 +58,12 @@ import com.radixdlt.sargon.annotation.UsesSampleValues
 import com.radixdlt.sargon.extensions.formatted
 import com.radixdlt.sargon.extensions.string
 import com.radixdlt.sargon.samples.sampleMainnet
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import rdx.works.core.domain.assets.NonFungibleCollection
 import rdx.works.core.domain.resources.Resource
 
+@OptIn(ExperimentalFoundationApi::class)
 fun LazyListScope.nftsTab(
     assetsViewData: AssetsViewData,
     state: AssetsViewState,
@@ -62,25 +83,77 @@ fun LazyListScope.nftsTab(
     item {
         Spacer(modifier = Modifier.height(RadixTheme.dimensions.paddingSemiLarge))
     }
-    assetsViewData.nonFungibleCollections.forEachIndexed { outerIndex, nonFungible ->
-        item(
-            key = nonFungible.collection.address.string,
+
+    val openedCollection = state.openedNFTCollectionId?.let { openedCollectionId ->
+        assetsViewData.nonFungibleCollections.firstOrNull {
+            it.collection.address.string == openedCollectionId
+        }
+    }
+
+    if (openedCollection != null) {
+        stickyHeader(
+            key = "opened-${openedCollection.collection.address.string}",
             contentType = { "collection" }
         ) {
-            NFTHeader(
-                collection = nonFungible,
-                state = state,
-                action = action,
-                modifier = Modifier.padding(top = if (outerIndex == 0) 0.dp else RadixTheme.dimensions.paddingLarge)
-            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+            ) {
+                NFTHeader(
+                    collection = openedCollection,
+                    state = state,
+                    action = action,
+                    isOpened = true
+                )
+            }
         }
 
-        items(
-            count = if (!state.isCollapsed(nonFungible.collection.address.string)) nonFungible.collection.amount.toInt() else 0,
-            key = { index -> "${nonFungible.collection.address}$index" },
-            contentType = { "nft" }
-        ) { index ->
-            NFTItem(index, nonFungible.collection, state, action)
+        when (state.nftsViewMode) {
+            NFTsViewMode.Full -> {
+                items(
+                    count = openedCollection.collection.amount.toInt(),
+                    key = { index -> "${openedCollection.collection.address}$index" },
+                    contentType = { "nft" }
+                ) { index ->
+                    NFTItem(index, openedCollection.collection, state, action)
+                }
+            }
+
+            NFTsViewMode.Grid -> {
+                val columns = 2
+                items(
+                    count = (openedCollection.collection.amount.toInt() + columns - 1) / columns,
+                    key = { rowIndex -> "${openedCollection.collection.address}-grid-$rowIndex" },
+                    contentType = { "nft_grid_row" }
+                ) { rowIndex ->
+                    NFTGridRow(rowIndex, openedCollection.collection, state, action)
+                }
+            }
+
+            NFTsViewMode.Row -> {
+                items(
+                    count = openedCollection.collection.amount.toInt(),
+                    key = { index -> "${openedCollection.collection.address}-row-$index" },
+                    contentType = { "nft_row" }
+                ) { index ->
+                    NFTRowItem(index, openedCollection.collection, state, action)
+                }
+            }
+        }
+    } else {
+        assetsViewData.nonFungibleCollections.forEachIndexed { outerIndex, nonFungible ->
+            item(
+                key = nonFungible.collection.address.string,
+                contentType = { "collection" }
+            ) {
+                NFTHeader(
+                    collection = nonFungible,
+                    state = state,
+                    action = action,
+                    isOpened = false,
+                    modifier = Modifier.padding(top = if (outerIndex == 0) 0.dp else RadixTheme.dimensions.paddingLarge)
+                )
+            }
         }
     }
 }
@@ -94,11 +167,10 @@ private fun NFTItem(
 ) {
     CommonCard(
         modifier = Modifier
-            .padding(top = 1.dp)
+            .padding(top = if (index == 0) RadixTheme.dimensions.paddingDefault else 1.dp)
             .padding(horizontal = RadixTheme.dimensions.paddingDefault),
         itemIndex = index,
-        allItemsSize = collection.amount.toInt(),
-        roundTopCorners = false
+        allItemsSize = collection.amount.toInt()
     ) {
         val nft = collection.items.getOrNull(index)
         if (nft != null) {
@@ -122,39 +194,223 @@ private fun NFTItem(
 }
 
 @Composable
+private fun NFTGridRow(
+    rowIndex: Int,
+    collection: Resource.NonFungibleResource,
+    state: AssetsViewState,
+    action: AssetsViewAction
+) {
+    val columns = 2
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = RadixTheme.dimensions.paddingDefault)
+            .padding(top = RadixTheme.dimensions.paddingDefault),
+        horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
+    ) {
+        repeat(columns) { column ->
+            val index = rowIndex * columns + column
+            if (index < collection.amount.toInt()) {
+                NFTGridCard(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    NFTGridItemContent(index, collection, state, action)
+                }
+            } else {
+                Spacer(modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun NFTGridCard(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(12.dp),
+        color = RadixTheme.colors.card,
+        shadowElevation = if (RadixTheme.config.isDarkTheme) 0.dp else 4.dp
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun NFTGridItemContent(
+    index: Int,
+    collection: Resource.NonFungibleResource,
+    state: AssetsViewState,
+    action: AssetsViewAction
+) {
+    val nft = collection.items.getOrNull(index)
+    if (nft != null) {
+        NonFungibleResourceGridItem(
+            collection = collection,
+            item = nft,
+            action = action
+        )
+    } else {
+        LaunchedEffect(collection.address, state.fetchingNFTsPerCollection) {
+            if (collection.address !in state.fetchingNFTsPerCollection) {
+                action.onNextNFtsPageRequest(collection)
+            }
+        }
+
+        NonFungibleResourcePlaceholder(
+            modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault),
+            isCompact = true
+        )
+    }
+}
+
+@Composable
+private fun NFTRowItem(
+    index: Int,
+    collection: Resource.NonFungibleResource,
+    state: AssetsViewState,
+    action: AssetsViewAction
+) {
+    CommonCard(
+        modifier = Modifier
+            .padding(top = if (index == 0) RadixTheme.dimensions.paddingDefault else 1.dp)
+            .padding(horizontal = RadixTheme.dimensions.paddingDefault),
+        itemIndex = index,
+        allItemsSize = collection.amount.toInt()
+    ) {
+        val nft = collection.items.getOrNull(index)
+        if (nft != null) {
+            NonFungibleResourceItem(
+                collection = collection,
+                item = nft,
+                action = action,
+                viewMode = NFTsViewMode.Row
+            )
+        } else {
+            LaunchedEffect(collection.address, state.fetchingNFTsPerCollection) {
+                if (collection.address !in state.fetchingNFTsPerCollection) {
+                    action.onNextNFtsPageRequest(collection)
+                }
+            }
+
+            NonFungibleResourceRowPlaceholder(
+                modifier = Modifier.padding(RadixTheme.dimensions.paddingDefault)
+            )
+        }
+    }
+}
+
+@Composable
 private fun NFTHeader(
     collection: NonFungibleCollection,
     state: AssetsViewState,
     action: AssetsViewAction,
+    isOpened: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val isCollapsed = state.isCollapsed(collection.resource.address.string)
-    CollapsibleCommonCard(
+    val rowModifier = if (isOpened) {
+        Modifier.fillMaxWidth()
+    } else {
+        Modifier
+            .fillMaxWidth()
+            .clickable {
+                action.onCollectionClick(collection.resource.address.string)
+            }
+    }
+    var controlsVisible by remember(collection.resource.address.string, isOpened) {
+        mutableStateOf(false)
+    }
+    val coroutineScope = rememberCoroutineScope()
+    LaunchedEffect(isOpened) {
+        controlsVisible = isOpened
+    }
+
+    val animationSpec = tween<androidx.compose.ui.unit.Dp>(durationMillis = 180)
+    val backSlotWidth by animateDpAsState(
+        targetValue = if (isOpened && controlsVisible) 36.dp else 0.dp,
+        animationSpec = animationSpec,
+        label = "nftHeaderBackSlotWidth"
+    )
+    val backSlotGap by animateDpAsState(
+        targetValue = if (isOpened && controlsVisible) RadixTheme.dimensions.paddingSmall else 0.dp,
+        animationSpec = animationSpec,
+        label = "nftHeaderBackSlotGap"
+    )
+    val toggleSlotWidth by animateDpAsState(
+        targetValue = if (isOpened && controlsVisible) 40.dp else 0.dp,
+        animationSpec = animationSpec,
+        label = "nftHeaderToggleSlotWidth"
+    )
+    val controlsAlpha by animateFloatAsState(
+        targetValue = if (isOpened && controlsVisible) 1f else 0f,
+        animationSpec = tween(durationMillis = 140),
+        label = "nftHeaderControlsAlpha"
+    )
+    val closeCollection = {
+        coroutineScope.launch {
+            controlsVisible = false
+            delay(120)
+            action.onCollectionClick(collection.resource.address.string)
+        }
+    }
+
+    Surface(
         modifier = modifier
             .padding(horizontal = RadixTheme.dimensions.paddingDefault),
-        isCollapsed = isCollapsed,
-        collapsedItems = collection.resource.amount.toInt()
+        shape = RoundedCornerShape(12.dp),
+        color = RadixTheme.colors.card,
+        shadowElevation = if (RadixTheme.config.isDarkTheme) 0.dp else 4.dp
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable {
-                    action.onCollectionClick(collection.resource.address.string)
-                }
-                .padding(RadixTheme.dimensions.paddingLarge),
+            modifier = rowModifier
+                .padding(horizontal = RadixTheme.dimensions.paddingDefault, vertical = RadixTheme.dimensions.paddingDefault),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+            horizontalArrangement = Arrangement.Start
         ) {
+            if (isOpened) {
+                Box(
+                    modifier = Modifier
+                        .width(backSlotWidth)
+                        .height(36.dp)
+                        .alpha(controlsAlpha)
+                        .throttleClickable {
+                            closeCollection()
+                        },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .padding(10.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        NFTHeaderBackIcon(
+                            modifier = Modifier.fillMaxSize(),
+                            color = RadixTheme.colors.icon
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.width(backSlotGap))
+            }
+
             Thumbnail.NonFungible(
-                modifier = Modifier.size(44.dp),
+                modifier = Modifier.size(48.dp),
                 collection = collection.resource
             )
-            Column(verticalArrangement = Arrangement.Center) {
+
+            Spacer(modifier = Modifier.width(RadixTheme.dimensions.paddingSmall))
+
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.Center
+            ) {
                 Text(
                     text = collection.displayTitle(),
                     style = RadixTheme.typography.secondaryHeader,
                     color = RadixTheme.colors.text,
-                    maxLines = 2
+                    maxLines = 1
                 )
 
                 Text(
@@ -162,6 +418,230 @@ private fun NFTHeader(
                     style = RadixTheme.typography.body2HighImportance,
                     color = RadixTheme.colors.textSecondary,
                 )
+            }
+
+            if (isOpened) {
+                Spacer(modifier = Modifier.width(RadixTheme.dimensions.paddingSmall))
+                Box(
+                    modifier = Modifier
+                        .width(toggleSlotWidth)
+                        .height(40.dp)
+                        .alpha(controlsAlpha),
+                    contentAlignment = Alignment.Center
+                ) {
+                    NFTViewModeToggle(
+                        viewMode = state.nftsViewMode,
+                        onClick = {
+                            action.onNFTsViewModeClick(state.nftsViewMode.next())
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NFTHeaderBackIcon(
+    modifier: Modifier,
+    color: Color
+) {
+    Canvas(modifier = modifier) {
+        val strokeWidth = 2.5.dp.toPx()
+        drawLine(
+            color = color,
+            start = center.copy(x = size.width * 0.9f),
+            end = center.copy(x = size.width * 0.15f),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+        drawLine(
+            color = color,
+            start = center.copy(x = size.width * 0.15f),
+            end = center.copy(x = size.width * 0.45f, y = size.height * 0.2f),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+        drawLine(
+            color = color,
+            start = center.copy(x = size.width * 0.15f),
+            end = center.copy(x = size.width * 0.45f, y = size.height * 0.8f),
+            strokeWidth = strokeWidth,
+            cap = StrokeCap.Round
+        )
+    }
+}
+
+@Composable
+private fun NFTViewModeToggle(
+    viewMode: NFTsViewMode,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(RadixTheme.colors.backgroundSecondary)
+            .throttleClickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        NFTViewModeIcon(
+            modifier = Modifier.size(18.dp),
+            viewMode = viewMode,
+            color = RadixTheme.colors.icon
+        )
+    }
+}
+
+@Composable
+private fun NFTViewModeIcon(
+    modifier: Modifier,
+    viewMode: NFTsViewMode,
+    color: Color
+) {
+    Canvas(modifier = modifier) {
+        val stroke = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round)
+        when (viewMode) {
+            NFTsViewMode.Full -> {
+                val iconSize = size.minDimension * 0.74f
+                val left = (size.width - iconSize) / 2f
+                val top = (size.height - iconSize) / 2f
+                drawRoundRect(
+                    color = color,
+                    topLeft = androidx.compose.ui.geometry.Offset(left, top),
+                    size = androidx.compose.ui.geometry.Size(iconSize, iconSize),
+                    cornerRadius = CornerRadius(3.dp.toPx(), 3.dp.toPx()),
+                    style = stroke
+                )
+            }
+
+            NFTsViewMode.Grid -> {
+                val cell = size.minDimension * 0.3f
+                val gap = size.minDimension * 0.2f
+                val total = cell * 2 + gap
+                val startX = (size.width - total) / 2f
+                val startY = (size.height - total) / 2f
+                repeat(2) { row ->
+                    repeat(2) { column ->
+                        drawRoundRect(
+                            color = color,
+                            topLeft = androidx.compose.ui.geometry.Offset(
+                                x = startX + column * (cell + gap),
+                                y = startY + row * (cell + gap)
+                            ),
+                            size = androidx.compose.ui.geometry.Size(cell, cell),
+                            cornerRadius = CornerRadius(2.dp.toPx(), 2.dp.toPx()),
+                            style = stroke
+                        )
+                    }
+                }
+            }
+
+            NFTsViewMode.Row -> {
+                val rectWidth = size.width * 0.88f
+                val rectHeight = size.height * 0.26f
+                val gap = size.height * 0.16f
+                val startX = (size.width - rectWidth) / 2f
+                val startY = (size.height - rectHeight * 2 - gap) / 2f
+                repeat(2) { index ->
+                    drawRoundRect(
+                        color = color,
+                        topLeft = androidx.compose.ui.geometry.Offset(
+                            x = startX,
+                            y = startY + index * (rectHeight + gap)
+                        ),
+                        size = androidx.compose.ui.geometry.Size(rectWidth, rectHeight),
+                        cornerRadius = CornerRadius(2.dp.toPx(), 2.dp.toPx()),
+                        style = stroke
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun NFTsViewMode.next(): NFTsViewMode = when (this) {
+    NFTsViewMode.Full -> NFTsViewMode.Grid
+    NFTsViewMode.Grid -> NFTsViewMode.Row
+    NFTsViewMode.Row -> NFTsViewMode.Full
+}
+
+@Composable
+private fun NonFungibleResourceGridItem(
+    collection: Resource.NonFungibleResource,
+    item: Resource.NonFungibleResource.Item,
+    action: AssetsViewAction
+) {
+    val clickableModifier = Modifier.throttleClickable {
+        when (action) {
+            is AssetsViewAction.Click -> {
+                action.onNonFungibleItemClick(collection, item)
+            }
+
+            is AssetsViewAction.Selection -> {
+                action.onNFTCheckChanged(collection, item, !action.isSelected(item.globalId))
+            }
+        }
+    }
+
+    Column(modifier = clickableModifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(12.dp))
+                .background(RadixTheme.colors.backgroundSecondary)
+        ) {
+            Thumbnail.NFT(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(RadixTheme.dimensions.paddingXSmall),
+                nft = item,
+                cropped = false,
+                cornerRadius = 12.dp,
+                forcedAspectRatio = 1f,
+                contentScale = ContentScale.Fit,
+                backgroundColor = RadixTheme.colors.backgroundSecondary
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingXXSmall)
+        ) {
+            item.name?.let { name ->
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = name,
+                    style = RadixTheme.typography.body1HighImportance,
+                    color = RadixTheme.colors.text,
+                    maxLines = 1
+                )
+            }
+
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = "ID: ${item.localId.formatted()}",
+                style = RadixTheme.typography.body2HighImportance,
+                color = RadixTheme.colors.textSecondary,
+                maxLines = 1
+            )
+
+            if (action is AssetsViewAction.Selection) {
+                val isSelected = remember(item, action) {
+                    action.isSelected(item.globalId)
+                }
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    AssetsViewCheckBox(
+                        modifier = Modifier.align(Alignment.CenterEnd),
+                        isSelected = isSelected,
+                        onCheckChanged = { isChecked ->
+                            action.onNFTCheckChanged(collection, item, isChecked)
+                        }
+                    )
+                }
             }
         }
     }
@@ -172,48 +652,117 @@ private fun NonFungibleResourceItem(
     modifier: Modifier = Modifier,
     collection: Resource.NonFungibleResource,
     item: Resource.NonFungibleResource.Item,
+    action: AssetsViewAction,
+    viewMode: NFTsViewMode = NFTsViewMode.Full
+) {
+    val clickableModifier = modifier.throttleClickable {
+        when (action) {
+            is AssetsViewAction.Click -> {
+                action.onNonFungibleItemClick(collection, item)
+            }
+
+            is AssetsViewAction.Selection -> {
+                action.onNFTCheckChanged(collection, item, !action.isSelected(item.globalId))
+            }
+        }
+    }
+
+    if (viewMode == NFTsViewMode.Row) {
+        NonFungibleResourceRowItem(
+            modifier = clickableModifier,
+            collection = collection,
+            item = item,
+            action = action
+        )
+        return
+    }
+
+    Column(
+        modifier = clickableModifier
+            .padding(horizontal = RadixTheme.dimensions.paddingDefault, vertical = RadixTheme.dimensions.paddingLarge),
+        verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingXXSmall)
+    ) {
+        Thumbnail.NFT(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = RadixTheme.dimensions.paddingSmall),
+            nft = item
+        )
+
+        item.name?.let { name ->
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = RadixTheme.dimensions.paddingXXSmall),
+                text = name,
+                style = RadixTheme.typography.body1HighImportance,
+                color = RadixTheme.colors.text,
+                maxLines = if (viewMode == NFTsViewMode.Grid) 1 else Int.MAX_VALUE
+            )
+        }
+
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = item.localId.formatted(),
+            style = RadixTheme.typography.body1HighImportance,
+            color = RadixTheme.colors.textSecondary,
+            maxLines = if (viewMode == NFTsViewMode.Grid) 1 else Int.MAX_VALUE
+        )
+
+        if (action is AssetsViewAction.Selection) {
+            val isSelected = remember(item, action) {
+                action.isSelected(item.globalId)
+            }
+            Box(modifier = Modifier.fillMaxWidth()) {
+                AssetsViewCheckBox(
+                    modifier = Modifier.align(Alignment.CenterEnd),
+                    isSelected = isSelected,
+                    onCheckChanged = { isChecked ->
+                        action.onNFTCheckChanged(collection, item, isChecked)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NonFungibleResourceRowItem(
+    modifier: Modifier = Modifier,
+    collection: Resource.NonFungibleResource,
+    item: Resource.NonFungibleResource.Item,
     action: AssetsViewAction
 ) {
     Row(
         modifier = modifier
-            .throttleClickable {
-                when (action) {
-                    is AssetsViewAction.Click -> {
-                        action.onNonFungibleItemClick(collection, item)
-                    }
-
-                    is AssetsViewAction.Selection -> {
-                        action.onNFTCheckChanged(collection, item, !action.isSelected(item.globalId))
-                    }
-                }
-            }
-            .padding(horizontal = RadixTheme.dimensions.paddingDefault, vertical = RadixTheme.dimensions.paddingLarge),
+            .fillMaxWidth()
+            .padding(horizontal = RadixTheme.dimensions.paddingDefault, vertical = RadixTheme.dimensions.paddingDefault),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
+        horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Thumbnail.NFT(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = RadixTheme.dimensions.paddingDefault),
-                nft = item
-            )
+        Thumbnail.NFT(
+            modifier = Modifier.size(64.dp),
+            nft = item
+        )
+
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingXXSmall)
+        ) {
             item.name?.let { name ->
                 Text(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = RadixTheme.dimensions.paddingXXSmall),
                     text = name,
                     style = RadixTheme.typography.body1HighImportance,
-                    color = RadixTheme.colors.text
+                    color = RadixTheme.colors.text,
+                    maxLines = 1
                 )
             }
 
             Text(
-                modifier = Modifier.fillMaxWidth(),
                 text = item.localId.formatted(),
                 style = RadixTheme.typography.body1HighImportance,
-                color = RadixTheme.colors.textSecondary
+                color = RadixTheme.colors.textSecondary,
+                maxLines = 1
             )
         }
 
@@ -233,7 +782,8 @@ private fun NonFungibleResourceItem(
 
 @Composable
 private fun NonFungibleResourcePlaceholder(
-    modifier: Modifier
+    modifier: Modifier,
+    isCompact: Boolean = false
 ) {
     Column(
         modifier = modifier,
@@ -259,15 +809,62 @@ private fun NonFungibleResourcePlaceholder(
                 )
         )
 
+        if (!isCompact) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(0.5f)
+                    .height(23.dp)
+                    .radixPlaceholder(
+                        visible = true,
+                        shape = RoundedCornerShape(Thumbnail.NFTCornerRadius)
+                    )
+            )
+        }
+    }
+}
+
+@Composable
+private fun NonFungibleResourceRowPlaceholder(
+    modifier: Modifier
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingDefault)
+    ) {
         Box(
             modifier = Modifier
-                .fillMaxSize(0.5f)
-                .height(23.dp)
+                .size(64.dp)
                 .radixPlaceholder(
                     visible = true,
                     shape = RoundedCornerShape(Thumbnail.NFTCornerRadius)
                 )
         )
+
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(RadixTheme.dimensions.paddingSmall)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(23.dp)
+                    .radixPlaceholder(
+                        visible = true,
+                        shape = RoundedCornerShape(Thumbnail.NFTCornerRadius)
+                    )
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.5f)
+                    .height(23.dp)
+                    .radixPlaceholder(
+                        visible = true,
+                        shape = RoundedCornerShape(Thumbnail.NFTCornerRadius)
+                    )
+            )
+        }
     }
 }
 
@@ -289,7 +886,8 @@ fun NFTCItemCollapsedPreview() {
                     onFungibleClick = {},
                     onLSUClick = {},
                     onPoolUnitClick = {},
-                    onClaimClick = {}
+                    onClaimClick = {},
+                    onNFTsViewModeClick = {}
                 ),
                 onInfoClick = {}
             )
@@ -315,7 +913,8 @@ fun NFTItemExpandedPreview() {
                     onFungibleClick = {},
                     onLSUClick = {},
                     onPoolUnitClick = {},
-                    onClaimClick = {}
+                    onClaimClick = {},
+                    onNFTsViewModeClick = {}
                 ),
                 onInfoClick = {}
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/NFTsTab.kt
@@ -560,12 +560,6 @@ private fun NFTViewModeIcon(
     }
 }
 
-private fun NFTsViewMode.next(): NFTsViewMode = when (this) {
-    NFTsViewMode.Full -> NFTsViewMode.Grid
-    NFTsViewMode.Grid -> NFTsViewMode.Row
-    NFTsViewMode.Row -> NFTsViewMode.Full
-}
-
 @Composable
 private fun NonFungibleResourceGridItem(
     collection: Resource.NonFungibleResource,

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/PoolUnitsTab.kt
@@ -263,7 +263,8 @@ fun PoolUnitTabPreview() {
                     onNextNFtsPageRequest = {},
                     onFungibleClick = {},
                     onPoolUnitClick = {},
-                    onNonFungibleItemClick = { _, _ -> }
+                    onNonFungibleItemClick = { _, _ -> },
+                    onNFTsViewModeClick = {}
                 ),
                 onInfoClick = {}
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/StakingTab.kt
@@ -833,7 +833,8 @@ fun StakingTabPreview() {
                     onNextNFtsPageRequest = {},
                     onFungibleClick = {},
                     onPoolUnitClick = {},
-                    onNonFungibleItemClick = { _, _ -> }
+                    onNonFungibleItemClick = { _, _ -> },
+                    onNFTsViewModeClick = {}
                 ),
                 onInfoClick = {}
             )

--- a/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TokensTab.kt
+++ b/app/src/main/java/com/babylon/wallet/android/presentation/ui/composables/assets/TokensTab.kt
@@ -349,7 +349,8 @@ private fun TokensTabPreview() {
                     onClaimClick = {},
                     onStakesRequest = {},
                     onCollectionClick = {},
-                    onTabClick = {}
+                    onTabClick = {},
+                    onNFTsViewModeClick = {}
                 ),
                 onInfoClick = {}
             )

--- a/app/src/test/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsViewStateTest.kt
+++ b/app/src/test/java/com/babylon/wallet/android/presentation/ui/composables/assets/AssetsViewStateTest.kt
@@ -1,0 +1,66 @@
+package com.babylon.wallet.android.presentation.ui.composables.assets
+
+import com.babylon.wallet.android.presentation.transfer.assets.AssetsTab
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AssetsViewStateTest {
+
+    @Test
+    fun `NFT state starts in full mode with no opened collection`() {
+        val state = AssetsViewState.init(selectedTab = AssetsTab.Nfts)
+
+        assertEquals(NFTsViewMode.Full, state.nftsViewMode)
+        assertNull(state.openedNFTCollectionId)
+    }
+
+    @Test
+    fun `clicking an NFT collection opens and closes it`() {
+        val initialState = AssetsViewState.init(selectedTab = AssetsTab.Nfts)
+
+        val openedState = initialState.onCollectionToggle(FIRST_COLLECTION_ID)
+        val closedState = openedState.onCollectionToggle(FIRST_COLLECTION_ID)
+
+        assertEquals(FIRST_COLLECTION_ID, openedState.openedNFTCollectionId)
+        assertNull(closedState.openedNFTCollectionId)
+    }
+
+    @Test
+    fun `clicking another NFT collection replaces the opened collection`() {
+        val initialState = AssetsViewState.init(selectedTab = AssetsTab.Nfts)
+
+        val state = initialState
+            .onCollectionToggle(FIRST_COLLECTION_ID)
+            .onCollectionToggle(SECOND_COLLECTION_ID)
+
+        assertEquals(SECOND_COLLECTION_ID, state.openedNFTCollectionId)
+    }
+
+    @Test
+    fun `non NFT collections retain accordion behavior`() {
+        val initialState = AssetsViewState.init(selectedTab = AssetsTab.Staking)
+
+        val expandedState = initialState.onCollectionToggle(FIRST_COLLECTION_ID)
+        val collapsedState = expandedState.onCollectionToggle(FIRST_COLLECTION_ID)
+
+        assertTrue(initialState.isCollapsed(FIRST_COLLECTION_ID))
+        assertFalse(expandedState.isCollapsed(FIRST_COLLECTION_ID))
+        assertTrue(collapsedState.isCollapsed(FIRST_COLLECTION_ID))
+        assertNull(expandedState.openedNFTCollectionId)
+    }
+
+    @Test
+    fun `NFT view mode cycles through all modes`() {
+        assertEquals(NFTsViewMode.Grid, NFTsViewMode.Full.next())
+        assertEquals(NFTsViewMode.Row, NFTsViewMode.Grid.next())
+        assertEquals(NFTsViewMode.Full, NFTsViewMode.Row.next())
+    }
+
+    private companion object {
+        const val FIRST_COLLECTION_ID = "collection-1"
+        const val SECOND_COLLECTION_ID = "collection-2"
+    }
+}


### PR DESCRIPTION
## Description

This PR replaces the accordion-style NFT collection list with a focused collection browser and adds three NFT display modes.

- Collection rows now show the collection image, name, and item count without expanding inline.
- Opening a collection shows only that collection and adds an animated back control and a single cycling view-mode control.
- Full, two-column grid, and compact row modes are available in both account assets and the transfer asset chooser.
- The opened collection header remains sticky while its NFTs scroll underneath it.
- Grid cards use square, fit-scaled image frames with consistent rounded corners, compact spacing, NFT names, and local IDs.
- Existing NFT detail and selection behavior is preserved.
- Asset tabs are evenly distributed and retain a sliding active indicator without the rectangular press/ripple artifact.

## How to test

1. Open an account containing multiple NFT collections and select the NFTs tab.
2. Verify collections appear as separate summary rows and do not expand inline.
3. Open a collection and verify only that collection's NFTs are shown.
4. Scroll the collection and verify the collection header remains sticky.
5. Use the header control to cycle through Full, Grid, and Row modes.
6. Verify portrait, landscape, and square NFT media remain fully visible inside their image frames.
7. Select an NFT and verify the existing details flow still opens.
8. Open the transfer asset chooser and verify collection navigation, display modes, and NFT selection still work.

Validation performed:

- Built successfully with `./gradlew :app:assembleLightDebug` using the matching locally built Sargon `1.2.58-a05aeaf3-SNAPSHOT` artifact.
- Added focused unit coverage for NFT defaults, collection navigation, non-NFT accordion behavior, and Full/Grid/Row mode cycling.
- Manually verified collection navigation, Full/Grid/Row mode switching, sticky header behavior, and NFT rendering on the Android emulator.
- Manually verified an account-to-account NFT transfer through recipient selection, NFT selection in all three modes, transfer composition, and the final transaction review screen. The transaction was intentionally not signed or submitted.
- The full unit-test task depends on Radix's private full Sargon package and Arculus submodule and is left to the repository CI workflow.

## Screenshot

| Full | Grid | Row |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/Kafkafrate/babylon-wallet-android/pr-assets/pr-assets/nft-view-modes/full.png" width="260" alt="NFT full view"> | <img src="https://raw.githubusercontent.com/Kafkafrate/babylon-wallet-android/pr-assets/pr-assets/nft-view-modes/grid.png" width="260" alt="NFT grid view"> | <img src="https://raw.githubusercontent.com/Kafkafrate/babylon-wallet-android/pr-assets/pr-assets/nft-view-modes/row.png" width="260" alt="NFT row view"> |

## PR submission checklist

- [x] I have tested account to account transfer flow and have confirmed that it works
- [x] I have written unit tests
